### PR TITLE
ATLAS-3665 Add 'queryText' attribute to the 'spark_process' type

### DIFF
--- a/addons/models/1000-Hadoop/patches/015-spark_process_add_query_text_attribute.json
+++ b/addons/models/1000-Hadoop/patches/015-spark_process_add_query_text_attribute.json
@@ -1,0 +1,23 @@
+{
+  "patches": [
+    {
+      "id": "TYPEDEF_PATCH_1000_015_001",
+      "description": "Add 'queryText' attribute to spark_process",
+      "action": "ADD_ATTRIBUTE",
+      "typeName": "spark_process",
+      "applyToVersion": "1.0",
+      "updateToVersion": "1.1",
+      "params": null,
+      "attributeDefs": [
+        {
+          "name": "queryText",
+          "typeName": "string",
+          "cardinality": "SINGLE",
+          "isIndexable": true,
+          "isOptional": true,
+          "isUnique": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `queryText` attribute to the `spark_process` type in order to make `spark_process` more readable by the user. The `queryText` attribute stores exact SQL query that is executed within Spark session as a `spark_process`.

## How was this patch tested?
    
Manually using modified version of Spark Atlas Connector:
- Install and start Atlas.
- Stop Atlas.
- Copy `015-spark_process_add_query_text_attribute.json` to `models/1000-Hadoop/patches`.
- Start Atlas.
- Verify that patch is applied and `application.log` contains the following entry:
```
INFO  - [main:] ~ TYPEDEF_PATCH_1000_015_001 (status: APPLIED; action: ADD_ATTRIBUTE) in file: ...
```
- Execute the next statements using spark-shell:
```
spark.sql("create table source_2_77_10(id int, new_id int, name string)");
spark.sql("create table ctas_2_77_10 as select id as new_id from source_2_77_10");
```
- Verify that corresponding `spark_process` is created and has `queryText`:
```
create table ctas_2_77_10 as select id as new_id from source_2_77_10
```