### PR TITLE
Added use of javax.annotation-api to resolve eclipse build errors.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
 
+		<dependency>
+		    <groupId>javax.annotation</groupId>
+		    <artifactId>javax.annotation-api</artifactId>
+		</dependency>
+			
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
@@ -102,6 +107,7 @@
             <groupId>org.apache.atlas</groupId>
             <artifactId>atlas-intg</artifactId>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -670,6 +670,7 @@
         <spring.security.version>4.2.6.RELEASE</spring.security.version>
 
         <javax.servlet.version>3.1.0</javax.servlet.version>
+        <javax.annotation.version>1.3.2</javax.annotation.version>
         <guava.version>19.0</guava.version>
         <scala.version>2.11.12</scala.version>
         <antlr4.version>4.7</antlr4.version>
@@ -742,7 +743,6 @@
     </properties>
 
     <modules>
-        <module>build-tools</module>
         <module>test-tools</module>
 
         <module>intg</module>
@@ -1622,6 +1622,14 @@
                 <artifactId>zkclient</artifactId>
                 <version>${zkclient.version}</version>
             </dependency>
+         
+			<!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
+			<dependency>
+			    <groupId>javax.annotation</groupId>
+			    <artifactId>javax.annotation-api</artifactId>
+			    <version>${javax.annotation.version}</version>
+			</dependency>
+			
 
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Some projects won't compile using

Eclipse IDE for Java Developers
Version: 2018-12 (4.10.0)
Build id: 20181214-0600
OS: Linux, v.4.18.0-15-generic, x86_64 / gtk 3.24.1
Java version: 1.8.0_191

Specifically:

**ATLAS_MIGRATION_MODE_FILENAME** cannot be resolved to a variable in 
atlas-webapp/AtlasSecurityconfig.java
atlas-repository/DataMigrationService.java
atlas-webapp/ServiceState.java

**AtlasConstants** cannot be resolved to a variable in atlas-webapp/ActiveInstanceElectorServiceTest.java
atlas-webapp/Atlas.java
atlas-webapp/EntityResource.java
atlas-webapp/SetupSteps.java
atlas-webapp/SetupStepsTest.java
atlas-client-v1/AtlasAdminClient.java
atlas-notifications/AtlasHook.java
atlas-server-api/AtlasServerIdSelector.java
atlas-repository/AuditsWriter.java
falcon-bridge/FalconBridge.java
hbase-bridge/HBaseAtlasHook.java
sqoop-bridge/SqoopHook.java
storm-bridge/StormAtlasHook.java

**AtlasPerfMetrics** cannot be resolved in
atlas-server-api/RequestContext.java

**AtlasPerfTracer** cannot be resolved in
atlas-webapp/AdminResource.java
atlas-webapp/DataSetLineageResource.java
atlas-webapp/DiscoveryREST.java
atlas-repository/AtlasEntityStoreV2.java
atlas-repository/ClassificationSearchProcessor.java
atlas-repository/DataAccess.java
atlas-graphdb-janus/AtlasJanusGraphDatabase.java

Using this plugin in atlas-common seems resolve the issue.