### PR TITLE
[ATLAS-3153] Add keycloak authentication

### DIFF
--- a/addons/hbase-bridge/src/main/java/org/apache/atlas/hbase/bridge/HBaseBridge.java
+++ b/addons/hbase-bridge/src/main/java/org/apache/atlas/hbase/bridge/HBaseBridge.java
@@ -143,7 +143,11 @@ public class HBaseBridge {
             }
 
 
-            if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
+            if (AuthenticationUtil.isKeycloakAuthenticationEnabled()) {
+                String token = AuthenticationUtil.getBearerTokenInput();
+
+                atlasClientV2 = new AtlasClientV2(urls, token);
+            } else if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
                 String[] basicAuthUsernamePassword = AuthenticationUtil.getBasicAuthenticationInput();
 
                 atlasClientV2 = new AtlasClientV2(urls, basicAuthUsernamePassword);

--- a/addons/hive-bridge/src/main/java/org/apache/atlas/hive/bridge/HiveMetaStoreBridge.java
+++ b/addons/hive-bridge/src/main/java/org/apache/atlas/hive/bridge/HiveMetaStoreBridge.java
@@ -125,7 +125,11 @@ public class HiveMetaStoreBridge {
             }
 
 
-            if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
+            if (AuthenticationUtil.isKeycloakAuthenticationEnabled()) {
+                String token = AuthenticationUtil.getBearerTokenInput();
+
+                atlasClientV2 = new AtlasClientV2(atlasEndpoint, token);
+            } else if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
                 String[] basicAuthUsernamePassword = AuthenticationUtil.getBasicAuthenticationInput();
 
                 atlasClientV2 = new AtlasClientV2(atlasEndpoint, basicAuthUsernamePassword);

--- a/addons/kafka-bridge/src/main/java/org/apache/atlas/kafka/bridge/KafkaBridge.java
+++ b/addons/kafka-bridge/src/main/java/org/apache/atlas/kafka/bridge/KafkaBridge.java
@@ -107,7 +107,11 @@ public class KafkaBridge {
             }
 
 
-            if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
+            if (AuthenticationUtil.isKeycloakAuthenticationEnabled()) {
+                String token = AuthenticationUtil.getBearerTokenInput();
+
+                atlasClientV2 = new AtlasClientV2(urls, token);
+            } else if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
                 String[] basicAuthUsernamePassword = AuthenticationUtil.getBasicAuthenticationInput();
 
                 atlasClientV2 = new AtlasClientV2(urls, basicAuthUsernamePassword);

--- a/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
+++ b/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
@@ -82,6 +82,10 @@ public class AtlasClientV2 extends AtlasBaseClient {
         super(baseUrl, basicAuthUserNamePassword);
     }
 
+    public AtlasClientV2(String[] baseUrl, String token) {
+        super(baseUrl, token);
+    }
+
     public AtlasClientV2(String... baseUrls) throws AtlasException {
         super(baseUrls);
     }

--- a/client/common/src/main/java/org/apache/atlas/AtlasBaseClient.java
+++ b/client/common/src/main/java/org/apache/atlas/AtlasBaseClient.java
@@ -110,6 +110,7 @@ public abstract class AtlasBaseClient {
     protected Configuration configuration;
     private String basicAuthUser;
     private String basicAuthPassword;
+    private String token;
     private AtlasClientContext atlasClientContext;
     private boolean retryEnabled = false;
     private Cookie cookie = null;
@@ -128,6 +129,12 @@ public abstract class AtlasBaseClient {
                 this.basicAuthPassword = basicAuthUserNamePassword[1];
             }
         }
+
+        initializeState(baseUrl, null, null);
+    }
+
+    protected AtlasBaseClient(String[] baseUrl, String token) {
+        this.token = token;
 
         initializeState(baseUrl, null, null);
     }
