### PR TITLE
ATLAS-4320 : Fixing location uri for DB entities in QuickStartV2

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/examples/QuickStartV2.java
+++ b/webapp/src/main/java/org/apache/atlas/examples/QuickStartV2.java
@@ -468,7 +468,7 @@ public class QuickStartV2 {
         entity.setAttribute(REFERENCEABLE_ATTRIBUTE_NAME, name + CLUSTER_SUFFIX);
         entity.setAttribute("description", description);
         entity.setAttribute("owner", owner);
-        entity.setAttribute("locationuri", locationUri);
+        entity.setAttribute("locationUri", locationUri);
         entity.setAttribute("createTime", System.currentTimeMillis());
 
         // set classifications


### PR DESCRIPTION
With the present code, on running quick_start.py, locationUri is not flowing in for DB entities. This fix will help associate the locationUri tag to the DB entities.