### PR TITLE
ATLAS-4263: Fix KafkaUtils to always enclose property values in double-quotes

### DIFF
--- a/common/src/main/java/org/apache/atlas/utils/KafkaUtils.java
+++ b/common/src/main/java/org/apache/atlas/utils/KafkaUtils.java
@@ -318,20 +318,9 @@ public class KafkaUtils implements AutoCloseable {
             return optionVal;
         }
 
-        String ret = optionVal;
-
-        // For property values which have special chars like "@" or "/", we need to enclose it in
-        // double quotes, so that Kafka can parse it
-        // If the property is already enclosed in double quotes, then do nothing.
-        if (optionVal.indexOf(0) != '"' && optionVal.indexOf(optionVal.length() - 1) != '"') {
-            // If the string as special characters like except _,-
-            final String SPECIAL_CHAR_LIST = "/!@#%^&*";
-
-            if (StringUtils.containsAny(optionVal, SPECIAL_CHAR_LIST)) {
-                ret = String.format("\"%s\"", optionVal);
-            }
-        }
-
-        return ret;
+        // Enclose property values in double quotes, so that Kafka can parse it.
+        // Escape all double quotes that may occur in the property value.
+        String doubleQuoteEscaped = optionVal.replace("\"", "\\\"");
+        return String.format("\"%s\"", doubleQuoteEscaped);
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `KafkaUtils` to always enclose property values in double-quotes. This helps to avoid the following error with Spark Atlas Connector trying to configure Atlas client to use delegation tokens:
```
java.lang.IllegalArgumentException: Value not specified for key 'null' in JAAS config
	at org.apache.kafka.common.security.JaasConfig.parseAppConfigurationEntry(JaasConfig.java:116)
	at org.apache.kafka.common.security.JaasConfig.<init>(JaasConfig.java:63)
	at org.apache.kafka.common.security.JaasContext.load(JaasContext.java:90)
	at org.apache.kafka.common.security.JaasContext.loadClientContext(JaasContext.java:84)
```
The following configuration is not handled properly:
```
atlas.jaas.KafkaClient.option.username=30CQ4q1hQMy0dB6X0eXfxQ
atlas.jaas.KafkaClient.option.password=KdaUQ4FlKWlDxwQrAeFGUVbb6sR0P+zoqOZDZjtIRP1wseXbSbhiTjz3QI9Ur9o4LTYZSv8TE1QqUC4FSwnoTA==
```
[KafkaUtils](https://github.com/apache/atlas/blob/8d3c4ab0e8844f04e29f66acb3577e9d40de9a16/common/src/main/java/org/apache/atlas/utils/KafkaUtils.java#L195) should always enclose property values in double-quotes, since unenclosed digits and `+` sign can not be parsed by Kafka [JaasConfig](https://github.com/apache/kafka/blob/2.0.0/clients/src/main/java/org/apache/kafka/common/security/JaasConfig.java#L116).


## How was this patch tested?

* Manually deploying a modified version of `atlas-common-*.jar` on a cluster
* Updated existing unit tests and added a new one