### PR TITLE
ATLAS-4111: Add replicationFactor attribute to kafka topic entity

### DIFF
--- a/addons/kafka-bridge/src/main/java/org/apache/atlas/kafka/bridge/KafkaBridge.java
+++ b/addons/kafka-bridge/src/main/java/org/apache/atlas/kafka/bridge/KafkaBridge.java
@@ -66,6 +66,7 @@ public class KafkaBridge {
     private static final String ATTRIBUTE_QUALIFIED_NAME   = "qualifiedName";
     private static final String DESCRIPTION_ATTR           = "description";
     private static final String PARTITION_COUNT            = "partitionCount";
+    private static final String REPLICATION_FACTOR         = "replicationFactor";
     private static final String NAME                       = "name";
     private static final String URI                        = "uri";
     private static final String CLUSTERNAME                = "clusterName";
@@ -236,9 +237,10 @@ public class KafkaBridge {
         ret.setAttribute(URI, topic);
         try {
             ret.setAttribute(PARTITION_COUNT, kafkaUtils.getPartitionCount(topic));
+            ret.setAttribute(REPLICATION_FACTOR, kafkaUtils.getReplicationFactor(topic));
         } catch (ExecutionException | InterruptedException e) {
-            LOG.error("Error while getting partition count for topic :" + topic, e);
-            throw new Exception("Error while getting partition count for topic :" + topic, e);
+            LOG.error("Error while getting partition data for topic :" + topic, e);
+            throw new Exception("Error while getting partition data for topic :" + topic, e);
         }
 
         return ret;

--- a/addons/models/1000-Hadoop/1070-kafka_model.json
+++ b/addons/models/1000-Hadoop/1070-kafka_model.json
@@ -163,6 +163,14 @@
                     "cardinality": "SINGLE",
                     "isUnique": false,
                     "isIndexable": false
+                },
+                {
+                    "name": "replicationFactor",
+                    "typeName": "int",
+                    "cardinality": "SINGLE",
+                    "isIndexable": true,
+                    "isOptional": true,
+                    "isUnique": false
                 }
             ]
         },

--- a/addons/models/1000-Hadoop/patches/018-kafka_topic_add_rf_attribute.json
+++ b/addons/models/1000-Hadoop/patches/018-kafka_topic_add_rf_attribute.json
@@ -1,0 +1,23 @@
+{
+  "patches": [
+    {
+      "id": "TYPEDEF_PATCH_1000_018_001",
+      "description": "Add 'replicationFactor' attribute to kafka_topic",
+      "action": "ADD_ATTRIBUTE",
+      "typeName": "kafka_topic",
+      "applyToVersion": "1.7",
+      "updateToVersion": "1.8",
+      "params": null,
+      "attributeDefs": [
+        {
+          "name": "replicationFactor",
+          "typeName": "int",
+          "cardinality": "SINGLE",
+          "isIndexable": true,
+          "isOptional": true,
+          "isUnique": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Currently, the replicationFactor is missing from kafka topic entities in Atlas. We should add them. 