### PR TITLE
ATLAS-3134 Change Date.getTime() to System.currentTimeMillis() for better performance.

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -525,12 +525,11 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
      * increment the version value for this vertex
      */
     private void markVertexUpdated(AtlasVertex vertex) {
-        Date   now         = new Date();
         Number currVersion = vertex.getProperty(Constants.VERSION_PROPERTY_KEY, Number.class);
         long   newVersion  = currVersion == null ? 1 : (currVersion.longValue() + 1);
 
         vertex.setProperty(Constants.MODIFIED_BY_KEY, getCurrentUser());
-        vertex.setProperty(Constants.MODIFICATION_TIMESTAMP_PROPERTY_KEY, now.getTime());
+        vertex.setProperty(Constants.MODIFICATION_TIMESTAMP_PROPERTY_KEY, System.currentTimeMillis());
         vertex.setProperty(Constants.VERSION_PROPERTY_KEY, newVersion);
     }
 


### PR DESCRIPTION
new Date() is just a thin wrapper around System.currentTimeMillis(). Using System.currentTimeMillis() is better since we don't need create a new object and the system can speed up.