### PR TITLE
ATLAS-3135 delete null data from typedefs results in messy data

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
@@ -473,6 +473,14 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
                     CollectionUtils.size(typesDef.getRelationshipDefs()));
         }
 
+        if (CollectionUtils.isEmpty(typesDef.getRelationshipDefs()) &&
+            CollectionUtils.isEmpty(typesDef.getStructDefs()) &&
+            CollectionUtils.isEmpty(typesDef.getClassificationDefs()) &&
+            CollectionUtils.isEmpty(typesDef.getEntityDefs()) &&
+            CollectionUtils.isEmpty(typesDef.getEnumDefs())) {
+            return;
+        }
+
         AtlasTransientTypeRegistry ttr = lockTypeRegistryAndReleasePostCommit();
 
         AtlasDefStore<AtlasEnumDef>           enumDefStore          = getEnumDefStore(ttr);


### PR DESCRIPTION
Currently, when we use http://IP:21000/api/atlas/v2/types/typedefs/, deleting the data of typedefs is empty ({"enumDefs":[],"structDefs":[],"classificationDefs":[],"entityDefs":[],"relationshipDefs":[]}), it will lead to messy data, and basic search error, so the atlas system must be restarted in order to recover the data.

please see issue: https://issues.apache.org/jira/browse/ATLAS-3135

