### PR TITLE
ATLAS-3640 Update 'spark_ml_model_ml_directory' and 'spark_ml_pipeline_ml_directory' relationship definitions

### DIFF
--- a/addons/models/1000-Hadoop/1100-spark_model.json
+++ b/addons/models/1000-Hadoop/1100-spark_model.json
@@ -436,8 +436,8 @@
     {
       "name": "spark_ml_model_ml_directory",
       "serviceType": "spark",
-      "typeVersion": "1.0",
-      "relationshipCategory": "COMPOSITION",
+      "typeVersion": "1.1",
+      "relationshipCategory": "AGGREGATION",
       "endDef1": {
         "type": "spark_ml_model",
         "name": "directory",
@@ -445,7 +445,7 @@
         "cardinality": "SINGLE"
       },
       "endDef2": {
-        "type": "spark_ml_directory",
+        "type": "DataSet",
         "name": "model",
         "isContainer": false,
         "cardinality": "SINGLE"
@@ -455,8 +455,8 @@
     {
       "name": "spark_ml_pipeline_ml_directory",
       "serviceType": "spark",
-      "typeVersion": "1.0",
-      "relationshipCategory": "COMPOSITION",
+      "typeVersion": "1.1",
+      "relationshipCategory": "AGGREGATION",
       "endDef1": {
         "type": "spark_ml_pipeline",
         "name": "directory",
@@ -464,7 +464,7 @@
         "cardinality": "SINGLE"
       },
       "endDef2": {
-        "type": "spark_ml_directory",
+        "type": "DataSet",
         "name": "pipeline",
         "isContainer": false,
         "cardinality": "SINGLE"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update `spark_ml_model_ml_directory` and `spark_ml_pipeline_ml_directory` relationship definitions to use `DataSet` type instead of it's child type `spark_ml_directory`. This is required in order to integrate Spark Atlas Connector's ML event processor.
Previously, Spark Atlas Connector used the `spark_ml_directory` model for ML model directory but this is changed in the scope of https://github.com/hortonworks-spark/spark-atlas-connector/issues/61, https://github.com/hortonworks-spark/spark-atlas-connector/pull/62 so ML model directory is `DataSet` entity(i.e. `hdfs_path`, `fs_path` and `aws_s3_object`).
Thus, relationship definitions must be updated, otherwise, an attempt to create relation leads to: 
```
org.apache.atlas.exception.AtlasBaseException: invalid relationshipDef: spark_ml_model_ml_directory: end type 1: spark_ml_directory, end type 2: spark_ml_model
```
since `COMPOSITION` requires `spark_ml_directory` to be set.

Proposed changes are safe for old clients since `DataSet` is parent type for the `spark_ml_directory`.

## How was this patch tested?

Manually and with unit tests.
