### PR TITLE
Hotfix#1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
   ~ limitations under the License.
   -->
 
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 

--- a/pom.xml
+++ b/pom.xml
@@ -832,7 +832,7 @@
         <repository>
             <id>typesafe</id>
             <name>Typesafe Repository</name>
-            <url>http://repo.typesafe.com/typesafe/releases/</url>
+            <url>https://repo.typesafe.com/typesafe/releases/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
   ~ limitations under the License.
   -->
 
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 


### PR DESCRIPTION
update  ‘http://repo.typesafe.com/typesafe/releases/’  to  'https', the ‘http://repo.typesafe.com/typesafe/releases/’  Connection refused