@@ -452,7 +459,10 @@ public abstract class AtlasBaseClient {
         this.configuration = configuration;
         Client client = getClient(configuration, ugi, doAsUser);
 
-        if ((!AuthenticationUtil.isKerberosAuthenticationEnabled()) && basicAuthUser != null && basicAuthPassword != null) {
+        if (token != null) {
+            final HTTPBearerTokenFilter authFilter = new HTTPBearerTokenFilter(token);
+            client.addFilter(authFilter);
+        } else if ((!AuthenticationUtil.isKerberosAuthenticationEnabled()) && basicAuthUser != null && basicAuthPassword != null) {
             final HTTPBasicAuthFilter authFilter = new HTTPBasicAuthFilter(basicAuthUser, basicAuthPassword);
             client.addFilter(authFilter);
         }

--- a/client/common/src/main/java/org/apache/atlas/HTTPBearerTokenFilter.java
+++ b/client/common/src/main/java/org/apache/atlas/HTTPBearerTokenFilter.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas;
+
+import com.sun.jersey.api.client.ClientHandlerException;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.filter.ClientFilter;
+
+public class HTTPBearerTokenFilter extends ClientFilter {
+  private final String authentication;
+
+  public HTTPBearerTokenFilter(String token) {
+    this.authentication = "Bearer " + token;
+  }
+
+  public ClientResponse handle(ClientRequest cr) throws ClientHandlerException {
+    if (!cr.getHeaders().containsKey("Authorization")) {
+      cr.getHeaders().add("Authorization", this.authentication);
+    }
+
+    return this.getNext().handle(cr);
+  }
+}

--- a/docs/src/site/twiki/Atlas-Authentication.twiki
+++ b/docs/src/site/twiki/Atlas-Authentication.twiki
@@ -7,6 +7,7 @@ Atlas supports following authentication methods
    * *File*
    * *Kerberos*
    * *LDAP*
+   * *Keycloak (OpenID Connect / OAUTH2)*
 
 
 Following properties should be set true to enable the authentication of that type in =atlas-application.properties= file.
@@ -16,6 +17,7 @@ Following properties should be set true to enable the authentication of that typ
 atlas.authentication.method.kerberos=true|false
 atlas.authentication.method.ldap=true|false
 atlas.authentication.method.file=true|false
+atlas.authentication.method.keycloak=true|false
 </verbatim>
 
 If two or more authentication methods are set to true, then the authentication falls back to the latter method if the earlier one fails.
@@ -111,3 +113,29 @@ atlas.authentication.method.ldap.user.searchfilter=(uid={0})
 atlas.authentication.method.ldap.default.role=ROLE_USER
 </verbatim>
 
+---++++ Keycloak Method.
+
+To enable Keycloak authentication mode in Atlas, set the property =atlas.authentication.method.keycloak= to true and also set the property =atlas.authentication.method.keycloak.file= to the localtion of your =keycloak.json= in =atlas-application.properties=.
+Also set =atlas.authentication.method.keycloak.ugi-groups= to false if you want to pickup groups from Keycloak. By default the groups will be picked up from the *roles* defined in Keycloak. In case you want to use the groups
+you need to create a mapping in keycloak and define =atlas.authentication.method.keycloak.groups_claim= equal to the token claim name. Make sure *not* to use the full group path and add the information to the access token.
+
+<verbatim>
+atlas.authentication.method.keycloak=true
+atlas.authentication.method.keycloak.file=/opt/atlas/conf/keycloak.json
+atlas.authentication.method.keycloak.ugi-groups=false
+</verbatim>
+
+Setup you keycloak.json per instructions from Keycloak. Make sure to include ="principal-attribute": "preferred_username"= to ensure readable user names and ="autodetect-bearer-only": true=.
+
+<verbatim>
+{
+  "realm": "auth",
+  "auth-server-url": "http://keycloak-server/auth",
+  "ssl-required": "external",
+  "resource": "atlas",
+  "public-client": true,
+  "confidential-port": 0,
+  "principal-attribute": "preferred_username",
+  "autodetect-bearer-only": true
+}
+</verbatim>

--- a/intg/src/main/java/org/apache/atlas/utils/AuthenticationUtil.java
+++ b/intg/src/main/java/org/apache/atlas/utils/AuthenticationUtil.java
@@ -23,12 +23,16 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
 import java.io.Console;
+import java.io.IOException;
+import java.io.InputStreamReader;
 
 /**
  * Util class for Authentication.
  */
-public final class AuthenticationUtil {
+public final class  AuthenticationUtil {
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticationUtil.class);
 
     private AuthenticationUtil() {
@@ -56,6 +60,24 @@ public final class AuthenticationUtil {
 
     public static boolean isKerberosAuthenticationEnabled(Configuration atlasConf, boolean defaultValue) {
         return atlasConf.getBoolean("atlas.authentication.method.kerberos", defaultValue);
+    }
+
+    public static boolean isKeycloakAuthenticationEnabled() {
+        try {
+            return isKeycloakAuthenticationEnabled(ApplicationProperties.get(), false);
+        } catch (AtlasException e) {
+            LOG.error("Error while isKeycloakAuthenticationEnabled", e);
+        }
+
+        return false;
+    }
+
+    public static boolean isKeycloakAuthenticationEnabled(Configuration atlasConf) {
+        return isKeycloakAuthenticationEnabled(atlasConf, false);
+    }
+
+    public static boolean isKeycloakAuthenticationEnabled(Configuration atlasConf, boolean defaultValue) {
+        return atlasConf.getBoolean("atlas.authentication.method.keycloak", defaultValue);
     }
 
     public static boolean includeHadoopGroups(){
@@ -95,6 +117,26 @@ public final class AuthenticationUtil {
             System.exit(1);
         }
         return new String[]{username, password};
+    }
+
+    public static String getBearerTokenInput() {
+        String fmt = "Provide bearer token for atlas oidc authentication :- ";
+
+        try {
+            Console console = System.console();
+            if (console != null) {
+                return console.readLine(fmt);
+            } else {
+                System.out.print(fmt);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+                return reader.readLine();
+            }
+        } catch (IOException ioe) {
+            System.out.print("Error while reading user input");
+            System.exit(1);
+        }
+
+        return null;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -719,6 +719,10 @@
         <hppc.version>0.8.1</hppc.version>
         <!-- Storm dependencies -->
 
+        <!-- keycloak dependencies -->
+        <keycloak.version>6.0.1</keycloak.version>
+        <!-- keycloak dependencies -->
+
         <PermGen>64m</PermGen>
         <MaxPermGen>512m</MaxPermGen>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -462,6 +462,14 @@
             <artifactId>hadoop-aws</artifactId>
             <version>${hadoop.version}</version>
         </dependency>
+
+        <!-- Keycloak -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-spring-security-adapter</artifactId>
+            <version>${keycloak.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/webapp/src/main/java/org/apache/atlas/examples/QuickStartV2.java
+++ b/webapp/src/main/java/org/apache/atlas/examples/QuickStartV2.java
@@ -150,21 +150,31 @@ public class QuickStartV2 {
 
     public static void main(String[] args) throws Exception {
         String[] basicAuthUsernamePassword = null;
+        String token = null;
 
-        if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
+        if (AuthenticationUtil.isKeycloakAuthenticationEnabled()) {
+            token = AuthenticationUtil.getBearerTokenInput();
+        } else if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
             basicAuthUsernamePassword = AuthenticationUtil.getBasicAuthenticationInput();
         }
 
-        runQuickstart(args, basicAuthUsernamePassword);
+        runQuickstart(args, basicAuthUsernamePassword, token);
     }
 
     @VisibleForTesting
     static void runQuickstart(String[] args, String[] basicAuthUsernamePassword) throws Exception {
+        runQuickstart(args, basicAuthUsernamePassword, null);
+    }
+
+    @VisibleForTesting
+    static void runQuickstart(String[] args, String[] basicAuthUsernamePassword, String token) throws Exception {
         String[] urls = getServerUrl(args);
 
         QuickStartV2 quickStartV2 = null;
         try {
-            if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
+            if (AuthenticationUtil.isKeycloakAuthenticationEnabled()) {
+                quickStartV2 = new QuickStartV2(urls, token);
+            } else if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
                 quickStartV2 = new QuickStartV2(urls, basicAuthUsernamePassword);
             } else {
                 quickStartV2 = new QuickStartV2(urls);
@@ -206,6 +216,10 @@ public class QuickStartV2 {
     }
 
     private final AtlasClientV2 atlasClientV2;
+
+    QuickStartV2(String[] urls, String token) {
+        atlasClientV2 = new AtlasClientV2(urls, token);
+    }
 
     QuickStartV2(String[] urls, String[] basicAuthUsernamePassword) {
         atlasClientV2 = new AtlasClientV2(urls,basicAuthUsernamePassword);

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasAuthenticationProvider.java
@@ -37,11 +37,14 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
 
     private boolean fileAuthenticationMethodEnabled = true;
     private boolean pamAuthenticationEnabled = false;
+    private boolean keycloakAuthenticationEnabled = false;
+
     private String ldapType = "NONE";
     public static final String FILE_AUTH_METHOD = "atlas.authentication.method.file";
     public static final String LDAP_AUTH_METHOD = "atlas.authentication.method.ldap";
     public static final String LDAP_TYPE = "atlas.authentication.method.ldap.type";
     public static final String PAM_AUTH_METHOD = "atlas.authentication.method.pam";
+    public static final String KEYCLOAK_AUTH_METHOD = "atlas.authentication.method.keycloak";
 
 
 
@@ -55,15 +58,19 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
 
     final AtlasPamAuthenticationProvider pamAuthenticationProvider;
 
+    final AtlasKeycloakAuthenticationProvider atlasKeycloakAuthenticationProvider;
+
     @Inject
     public AtlasAuthenticationProvider(AtlasLdapAuthenticationProvider ldapAuthenticationProvider,
                                        AtlasFileAuthenticationProvider fileAuthenticationProvider,
                                        AtlasADAuthenticationProvider adAuthenticationProvider,
-                                       AtlasPamAuthenticationProvider pamAuthenticationProvider) {
+                                       AtlasPamAuthenticationProvider pamAuthenticationProvider,
+                                       AtlasKeycloakAuthenticationProvider atlasKeycloakAuthenticationProvider) {
         this.ldapAuthenticationProvider = ldapAuthenticationProvider;
         this.fileAuthenticationProvider = fileAuthenticationProvider;
         this.adAuthenticationProvider = adAuthenticationProvider;
         this.pamAuthenticationProvider = pamAuthenticationProvider;
+        this.atlasKeycloakAuthenticationProvider = atlasKeycloakAuthenticationProvider;
     }
 
     @PostConstruct
@@ -74,6 +81,8 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
             this.fileAuthenticationMethodEnabled = configuration.getBoolean(FILE_AUTH_METHOD, true);
 
             this.pamAuthenticationEnabled = configuration.getBoolean(PAM_AUTH_METHOD, false);
+
+            this.keycloakAuthenticationEnabled = configuration.getBoolean(KEYCLOAK_AUTH_METHOD, false);
 
             boolean ldapAuthenticationEnabled = configuration.getBoolean(LDAP_AUTH_METHOD, false);
 
@@ -118,6 +127,12 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
                 } catch (Exception ex) {
                     LOG.error("Error while PAM authentication", ex);
                 }
+            } else if (keycloakAuthenticationEnabled) {
+                try {
+                    authentication = atlasKeycloakAuthenticationProvider.authenticate(authentication);
+                } catch (Exception ex) {
+                    LOG.error("Error while Keycloak authentication", ex);
+                }
             }
         }
 
@@ -135,6 +150,21 @@ public class AtlasAuthenticationProvider extends AtlasAbstractAuthenticationProv
 
         LOG.error("Authentication failed.");
         throw new AtlasAuthenticationException("Authentication failed.");
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        if (pamAuthenticationEnabled) {
+            return pamAuthenticationProvider.supports(authentication);
+        } else if (ldapType.equalsIgnoreCase("LDAP")) {
+            return ldapAuthenticationProvider.supports(authentication);
+        } else if (ldapType.equalsIgnoreCase("AD")) {
+            return adAuthenticationProvider.supports(authentication);
+        } else if (keycloakAuthenticationEnabled) {
+            return atlasKeycloakAuthenticationProvider.supports(authentication);
+        } else {
+            return super.supports(authentication);
+        }
     }
 
     public boolean isSsoEnabled() {

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasKeycloakAuthenticationProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.web.security;
+
+import org.apache.atlas.ApplicationProperties;
+import org.apache.commons.configuration.Configuration;
+import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
+import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class AtlasKeycloakAuthenticationProvider extends AtlasAbstractAuthenticationProvider {
+  private final boolean groupsFromUGI;
+  private final String groupsClaim;
+
+  private final KeycloakAuthenticationProvider keycloakAuthenticationProvider;
+
+  public AtlasKeycloakAuthenticationProvider() throws Exception {
+    this.keycloakAuthenticationProvider = new KeycloakAuthenticationProvider();
+
+    Configuration configuration = ApplicationProperties.get();
+    this.groupsFromUGI = configuration.getBoolean("atlas.authentication.method.keycloak.ugi-groups", true);
+    this.groupsClaim = configuration.getString("atlas.authentication.method.keycloak.groups_claim");
+  }
+
+  @Override
+  public Authentication authenticate(Authentication authentication) {
+    authentication = keycloakAuthenticationProvider.authenticate(authentication);
+
+    if (groupsFromUGI) {
+      List<GrantedAuthority> groups = getAuthoritiesFromUGI(authentication.getName());
+      KeycloakAuthenticationToken token = (KeycloakAuthenticationToken) authentication;
+
+      authentication = new KeycloakAuthenticationToken(token.getAccount(), token.isInteractive(), groups);
+    } else if (groupsClaim != null) {
+      KeycloakAuthenticationToken token = (KeycloakAuthenticationToken)authentication;
+      Map<String, Object> claims = token.getAccount().getKeycloakSecurityContext().getToken().getOtherClaims();
+      if (claims.containsKey(groupsClaim)) {
+        List<String> membership = (List<String>)claims.get(groupsClaim);
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        for (String group : membership) {
+          grantedAuthorities.add(new SimpleGrantedAuthority(group));
+        }
+        authentication = new KeycloakAuthenticationToken(token.getAccount(), token.isInteractive(), grantedAuthorities);
+      }
+    }
+
+    return authentication;
+  }
+
+  @Override
+  public boolean supports(Class<?> aClass) {
+    return keycloakAuthenticationProvider.supports(aClass);
+  }
+}

--- a/webapp/src/test/resources/test-spring-security.xml
+++ b/webapp/src/test/resources/test-spring-security.xml
@@ -62,11 +62,13 @@
     </beans:bean>
     <beans:bean id="atlasADProvider" class="org.apache.atlas.web.security.AtlasADAuthenticationProvider"/>
     <beans:bean id="atlasPamProvider" class="org.apache.atlas.web.security.AtlasPamAuthenticationProvider"/>
+    <beans:bean id="atlasKeycloakProvider" class="org.apache.atlas.web.security.AtlasKeycloakAuthenticationProvider"/>
     <beans:bean id="atlasAuthenticationProvider" class="org.apache.atlas.web.security.AtlasAuthenticationProvider">
         <beans:constructor-arg index="0" ref="atlasLDAPProvider"/>
         <beans:constructor-arg index="1" ref="atlasFileProvider"/>
         <beans:constructor-arg index="2" ref="atlasADProvider"/>
         <beans:constructor-arg index="3" ref="atlasPamProvider"/>
+        <beans:constructor-arg index="4" ref="atlasKeycloakProvider" />
     </beans:bean>
 
     <beans:bean id="krbAuthenticationFilter" class="org.apache.atlas.web.filters.AtlasAuthenticationFilter">


### PR DESCRIPTION
Keycloak is an open source Identity and Access Management solution aimed at modern applications and services. It makes it easy to secure applications and services with little to no code.
This enabled Atlas to use OpenID Connect (OAUTH2) and allows integration with more services.

This is a working implementation.