### PR TITLE
ATLAS-3102: Missing setServiceType in AtlasBaseTypeDef copy constructor

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasBaseTypeDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasBaseTypeDef.java
@@ -191,6 +191,7 @@ public abstract class AtlasBaseTypeDef implements java.io.Serializable {
             setUpdateTime(other.getUpdateTime());
             setVersion(other.getVersion());
             setName(other.getName());
+            setServiceType(other.getServiceType());
             setDescription(other.getDescription());
             setTypeVersion(other.getTypeVersion());
             setOptions(other.getOptions());
@@ -204,6 +205,7 @@ public abstract class AtlasBaseTypeDef implements java.io.Serializable {
             setUpdateTime(null);
             setVersion(null);
             setName(null);
+            setServiceType(null);
             setDescription(null);
             setTypeVersion(null);
             setOptions(null);

--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasRelationshipDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasRelationshipDef.java
@@ -126,7 +126,7 @@ public class AtlasRelationshipDef extends AtlasStructDef implements java.io.Seri
      * AtlasRelationshipDef contructor
      * @throws AtlasBaseException
      */
-    public AtlasRelationshipDef() throws AtlasBaseException {
+    public AtlasRelationshipDef() {
         this(null, null, null, null,null, null, null);
     }
 
@@ -268,7 +268,7 @@ public class AtlasRelationshipDef extends AtlasStructDef implements java.io.Seri
         setEndDef2(endDef2);
     }
 
-    public AtlasRelationshipDef(AtlasRelationshipDef other) throws AtlasBaseException {
+    public AtlasRelationshipDef(AtlasRelationshipDef other) {
         super(other);
 
         if (other != null) {


### PR DESCRIPTION
The AtlasBaseServiceType copy constructor misses of the setServiceType to set the serviceType. The problem was corrected in the pull request.

Also the AtlasRelationshipDef copy costructor throws an AtlasBaseException that is unused because nothing can throw that exception in AtlasRelationshipDef constructor and its superclasses. Removed.