### PR TITLE
[ATLAS-3424][addons/hbase-brige] hbase 2.2.0 does not execute the Atlas implemented coprocessor

### DIFF
--- a/addons/hbase-bridge/src/main/java/org/apache/atlas/hbase/hook/HBaseAtlasCoprocessor.java
+++ b/addons/hbase-bridge/src/main/java/org/apache/atlas/hbase/hook/HBaseAtlasCoprocessor.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 public class HBaseAtlasCoprocessor implements MasterCoprocessor, MasterObserver, RegionObserver, RegionServerObserver  {
     private static final Logger LOG = LoggerFactory.getLogger(HBaseAtlasCoprocessor.class);
@@ -44,6 +45,11 @@ public class HBaseAtlasCoprocessor implements MasterCoprocessor, MasterObserver,
 
     public HBaseAtlasCoprocessor() {
         hbaseAtlasHook = HBaseAtlasHook.getInstance();
+    }
+
+    @Override
+    public Optional<MasterObserver> getMasterObserver() {
+                return Optional.of(this);
     }
 
     @Override


### PR DESCRIPTION
in atlas 2.0.0, we use hbase-hook to capture the changes of name space,table,column faimily schema in hbase 2.2.0. According to steps of the  official document, we found that the hbase master loaded HBaseAtlasCoprocessor , but it will not call the  methods like postCreateTable/postDeleteTable.
from remote debug,we found that HBaseAtlasCoprocessor must override the default implementation of MasterCoprocessor.getMasterObserver method to make Atlas coprocessor runs correctly.