### PR TITLE
Today AWS scheme is missing the aws account id that contains the S3 bucket.

### DIFF
--- a/addons/models/3000-Cloud/3030-aws_s3_v2_typedefs.json
+++ b/addons/models/3000-Cloud/3030-aws_s3_v2_typedefs.json
@@ -195,7 +195,16 @@
       "serviceType": "aws",
       "typeVersion": "1.0",
       "attributeDefs": [
-        {
+       {
+          "name":        "accountId",
+          "typeName":    "string",
+          "cardinality": "SINGLE",
+          "isIndexable": true,
+          "isOptional":  true,
+          "isUnique":    false,
+          "searchWeight" : 5
+        },
+		{
           "name":        "creationTime",
           "typeName":    "date",
           "cardinality": "SINGLE",


### PR DESCRIPTION
adding optional field for account id, so it will not break existing products that are using the current scheme, and will add ability for products to have the context of which account contains the bucket.