### PR TITLE
Update LoginProcessor.java

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/listeners/LoginProcessor.java
+++ b/webapp/src/main/java/org/apache/atlas/web/listeners/LoginProcessor.java
@@ -39,8 +39,8 @@ public class LoginProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(LoginProcessor.class);
     public static final String ATLAS_AUTHENTICATION_PREFIX = "atlas.authentication.";
     public static final String AUTHENTICATION_KERBEROS_METHOD = ATLAS_AUTHENTICATION_PREFIX + "method.kerberos";
-    public static final String AUTHENTICATION_PRINCIPAL = ATLAS_AUTHENTICATION_PREFIX + "principal";
-    public static final String AUTHENTICATION_KEYTAB = ATLAS_AUTHENTICATION_PREFIX + "keytab";
+    public static final String AUTHENTICATION_PRINCIPAL = AUTHENTICATION_KERBEROS_METHOD + ".principal";
+    public static final String AUTHENTICATION_KEYTAB = AUTHENTICATION_KERBEROS_METHOD + ".keytab";
 
     /**
      * Perform a SIMPLE login based on established OS identity or a kerberos based login using the configured


### PR DESCRIPTION
Fix the bug that Atlas can't find the vaule of kerberos config ,because of path problem.
According to the user's manual  from http://atlas.apache.org/, properties  for  kerberos  should be:
atlas.authentication.method.kerberos.principal=
atlas.authentication.method.kerberos.keytab =

But , in the codes, paths are below:
public static final String AUTHENTICATION_PRINCIPAL = ATLAS_AUTHENTICATION_PREFIX+ "principal";
public static final String AUTHENTICATION_KEYTAB = ATLAS_AUTHENTICATION_PREFIX+ "keytab";

that are :atlas.authentication.principal    &  atlas.authentication.keytab

so, the properties for kerberos  couldn't be get correctly!