### PR TITLE
ATLAS-3923: fix NullPointException in HBaseBasedAuditRepository.listEventsV2

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/audit/HBaseBasedAuditRepository.java
+++ b/repository/src/main/java/org/apache/atlas/repository/audit/HBaseBasedAuditRepository.java
@@ -228,7 +228,7 @@ public class HBaseBasedAuditRepository extends AbstractStorageBasedAuditReposito
 
     public List<EntityAuditEventV2> listEventsV2(String entityId, EntityAuditActionV2 auditAction, String startKey, short maxResultCount) throws AtlasBaseException {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Listing events for entity id {}, operation {}, starting key{}, maximum result count {}", entityId, auditAction.toString(), startKey, maxResultCount);
+            LOG.debug("Listing events for entity id {}, operation {}, starting key{}, maximum result count {}", entityId, auditAction, startKey, maxResultCount);
         }
 
         Table         table   = null;


### PR DESCRIPTION
fix NullPointException in HBaseBasedAuditRepository.listEventsV2