### PR TITLE
ATLAS-3180:New Bulk retrieval API with servicetype parameter

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/SearchFilter.java
+++ b/intg/src/main/java/org/apache/atlas/model/SearchFilter.java
@@ -43,7 +43,9 @@ public class SearchFilter {
     public static final String PARAM_TYPE = "type";
     public static final String PARAM_NAME = "name";
     public static final String PARAM_SUPERTYPE = "supertype";
+    public static final String PARAM_SERVICETYPE = "servicetype";
     public static final String PARAM_NOT_SUPERTYPE = "notsupertype";
+    public static final String PARAM_NOT_SERVICETYPE = "notservicetype";
     public static final String PARAM_NOT_NAME      = "notname";
 
     /**

--- a/repository/src/main/java/org/apache/atlas/repository/util/FilterUtil.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/FilterUtil.java
@@ -40,7 +40,10 @@ public class FilterUtil {
         final String       type         = searchFilter.getParam(SearchFilter.PARAM_TYPE);
         final String       name         = searchFilter.getParam(SearchFilter.PARAM_NAME);
         final String       supertype    = searchFilter.getParam(SearchFilter.PARAM_SUPERTYPE);
+        final String	   serviceType  = searchFilter.getParam(SearchFilter.PARAM_SERVICETYPE);
+        
         final String       notSupertype = searchFilter.getParam(SearchFilter.PARAM_NOT_SUPERTYPE);
+        final String	   notServiceType = searchFilter.getParam(SearchFilter.PARAM_NOT_SERVICETYPE);
         final List<String> notNames     = searchFilter.getParams(SearchFilter.PARAM_NOT_NAME);
 
         // Add filter for the type/category
@@ -52,6 +55,11 @@ public class FilterUtil {
         if (StringUtils.isNotBlank(name)) {
             predicates.add(getNamePredicate(name));
         }
+        
+        //Add filter for the serviceType
+        if(StringUtils.isNotBlank(serviceType)) {
+        	predicates.add(getServiceTypePredicate(serviceType));
+        }
 
         // Add filter for the supertype
         if (StringUtils.isNotBlank(supertype)) {
@@ -62,6 +70,16 @@ public class FilterUtil {
         if (StringUtils.isNotBlank(notSupertype)) {
             predicates.add(new NotPredicate(getSuperTypePredicate(notSupertype)));
         }
+        
+        // Add filter for the serviceType negation
+        // NOTE: Creating code for the exclusion of multiple service types is currently useless. 
+        // In fact the getSearchFilter in TypeREST.java uses the HttpServletRequest.getParameter(key) 
+        // that if the key takes more values it takes only the first the value. Could be usefull
+        // to change the getSearchFilter to use getParameterValues instead of getParameter.
+        if (StringUtils.isNotBlank(notServiceType)) {
+            predicates.add(new NotPredicate(getServiceTypePredicate(notServiceType)));
+        }
+
 
         // Add filter for the type negation
         if (CollectionUtils.isNotEmpty(notNames)) {
@@ -84,6 +102,25 @@ public class FilterUtil {
                 return o != null && isAtlasType(o) && Objects.equals(((AtlasType) o).getTypeName(), name);
             }
         };
+    }
+    
+    private static Predicate getServiceTypePredicate(final String serviceType) {
+    	return new Predicate() {
+            private boolean isClassificationType(Object o) {
+                return o instanceof AtlasClassificationType;
+            }
+
+            private boolean isAtlasType(Object o) {
+                return o instanceof AtlasType;
+            }
+
+			@Override
+			public boolean evaluate(Object o) {
+                return o != null && isAtlasType(o) && !isClassificationType(o) 
+                		&& Objects.equals(((AtlasType) o).getServiceType(), serviceType);
+			}
+    		
+    	};
     }
 
     private static Predicate getSuperTypePredicate(final String supertype) {


### PR DESCRIPTION
ATLAS-3180: The Bulk api retrieval returns all defined types or filtered types by name, type and supertype. With the addition of the service type among the basic attributes of the Atlas types it is necessary to have the possibility to search also for service type through a http request of the type:

```http://host:port/api/atlas/V2/types/typedefs?serviceType = requested-service-type```

to search only for types related to a specific service type.
This pull request solves this problem