### PR TITLE
Fixing logging of exceptions, other than NotificationException

### DIFF
--- a/notification/src/main/java/org/apache/atlas/hook/AtlasHook.java
+++ b/notification/src/main/java/org/apache/atlas/hook/AtlasHook.java
@@ -214,14 +214,18 @@ public abstract class AtlasHook {
             }
         }
 
-        if (shouldLogFailedMessages && notificationFailure instanceof NotificationException) {
-            final List<String> failedMessages = ((NotificationException) notificationFailure).getFailedMessages();
+        if (shouldLogFailedMessages) {
+            if (notificationFailure instanceof NotificationException) {
+        	final List<String> failedMessages = ((NotificationException) notificationFailure).getFailedMessages();
 
-            for (String msg : failedMessages) {
-                logger.log(msg);
+                for (String msg : failedMessages) {
+                    logger.log(msg);
+                }
             }
-
-            LOG.error("Giving up after {} failed attempts to send notification to Atlas: {}", maxAttempts, message, notificationFailure);
+            
+            if (notificationFailure instanceof Exception) {
+        	LOG.error("Giving up after {} failed attempts to send notification to Atlas: {}", maxAttempts, message, notificationFailure);
+            }
         }
     }
 


### PR DESCRIPTION
Currently, exceptions such as "Failed to construct kafka producer"
are not logged, because they are an instance of KafkaException.
This fix makes sure we log these exceptions as well.
![image](https://user-images.githubusercontent.com/3027370/47596715-0da5c400-d93d-11e8-9197-a6f1ce1c96b8.png)
