### PR TITLE
ATLAS-3508: Add API for getting the active instance as a HTTP status code (503 or 200)

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
@@ -271,6 +271,33 @@ public class AdminResource {
         return response;
     }
 
+    /**
+     * Check if the host is ACTIVE.
+     *
+     * @return HTTP 200 only when the host is active, HTTP 503 otherwise.
+     */
+    @GET
+    @Path("httphealth")
+    @Produces(Servlets.JSON_MEDIA_TYPE)
+    public Response getHttpHealth() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> AdminResource.getHttpHealth()");
+        }
+
+        Response response;
+        if (serviceState.getState() == ServiceState.ServiceStateValue.ACTIVE) {
+            response = Response.ok().build();
+        } else {
+            response = Response.serverError().build();
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== AdminResource.getHttpHealth()");
+        }
+
+        return response;
+    }
+
     @GET
     @Path("session")
     @Produces(Servlets.JSON_MEDIA_TYPE)

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -176,7 +176,8 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
             "/n/js/**",
             "/ieerror.html",
             "/api/atlas/admin/status",
-            "/api/atlas/admin/metrics"));
+            "/api/atlas/admin/metrics",
+            "/api/atlas/admin/httphealth"));
 
         if (!keycloakEnabled) {
             matchers.add("/login.jsp");

--- a/webapp/src/main/resources/spring-security.xml
+++ b/webapp/src/main/resources/spring-security.xml
@@ -28,6 +28,7 @@
     <security:http pattern="/ieerror.html" security="none" />
     <security:http pattern="/api/atlas/admin/status" security="none" />
     <security:http pattern="/api/atlas/admin/metrics" security="none" />
+    <security:http pattern="/api/atlas/admin/httphealth" security="none" />
 
     <security:http create-session="always"
                    entry-point-ref="entryPoint">

--- a/webapp/src/test/java/org/apache/atlas/web/resources/AdminResourceTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/resources/AdminResourceTest.java
@@ -70,4 +70,23 @@ public class AdminResourceTest {
         assertEquals(entity.get("Status").asText(), "PASSIVE");
 
     }
+
+    @Test
+    public void getHttpHealthActive() throws IOException {
+
+        when(serviceState.getState()).thenReturn(ServiceState.ServiceStateValue.ACTIVE);
+
+        AdminResource adminResource = new AdminResource(serviceState, null, null, null, null, null, null, null, null, null);
+        Response response = adminResource.getHttpHealth();
+        assertEquals(response.getStatus(), HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    public void getHttpHealthPassive() throws IOException {
+        when(serviceState.getState()).thenReturn(ServiceState.ServiceStateValue.PASSIVE);
+
+        AdminResource adminResource = new AdminResource(serviceState, null, null, null, null, null, null, null, null, null);
+        Response response = adminResource.getHttpHealth();
+        assertEquals(response.getStatus(), HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
 }

--- a/webapp/src/test/resources/test-spring-security.xml
+++ b/webapp/src/test/resources/test-spring-security.xml
@@ -26,6 +26,7 @@
     <security:http pattern="/ieerror.html" security="none" />
     <security:http pattern="/api/atlas/admin/status" security="none" />
     <security:http pattern="/api/atlas/admin/metrics" security="none" />
+    <security:http pattern="/api/atlas/admin/httphealth" security="none" />
 
     <security:http create-session="always"
                    entry-point-ref="entryPoint">


### PR DESCRIPTION
Currently, Atlas exposes the active instance using the web API /api/atlas/admin/status.  However, this returns the status using a string embedded in the body of the response rather than a HTTP error code.  For haproxy, this works but requires a sufficient buffer size for the response.  On the other hand, for certain proxies (envoy in particular), this is not supported.  This proposes to add a new API to return the status of the instance as an HTTP error code: 200 for active, 503 for passive