### PR TITLE
[ATLAS-3261] Set kafka user as current principal for Ranger Authorization

### DIFF
--- a/docs/src/site/twiki/Configuration.twiki
+++ b/docs/src/site/twiki/Configuration.twiki
@@ -113,7 +113,7 @@ atlas.enableTLS=false
 
 ---+++ Kafka message principal
 The following property enables passing user name from kafka lineage message to NotificationHookConsumer for Ranger Authorizer
-atlas.authentication.method.kafka.message.principal=false|true
+atlas.notification.authorize.using.message.user=false|true
 
 ---++ High Availability Properties
 The following properties describe High Availability related configuration options:

--- a/docs/src/site/twiki/Configuration.twiki
+++ b/docs/src/site/twiki/Configuration.twiki
@@ -111,6 +111,10 @@ The following property is used to toggle the SSL feature.
 atlas.enableTLS=false
 </verbatim>
 
+---+++ Kafka message principal
+The following property enables passing user name from kafka lineage message to NotificationHookConsumer for Ranger Authorizer
+atlas.authentication.method.kafka.message.principal=false|true
+
 ---++ High Availability Properties
 The following properties describe High Availability related configuration options:
 

--- a/webapp/src/main/java/org/apache/atlas/notification/NotificationHookConsumer.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/NotificationHookConsumer.java
@@ -486,7 +486,7 @@ public class NotificationHookConsumer implements Service, ActiveStateChangeHandl
 
         private void setMessagePrincipal(String messageUser) throws AtlasException {
             Configuration configuration = ApplicationProperties.get();
-            boolean msgPrincipalEnabled = configuration.getBoolean("atlas.authentication.method.kafka.message.principal", false);
+            boolean msgPrincipalEnabled = configuration.getBoolean("atlas.notification.authorize.using.message.user", false);
 
             if(msgPrincipalEnabled) {
                 if (!StringUtils.isEmpty(messageUser)) {


### PR DESCRIPTION
If lineage message sent to ATLAS_HOOK has non empty "user" value, NotificationHookConsumer.java will set Authentication context to this user, allowing check in Ranger policies by Atlas authorizer.

Currently no user is set by NotificationHookConsumer, so Atlas authorizer is not invoked. 