### PR TITLE
Upgrade frontend-maven-plugin to support s390x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1788,7 +1788,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.5</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
frontend-maven-plugin 1.4 does not support s390x, takes s390x arch as x86, and failed to install node.js.

After 1.5, frontend-maven-plugin starts to support s390x.

With this change, mvn can build atlas on s390x and atlas can be executed on s390x environment.