### PR TITLE
ATLAS-3041 : Fix for Cannot delete relationship types using the /typedef/name REST API

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
@@ -619,6 +619,8 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
             typesDef.setEntityDefs(Collections.singletonList((AtlasEntityDef) baseTypeDef));
         } else if (baseTypeDef instanceof AtlasEnumDef) {
             typesDef.setEnumDefs(Collections.singletonList((AtlasEnumDef) baseTypeDef));
+        } else if (baseTypeDef instanceof AtlasRelationshipDef) {
+            typesDef.setRelationshipDefs(Collections.singletonList((AtlasRelationshipDef) baseTypeDef));
         } else if (baseTypeDef instanceof AtlasStructDef) {
             typesDef.setStructDefs(Collections.singletonList((AtlasStructDef) baseTypeDef));
         }

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStoreTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStoreTest.java
@@ -332,9 +332,15 @@ public class AtlasTypeDefGraphStoreTest {
         try {
             final String HIVEDB_v2_JSON = "hiveDBv2";
             final String hiveDB2 = "hive_db_v2";
+            final String relationshipDefName = "cluster_hosts_relationship";
+            final String hostEntityDef = "host";
+            final String clusterEntityDef = "cluster";
             AtlasTypesDef typesDef = TestResourceFileUtils.readObjectFromJson(".", HIVEDB_v2_JSON, AtlasTypesDef.class);
             typeDefStore.createTypesDef(typesDef);
             typeDefStore.deleteTypeByName(hiveDB2);
+            typeDefStore.deleteTypeByName(relationshipDefName);
+            typeDefStore.deleteTypeByName(hostEntityDef);
+            typeDefStore.deleteTypeByName(clusterEntityDef);
         } catch (AtlasBaseException e) {
             fail("Deletion should've succeeded");
         }

--- a/repository/src/test/resources/json/hiveDBv2.json
+++ b/repository/src/test/resources/json/hiveDBv2.json
@@ -52,5 +52,58 @@
       "isUnique": false,
       "isIndexable": false
     }]
-  }]
+  },
+    {
+      "name": "cluster",
+      "serviceType": "atlas_core",
+      "typeVersion": "1.0",
+      "attributeDefs": [
+        {
+          "name": "attr1",
+          "typeName": "string",
+          "cardinality": "SINGLE",
+          "isIndexable": true,
+          "isOptional": false,
+          "isUnique": false
+        }
+      ]
+    },
+    {
+      "name": "host",
+      "serviceType": "atlas_core",
+      "typeVersion": "1.0",
+      "attributeDefs": [
+        {
+          "name": "attr2",
+          "typeName": "string",
+          "cardinality": "SINGLE",
+          "isIndexable": true,
+          "isOptional": false,
+          "includeInNotification": true,
+          "isUnique": false
+        }
+      ]
+    }],
+  "relationshipDefs": [
+    {
+      "name": "cluster_hosts_relationship",
+      "relationshipLabel": "cluster_hosts_relationship_label",
+      "serviceType": "atlas_core",
+      "typeVersion": "1.0",
+      "relationshipCategory": "COMPOSITION",
+      "propagateTags": "NONE",
+      "endDef1": {
+        "type": "cluster",
+        "name": "host_list",
+        "isContainer": true,
+        "cardinality": "SET"
+      },
+      "endDef2": {
+        "type": "host",
+        "name": "cluster",
+        "isContainer": false,
+        "cardinality": "SINGLE"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
…/typedef/name REST API

Since the AtlasRelationshipDef is extending AtlasStructDef, we make an additonal
check in deleteByName before the AtlasStructDef check to see if the instance to be
deleted is of type AtlasRelationshipDef.