### PR TITLE
ATLAS-3940 : Upgrade snakeyaml to a version without CVE-2017-18640

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1665,6 +1665,13 @@
                 <artifactId>zkclient</artifactId>
                 <version>${zkclient.version}</version>
             </dependency>
+          
+          <!-- Fix for cassandra-all tranitive dependency CVE-2017-18640 : https://nvd.nist.gov/vuln/detail/CVE-2017-18640 -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.26</version>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- Maven package `cassandra-all` has transitive dependency on `org.yaml:snakeyaml:1.11` which has CVE-2017-18640:https://nvd.nist.gov/vuln/detail/CVE-2017-18640
- Raised a PR to Cassandra to upgrade the version of `snakeyaml` to `1.26` where the CVE got fixed : https://github.com/apache/cassandra/pull/736
- Upgrade to the latest version once `cassandra-all` new release become available