### PR TITLE
fix rename table with diff db bugs

### DIFF
--- a/addons/hive-bridge/src/main/java/org/apache/atlas/hive/hook/HiveMetastoreHookImpl.java
+++ b/addons/hive-bridge/src/main/java/org/apache/atlas/hive/hook/HiveMetastoreHookImpl.java
@@ -173,8 +173,8 @@ public class HiveMetastoreHookImpl extends MetaStoreEventListener {
     }
 
     private static boolean isTableRename(Table oldTable, Table newTable) {
-        String oldTableName = oldTable.getTableName();
-        String newTableName = newTable.getTableName();
+        String oldTableName = oldTable.getDbName() + "." + oldTable.getTableName();
+        String newTableName = newTable.getDbName() + "." + newTable.getTableName();
 
         return !StringUtils.equalsIgnoreCase(oldTableName, newTableName);
     }


### PR DESCRIPTION
Fix rename table bugs like: ALTER TABLE db_name.test_1 RENAME TO db_name1.test_1;