### PR TITLE
ATLAS-3092: Atlas Plugin ClassLoader Doesn't Restore Thread ClassLoader

### DIFF
--- a/plugin-classloader/src/test/java/org/apache/atlas/plugin/classloader/AtlasPluginClassLoaderTest.java
+++ b/plugin-classloader/src/test/java/org/apache/atlas/plugin/classloader/AtlasPluginClassLoaderTest.java
@@ -34,7 +34,7 @@ public class AtlasPluginClassLoaderTest {
             //expected
         }
 
-        AtlasPluginClassLoader classLoader = new AtlasPluginClassLoader("../common/target");
+        AtlasPluginClassLoader classLoader = new AtlasPluginClassLoader("../common/target","dummyType");
 
         classLoader.activate();
 


### PR DESCRIPTION
**PROBLEM:** Atlas Plugin ClassLoader's MyComponent parent always set to UDFClassLoader after hiveserver2 start even though it is closed, Hiveserver2 can run sessions concurrently with different sessionstate, so if the sessionstate disgraded and associated UDF classloader is closed, MyComponent parent loader still has this closed parent classloader. this can yield into the CNF exception for custom hive udf.

**Fix:** In this proposed fix, during activate call I am storing current classloader in prevClassloader and during deactivate checking if the plugintype is hive( don't want to break the other components) then setting the Thread current class loader back to the previous one.

**Test:** Run few test on my reproduce where hive custom udf were failing due to CNF which are succeeded now. 