### PR TITLE
ATLAS-3655: Create 'spark_application' type to avoid 'spark_process' from being updated for multiple operations

### DIFF
--- a/addons/models/1000-Hadoop/1100-spark_model.json
+++ b/addons/models/1000-Hadoop/1100-spark_model.json
@@ -306,6 +306,34 @@
       ]
     },
     {
+      "name": "spark_application",
+      "superTypes": [
+        "Process"
+      ],
+      "serviceType": "spark",
+      "typeVersion": "1.0",
+      "attributeDefs": [
+        {
+          "name": "currentUser",
+          "typeName": "string",
+          "isOptional": true,
+          "cardinality": "SINGLE",
+          "isUnique": false,
+          "isIndexable": true,
+          "searchWeight": 10
+        },
+        {
+          "name": "remoteUser",
+          "typeName": "string",
+          "isOptional": true,
+          "cardinality": "SINGLE",
+          "isUnique": false,
+          "isIndexable": true,
+          "searchWeight": 10
+        }
+      ]
+    },
+    {
       "name": "spark_process",
       "superTypes": [
         "Process"
@@ -495,6 +523,25 @@
         "name": "columnLineages",
         "isContainer": true,
         "cardinality": "SET"
+
+      },
+      "propagateTags": "NONE"
+    },
+    {
+      "name": "spark_application_processes",
+      "serviceType": "spark",
+      "typeVersion": "1.0",
+      "relationshipCategory": "AGGREGATION",
+      "endDef1": {
+        "type": "spark_application",
+        "name": "processes",
+        "cardinality": "SET",
+        "isContainer": true
+      },
+      "endDef2": {
+        "type": "spark_process",
+        "name": "application",
+        "cardinality": "SINGLE"
       },
       "propagateTags": "NONE"
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create `spark_application` type to avoid `spark_process` from being updated for multiple operations. Currently, Spark Atlas Connector uses `spark_process` as a top-level type for a Spark session, thus it's being updated for multiple operations within the same session.

The following statements:
```
spark.sql("create table table_1(col1 int,col2 string)");
spark.sql("create table table_2 as select * from table_1");
```
result in the next correct lineage:
```
table1 ------> spark_process1 -------> table2
```
but executing similar statements in the same spark session:
```
spark.sql("create table table_3(col1 int,col2 string)"); 
spark.sql("create table table_4 as select * from table_3");
```
result in the same `spark_process` being updated and the lineage now connects all the 4 tables.
The proposal is to create a `spark_application` entity and associate all `spark_process` entities (created within that session) to it.

## How was this patch tested?

Manually using modified version of Spark Atlas Connector:
- Installed and started Atlas.
- Executed the next statements using spark-shell:

```
spark.sql("create table table_1_17(col1 int,col2 string)");
spark.sql("create table table_2_17 as select * from table_1_17");
spark.sql("create table table_3_17(col1 int,col2 string)");
spark.sql("create table table_4_17 as select * from table_3_17");
```

- Verified that all 4 entites are connected in Atlas lineage.
- `1100-spark_model.json` is updated with proposed changes.
- Once again executed similar statements:

```
spark.sql("create table table_1_37(col1 int,col2 string)");
spark.sql("create table table_2_37 as select * from table_1_37");
spark.sql("create table table_3_37(col1 int,col2 string)");
spark.sql("create table table_4_37 as select * from table_3_37");
```

- Verified that two `spark_process` entities are created,
that have a single `spark_application` entity as `application`.
Each of these processes has it's own lineage.