### PR TITLE
ATLAS-2933:Empty array attributes are returned as null instead of an empty list

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
@@ -207,12 +207,15 @@ public class AtlasGraphUtilsV2 {
         Object existingValue = element.getProperty(propertyName, Object.class);
 
         if (value == null || (value instanceof Collection && ((Collection)value).isEmpty())) {
-            if (existingValue != null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Removing property {} from {}", propertyName, toString(element));
+            if (value == null) {
+                if (existingValue != null) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Removing property {} from {}", propertyName, toString(element));
+                    }
+                    element.removeProperty(propertyName);
                 }
-
-                element.removeProperty(propertyName);
+            } else {
+                element.setProperty(propertyName, value);
             }
         } else {
             if (!value.equals(existingValue)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -725,6 +725,10 @@ public class EntityGraphRetriever {
         List<AtlasObjectId> ret        = null;
         List                softRefVal = entityVertex.getListProperty(attribute.getVertexPropertyName(), List.class);
 
+        if (CollectionUtils.isEmpty(softRefVal)) {
+            return softRefVal;
+        }
+
         if (CollectionUtils.isNotEmpty(softRefVal)) {
             ret = new ArrayList<>();
 
@@ -822,7 +826,7 @@ public class EntityGraphRetriever {
         List<Object>   arrayElements    = getArrayElementsProperty(arrayElementType, entityVertex, attribute);
 
         if (CollectionUtils.isEmpty(arrayElements)) {
-            return null;
+            return arrayElements;
         }
 
         if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
Empty array attributes are returned as null instead of an empty list