### PR TITLE
ATLAS-4318 : Remove unnecessary imports from python script

### DIFF
--- a/atlas-examples/sample-app/src/main/python/entity_example.py
+++ b/atlas-examples/sample-app/src/main/python/entity_example.py
@@ -21,7 +21,7 @@ import json
 import logging
 
 from apache_atlas.model.enums    import EntityOperation
-from apache_atlas.model.instance import AtlasEntityWithExtInfo, EntityMutations, AtlasRelatedObjectId
+from apache_atlas.model.instance import AtlasEntityWithExtInfo, AtlasRelatedObjectId
 from apache_atlas.utils          import type_coerce
 
 

--- a/distro/src/bin/atlas_admin.py
+++ b/distro/src/bin/atlas_admin.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
+
 import sys
 
 import atlas_config as mc

--- a/distro/src/bin/atlas_update_simple_auth_json.py
+++ b/distro/src/bin/atlas_update_simple_auth_json.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
+
 import sys
 
 import atlas_config as mc

--- a/distro/src/bin/quick_start.py
+++ b/distro/src/bin/quick_start.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
+
 import sys
 
 import atlas_config as mc

--- a/distro/src/bin/quick_start_v1.py
+++ b/distro/src/bin/quick_start_v1.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
+
 import sys
 
 import atlas_config as mc


### PR DESCRIPTION
This patch will remove these unnecessary imports from python scripts.