### PR TITLE
ATLAS-4321 : Ignore files generated under webapp/overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ distro/solr/*.tgz
 # emacs files
 *#
 *~
+
+# webapp
+/webapp/overlays/


### PR DESCRIPTION
By modifying the `.gitignore` configuration file, we can ignore the files generated under `webapp/overlays` and avoid submitting temporary files by mistake.