### PR TITLE
[ATLAS-3314] Loosen the relationship between spark_table and spark_storagedesc

### DIFF
--- a/addons/models/1000-Hadoop/1100-spark_model.json
+++ b/addons/models/1000-Hadoop/1100-spark_model.json
@@ -420,17 +420,15 @@
       "name": "spark_table_storagedesc",
       "serviceType": "spark",
       "typeVersion": "1.0",
-      "relationshipCategory": "COMPOSITION",
+      "relationshipCategory": "ASSOCIATION",
       "endDef1": {
         "type": "spark_table",
         "name": "sd",
-        "isContainer": true,
         "cardinality": "SINGLE"
       },
       "endDef2": {
         "type": "spark_storagedesc",
         "name": "table",
-        "isContainer": false,
         "cardinality": "SINGLE"
       },
       "propagateTags": "NONE"


### PR DESCRIPTION
This patch loosens the relationship between `spark_table` and `spark_storagedesc` to ensure either side of setting relationship works instead of requiring entity of `spark_storagedesc` to refer entity of `spark_table`.

Please refer https://issues.apache.org/jira/browse/ATLAS-3314 for more details on rationalization.