### PR TITLE
add missing memory requirements

### DIFF
--- a/dev-support/atlas-docker/Dockerfile
+++ b/dev-support/atlas-docker/Dockerfile
@@ -37,6 +37,10 @@ WORKDIR /root
 # Pull down Atlas and build it into /root/atlas-bin.
 RUN git clone https://github.com/apache/atlas.git -b master
 
+# Memory requirements
+ENV MAVEN_OPTS "-Xms2g -Xmx2g"
+# RUN export MAVEN_OPTS="-Xms2g -Xmx2g"
+
 # Remove -DskipTests if unit tests are to be included
 RUN mvn clean install -DskipTests -Pdist,embedded-hbase-solr -f ./atlas/pom.xml
 RUN mkdir -p atlas-bin


### PR DESCRIPTION
Without memory config, this error occurs

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15:06 min
[INFO] Finished at: 2019-05-07T12:50:22Z
[INFO] ------------------------------------------------------------------------
[ERROR] GC overhead limit exceeded -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/OutOfMemoryError
```