### PR TITLE
ATLAS-3219: New REST APIs for serviceType.

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -161,6 +161,7 @@ public enum AtlasErrorCode {
     // All Not found enums go here
     TYPE_NAME_NOT_FOUND(404, "ATLAS-404-00-001", "Given typename {0} was invalid"),
     TYPE_GUID_NOT_FOUND(404, "ATLAS-404-00-002", "Given type guid {0} was invalid"),
+    TYPE_SERVICE_TYPE_NOT_FOUND(404, "ATLAS-404-00-014", "Given service type {0} was invalid"),
     NO_CLASSIFICATIONS_FOUND_FOR_ENTITY(404, "ATLAS-404-00-003", "No classifications associated with entity: {0}"),
     EMPTY_RESULTS(404, "ATLAS-404-00-004", "No result found for {0}"),
     INSTANCE_GUID_NOT_FOUND(404, "ATLAS-404-00-005", "Given instance guid {0} is invalid/not found"),

--- a/intg/src/main/java/org/apache/atlas/model/SearchFilter.java
+++ b/intg/src/main/java/org/apache/atlas/model/SearchFilter.java
@@ -43,7 +43,9 @@ public class SearchFilter {
     public static final String PARAM_TYPE = "type";
     public static final String PARAM_NAME = "name";
     public static final String PARAM_SUPERTYPE = "supertype";
+    public static final String PARAM_SERVICETYPE = "servicetype";
     public static final String PARAM_NOT_SUPERTYPE = "notsupertype";
+    public static final String PARAM_NOT_SERVICETYPE = "notservicetype";
     public static final String PARAM_NOT_NAME      = "notname";
 
     /**

--- a/intg/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
+++ b/intg/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
@@ -17,6 +17,7 @@
  */
 package org.apache.atlas.store;
 
+import java.util.List;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.SearchFilter;
 import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
@@ -39,6 +40,8 @@ public interface AtlasTypeDefStore {
     AtlasEnumDef getEnumDefByName(String name) throws AtlasBaseException;
 
     AtlasEnumDef getEnumDefByGuid(String guid) throws AtlasBaseException;
+    
+    List<AtlasEnumDef> getEnumDefByServiceType(String serviceType) throws AtlasBaseException;
 
     AtlasEnumDef updateEnumDefByName(String name, AtlasEnumDef enumDef) throws AtlasBaseException;
 
@@ -50,6 +53,8 @@ public interface AtlasTypeDefStore {
 
     AtlasStructDef getStructDefByGuid(String guid) throws AtlasBaseException;
 
+	List<AtlasStructDef> getStructDefByServiceType(String serviceType) throws AtlasBaseException;
+    
     AtlasStructDef updateStructDefByName(String name, AtlasStructDef structDef) throws AtlasBaseException;
 
     AtlasStructDef updateStructDefByGuid(String guid, AtlasStructDef structDef) throws AtlasBaseException;
@@ -72,6 +77,8 @@ public interface AtlasTypeDefStore {
 
     AtlasEntityDef getEntityDefByGuid(String guid) throws AtlasBaseException;
 
+	List<AtlasEntityDef> getEntityDefByServiceType(String serviceType)throws AtlasBaseException;
+
     AtlasEntityDef updateEntityDefByName(String name, AtlasEntityDef entityDef) throws AtlasBaseException;
 
     AtlasEntityDef updateEntityDefByGuid(String guid, AtlasEntityDef entityDef) throws AtlasBaseException;
@@ -80,6 +87,8 @@ public interface AtlasTypeDefStore {
     AtlasRelationshipDef getRelationshipDefByName(String name) throws AtlasBaseException;
 
     AtlasRelationshipDef getRelationshipDefByGuid(String guid) throws AtlasBaseException;
+    
+	List<AtlasRelationshipDef> getRelationshipDefByServiceType(String serviceType) throws AtlasBaseException;
 
     AtlasRelationshipDef updateRelationshipDefByName(String name, AtlasRelationshipDef structDef) throws AtlasBaseException;
 
@@ -98,12 +107,18 @@ public interface AtlasTypeDefStore {
     void deleteTypesDef(AtlasTypesDef atlasTypesDef) throws AtlasBaseException;
 
     AtlasTypesDef searchTypesDef(SearchFilter searchFilter) throws AtlasBaseException;
-
+    
+    AtlasTypesDef  getTypesByServiceType(String serviceType) throws AtlasBaseException;
 
     /* Generic operation */
     AtlasBaseTypeDef getByName(String name) throws AtlasBaseException;
 
     AtlasBaseTypeDef getByGuid(String guid) throws AtlasBaseException;
+    
+    List<AtlasBaseTypeDef> getByServiceType(String serviceType) throws AtlasBaseException;
 
     void deleteTypeByName(String typeName) throws AtlasBaseException;
+    
+    public void deleteTypesByServiceType(String serviceType) throws AtlasBaseException;
+
 }

--- a/repository/src/main/java/org/apache/atlas/repository/util/FilterUtil.java
+++ b/repository/src/main/java/org/apache/atlas/repository/util/FilterUtil.java
@@ -40,7 +40,10 @@ public class FilterUtil {
         final String       type         = searchFilter.getParam(SearchFilter.PARAM_TYPE);
         final String       name         = searchFilter.getParam(SearchFilter.PARAM_NAME);
         final String       supertype    = searchFilter.getParam(SearchFilter.PARAM_SUPERTYPE);
+        final String	   serviceType  = searchFilter.getParam(SearchFilter.PARAM_SERVICETYPE);
+        
         final String       notSupertype = searchFilter.getParam(SearchFilter.PARAM_NOT_SUPERTYPE);
+        final String	   notServiceType = searchFilter.getParam(SearchFilter.PARAM_NOT_SERVICETYPE);
         final List<String> notNames     = searchFilter.getParams(SearchFilter.PARAM_NOT_NAME);
 
         // Add filter for the type/category
@@ -52,6 +55,11 @@ public class FilterUtil {
         if (StringUtils.isNotBlank(name)) {
             predicates.add(getNamePredicate(name));
         }
+        
+        //Add filter for the serviceType
+        if(StringUtils.isNotBlank(serviceType)) {
+        	predicates.add(getServiceTypePredicate(serviceType));
+        }
 
         // Add filter for the supertype
         if (StringUtils.isNotBlank(supertype)) {
@@ -62,6 +70,16 @@ public class FilterUtil {
         if (StringUtils.isNotBlank(notSupertype)) {
             predicates.add(new NotPredicate(getSuperTypePredicate(notSupertype)));
         }
+        
+        // Add filter for the serviceType negation
+        // NOTE: Creating code for the exclusion of multiple service types is currently useless. 
+        // In fact the getSearchFilter in TypeREST.java uses the HttpServletRequest.getParameter(key) 
+        // that if the key takes more values it takes only the first the value. Could be usefull
+        // to change the getSearchFilter to use getParameterValues instead of getParameter.
+        if (StringUtils.isNotBlank(notServiceType)) {
+            predicates.add(new NotPredicate(getServiceTypePredicate(notServiceType)));
+        }
+
 
         // Add filter for the type negation
         if (CollectionUtils.isNotEmpty(notNames)) {
@@ -84,6 +102,25 @@ public class FilterUtil {
                 return o != null && isAtlasType(o) && Objects.equals(((AtlasType) o).getTypeName(), name);
             }
         };
+    }
+    
+    private static Predicate getServiceTypePredicate(final String serviceType) {
+    	return new Predicate() {
+            private boolean isClassificationType(Object o) {
+                return o instanceof AtlasClassificationType;
+            }
+
+            private boolean isAtlasType(Object o) {
+                return o instanceof AtlasType;
+            }
+
+			@Override
+			public boolean evaluate(Object o) {
+                return o != null && isAtlasType(o) && !isClassificationType(o) 
+                		&& Objects.equals(((AtlasType) o).getServiceType(), serviceType);
+			}
+    		
+    	};
     }
 
     private static Predicate getSuperTypePredicate(final String supertype) {

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -104,6 +104,24 @@ public class TypesREST {
 
         return ret;
     }
+    
+    /**
+     * Get type definition by it's service type
+     * @param servicetype Service Type of the types
+     * @return Types definition
+     * @throws AtlasBaseException
+     * @HTTP 200 Successful lookup
+     * @HTTP 404 Failed lookup
+     */
+    @GET
+    @Path("/typedef/servicetype/{servicetype}")
+    public AtlasTypesDef getTypeDefsByServiceType(@PathParam("servicetype") String serviceType) throws AtlasBaseException {
+    	Servlets.validateQueryParamLength("servicetype", serviceType);
+    	
+    	AtlasTypesDef ret = typeDefStore.getTypesByServiceType(serviceType);
+    	
+    	return ret;
+    }
 
     /**
      * Bulk retrieval API for all type definitions returned as a list of minimal information header
@@ -124,7 +142,7 @@ public class TypesREST {
 
     /**
      * Bulk retrieval API for retrieving all type definitions in Atlas
-     * @return A composite wrapper object with lists of all type definitions
+     * @return A composite wrapper object with lists of all type definitions 
      * @throws Exception
      * @HTTP 200 {@link AtlasTypesDef} with type definitions matching the search criteria or else returns empty list of type definitions
      */
@@ -174,7 +192,23 @@ public class TypesREST {
         return ret;
     }
 
+    /**
+     * Get the enum definition for the given serviceType
+     * @param guid enum serviceType
+     * @return enum definition
+     * @throws AtlasBaseException
+     * @HTTP 200 On successful lookup of the the enum definition by it's guid
+     * @HTTP 404 On Failed lookup for the given serviceType
+     */
+    @GET
+    @Path("/enumdef/servicetype/{servicetype}")
+    public List<AtlasEnumDef> getEnumDefByServiceType(@PathParam("servicetype") String serviceType) throws AtlasBaseException {
+        Servlets.validateQueryParamLength("servicetype", serviceType);
 
+        List<AtlasEnumDef> ret = typeDefStore.getEnumDefByServiceType(serviceType);
+
+        return ret;
+    }
     /**
      * Get the struct definition by it's name (unique)
      * @param name struct name
@@ -207,6 +241,24 @@ public class TypesREST {
         Servlets.validateQueryParamLength("guid", guid);
 
         AtlasStructDef ret = typeDefStore.getStructDefByGuid(guid);
+
+        return ret;
+    }
+    
+    /**
+     * Get the struct definition for the given serviceType
+     * @param servicetype struct serviceType
+     * @return struct definition
+     * @throws AtlasBaseException
+     * @HTTP 200 On successful lookup of the the struct definition by it's serviceType
+     * @HTTP 404 On Failed lookup for the given serviceType
+     */
+    @GET
+    @Path("/structdef/servicetype/{servicetype}")
+    public List<AtlasStructDef> getStructDefByServiceType(@PathParam("servicetype") String serviceType) throws AtlasBaseException {
+        Servlets.validateQueryParamLength("servicetype", serviceType);
+
+        List<AtlasStructDef> ret = typeDefStore.getStructDefByServiceType(serviceType);
 
         return ret;
     }
@@ -282,6 +334,24 @@ public class TypesREST {
 
         return ret;
     }
+    
+    /**
+     * Get the Entity definition for the given serviceType
+     * @param guid entity serviceTyu
+     * @return Entity definition
+     * @throws AtlasBaseException
+     * @HTTP 200 On successful lookup of the the entity definition by it's serviceType
+     * @HTTP 404 On Failed lookup for the given serviceType
+     */
+    @GET
+    @Path("/entitydef/servicetype/{servicetype}")
+    public List<AtlasEntityDef> getEntityDefByServiceType(@PathParam("servicetype") String serviceType) throws AtlasBaseException {
+        Servlets.validateQueryParamLength("servicetype", serviceType);
+
+        List<AtlasEntityDef> ret = typeDefStore.getEntityDefByServiceType(serviceType);
+
+        return ret;
+    }
     /**
      * Get the relationship definition by it's name (unique)
      * @param name relationship name
@@ -317,6 +387,25 @@ public class TypesREST {
 
         return ret;
     }
+    
+    /**
+     * Get the relationship definition for the given serviceType
+     * @param servicetype relationship serviceType
+     * @return relationship definition
+     * @throws AtlasBaseException
+     * @HTTP 200 On successful lookup of the the relationship definition by it's serviceType
+     * @HTTP 404 On Failed lookup for the given serviceType
+     */
+    @GET
+    @Path("/relationshipdef/servicetype/{servicetype}")
+    public List<AtlasRelationshipDef> getRelationshipDefByServiceType(@PathParam("servicetype") String serviceType) throws AtlasBaseException {
+        Servlets.validateQueryParamLength("servicetype", serviceType);
+
+        List<AtlasRelationshipDef> ret = typeDefStore.getRelationshipDefByServiceType(serviceType);
+
+        return ret;
+    }
+    
     /* Bulk API operation */
 
     /**
@@ -417,6 +506,30 @@ public class TypesREST {
             }
 
             typeDefStore.deleteTypeByName(typeName);
+        } finally {
+            AtlasPerfTracer.log(perf);
+        }
+    }
+    
+    /**
+     * Delete API for type identified by its name.
+     * @param typeName Name of the type to be deleted.
+     * @throws AtlasBaseException
+     * @HTTP 204 On successful deletion of the requested type definitions
+     * @HTTP 400 On validation failure for any type definitions
+     */
+    @DELETE
+    @Path("/typedef/servicetype/{servicetype}")
+    public void deleteAtlasTypeByServiceType(@PathParam("servicetype") final String serviceType) throws AtlasBaseException {
+        AtlasPerfTracer perf = null;
+
+        try {
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "TypesREST.deleteAtlasTypeByServiceType(" 
+                		+ serviceType + ")");
+            }
+
+            typeDefStore.deleteTypesByServiceType(serviceType);
         } finally {
             AtlasPerfTracer.log(perf);
         }


### PR DESCRIPTION
This pull request supersedes the pull request ATLAS-3180.

The new basic attribute serviceType, introduced by Atlas Team, has no use if it is not searchable ina any way. This pull request solves this problem by adding the following REST APIs.

GET / typedef / servicetype / {servicetype}
GET / typedefs / headers? Servicetype = {serviceType}
GET / typedefs? Servicetype = {servicetype}
GET / enumdef / servicetype / {servicetype}
GET / entitydef / servicetype / {servicetype}
GET / structdef / servicetype / {servicetype}
GET / relationshipdef / servicetype / {servicetype}
DELETE / typedef / servicetype / {servicetype}

The APIs were tested on ATLAS 2.0 and on the new SNAPSHOT 3.0