### PR TITLE
ATLAS-4318 : Remove useless pass statement in python client

### DIFF
--- a/distro/src/bin/atlas_config.py
+++ b/distro/src/bin/atlas_config.py
@@ -165,7 +165,6 @@ def expandWebApp(dir):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise e
-            pass
         atlasWarPath = os.path.join(atlasDir(), "server", "webapp", "atlas.war")
         if (isCygwin()):
             atlasWarPath = convertCygwinPath(atlasWarPath)


### PR DESCRIPTION
This patch will remove a useless pass statement in `atlas_config.py` file.