### PR TITLE
fix - aws_s3_bucket createTime attribute

### DIFF
--- a/addons/models/3000-Cloud/3020-aws_s3_typedefs.json
+++ b/addons/models/3000-Cloud/3020-aws_s3_typedefs.json
@@ -238,7 +238,7 @@
                     "isUnique":    false
                 },
                 {
-                    "name":        "createtime",
+                    "name":        "createTime",
                     "typeName":    "date",
                     "cardinality": "SINGLE",
                     "isIndexable": true,


### PR DESCRIPTION
It fixes the inconsistency with name attribute `createtime` - all attribute names are camelCase