### PR TITLE
ATLAS-2925: Better logging for graph database initialization error

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/AtlasGraphProvider.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/AtlasGraphProvider.java
@@ -101,7 +101,7 @@ public class AtlasGraphProvider implements IAtlasGraphProvider {
             } catch (Exception ex) {
                 retryCounter++;
 
-                LOG.info("Failed to obtain graph instance on retry " + retryCounter + " of " + MAX_RETRY_COUNT + " error: " + ex);
+                LOG.error("Failed to obtain graph instance on retry {} of {}", retryCounter,  MAX_RETRY_COUNT, ex);
 
                 if (retryCounter >= MAX_RETRY_COUNT) {
                     LOG.info("Max retries exceeded.");


### PR DESCRIPTION
Improve logs to know the reason of a graph failure. The old code was appending the exception object, which was only writing the exception message without the real reason of the graph database initialization failure.

This pr solves [ATLAS-2925](https://issues.apache.org/jira/browse/ATLAS-2925)