### PR TITLE
ATLAS-3160: ctor creates a useless AtlasBaseException

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/typedef/AtlasRelationshipDef.java
+++ b/intg/src/main/java/org/apache/atlas/model/typedef/AtlasRelationshipDef.java
@@ -126,7 +126,7 @@ public class AtlasRelationshipDef extends AtlasStructDef implements java.io.Seri
      * AtlasRelationshipDef contructor
      * @throws AtlasBaseException
      */
-    public AtlasRelationshipDef() throws AtlasBaseException {
+    public AtlasRelationshipDef()  {
         this(null, null, null, null,null, null, null);
     }
 
@@ -192,7 +192,7 @@ public class AtlasRelationshipDef extends AtlasStructDef implements java.io.Seri
                                 RelationshipCategory relationshipCategory,
                                 PropagateTags propagatetags,
                                 AtlasRelationshipEndDef endDef1,
-                                AtlasRelationshipEndDef endDef2) throws AtlasBaseException {
+                                AtlasRelationshipEndDef endDef2)  {
         this(name, description, typeVersion, relationshipCategory,propagatetags, endDef1, endDef2,
              new ArrayList<AtlasAttributeDef>());
     }


### PR DESCRIPTION
ATLAS-3160: This exception is raised by the default constructor and by another one but none of these two constructors call functions that can give rise to these exceptions. The  problem is not blocking but it is annoying if someone wants to subclass this class.