### PR TITLE
ATLAS-3098: Missing getTypesDef with AtlasRelationshipDef param in AtlasTypeUtil.

### DIFF
--- a/intg/src/main/java/org/apache/atlas/type/AtlasTypeUtil.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasTypeUtil.java
@@ -294,6 +294,14 @@ public class AtlasTypeUtil {
         List<AtlasEntityDef> classes) {
         return new AtlasTypesDef(enums, structs, traits, classes);
     }
+    
+    public static AtlasTypesDef getTypesDef(List<AtlasEnumDef> enums,
+            List<AtlasStructDef> structs,
+            List<AtlasClassificationDef> traits,
+            List<AtlasEntityDef> classes,
+            List<AtlasRelationshipDef> relationships) {
+            return new AtlasTypesDef(enums, structs, traits, classes, relationships);
+        }
 
     public static List<AtlasTypeDefHeader> toTypeDefHeader(AtlasTypesDef typesDef) {
         List<AtlasTypeDefHeader> headerList = new LinkedList<>();


### PR DESCRIPTION
In AtlasTypesDef.java Atlas team introduced the AtlasTypesDef .ctor with the List<AtlasRelationshipDef> parameter but in AtlasTypeUtil the getTypesDef method does not accept 5 parameters.

I think we can use directly the AtlasTypesDef contructors so this Bug in my opinion is a minor issue. Any way I submitted the pull-request