### PR TITLE
ATLAS-3001: Fixed AtlasClientV2.updateClassifications() to not expect a return body

### DIFF
--- a/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
+++ b/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
@@ -318,11 +318,11 @@ public class AtlasClientV2 extends AtlasBaseClient {
     }
 
     public void addClassifications(String guid, List<AtlasClassification> classifications) throws AtlasServiceException {
-        callAPI(formatPathParameters(API_V2.ADD_CLASSIFICATIONS, guid), (Class<?>)null, classifications, (String[]) null);
+        callAPI(formatPathParameters(API_V2.ADD_CLASSIFICATIONS, guid), (Class<?>) null, classifications);
     }
 
     public void updateClassifications(String guid, List<AtlasClassification> classifications) throws AtlasServiceException {
-        callAPI(formatPathParameters(API_V2.UPDATE_CLASSIFICATIONS, guid), AtlasClassifications.class, classifications);
+        callAPI(formatPathParameters(API_V2.UPDATE_CLASSIFICATIONS, guid), (Class<?>) null, classifications);
     }
 
     public void deleteClassifications(String guid, List<AtlasClassification> classifications) throws AtlasServiceException {


### PR DESCRIPTION
[JIRA](https://issues.apache.org/jira/browse/ATLAS-3001)

Right now, the `AtlasClientV2.updateClassifications()` method is not functional because it expects a response body that can be deserialized into an `AtlasClassifications` instance, but the [response according to the REST API](https://atlas.apache.org/api/v2/resource_EntityREST.html#resource_EntityREST_updateClassifications_PUT) will be empty, with a status code of `204 No Content`. This change fixes the client so that the response's body will not be de-serialized.