### PR TITLE
ATLAS-3661 Create 'spark_column_lineage' type and relationship definition

### DIFF
--- a/addons/models/1000-Hadoop/1100-spark_model.json
+++ b/addons/models/1000-Hadoop/1100-spark_model.json
@@ -359,6 +359,14 @@
       ]
     },
     {
+      "name" : "spark_column_lineage",
+      "superTypes" : [
+        "Process"
+      ],
+      "serviceType": "spark",
+      "typeVersion" : "1.0"
+    },
+    {
       "name": "spark_ml_pipeline",
       "superTypes": [
         "DataSet"
@@ -468,6 +476,25 @@
         "name": "pipeline",
         "isContainer": false,
         "cardinality": "SINGLE"
+      },
+      "propagateTags": "NONE"
+    },
+    {
+      "name": "spark_process_column_lineages",
+      "serviceType": "spark",
+      "typeVersion": "1.0",
+      "relationshipCategory": "AGGREGATION",
+      "endDef1": {
+        "type": "spark_column_lineage",
+        "name": "process",
+        "isContainer": false,
+        "cardinality": "SINGLE"
+      },
+      "endDef2": {
+        "type": "spark_process",
+        "name": "columnLineages",
+        "isContainer": true,
+        "cardinality": "SET"
       },
       "propagateTags": "NONE"
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create `spark_column_lineage` type and relationship definition to add support of column level lineage for `CREATE TABLE AS SELECT ...` statements and views. Column level lineage refers to lineage created between the input and output columns.
For example:
```
hive > create table employee_ctas as select id from employee;
```    
For the above query, lineage is created from `employee` to `employee_ctas`, and also from `employee.id` to `employee_ctas.id`.

## How was this patch tested?

Manually using modified version of Spark Atlas Connector:
- Installed and started Atlas.
- `1100-spark_model.json` is updated with proposed changes. Atlas is restarted.
- Executed the next statements using spark-shell:

```
spark.sql("create table sparkemployee_1_2(id int,name string)");
spark.sql("create table sparkemployee_ctas_1_2 as select id from sparkemployee_1_2");
```
- Verified that each table has column entities and `spark_column_lineage` entity is created.