### PR TITLE
Log solr wait searcher conf only if index backend is solr

### DIFF
--- a/intg/src/main/java/org/apache/atlas/ApplicationProperties.java
+++ b/intg/src/main/java/org/apache/atlas/ApplicationProperties.java
@@ -362,7 +362,6 @@ public final class ApplicationProperties extends PropertiesConfiguration {
         addPropertyDirect(INDEX_SEARCH_MAX_RESULT_SET_SIZE, indexMaxResultSetSize);
 
         LOG.info("Setting " + INDEX_SEARCH_MAX_RESULT_SET_SIZE + " = " + indexMaxResultSetSize);
-        LOG.info("Setting " + SOLR_WAIT_SEARCHER_CONF + " = " + getBoolean(SOLR_WAIT_SEARCHER_CONF));
 
         setDbCacheConfDefaults();
     }


### PR DESCRIPTION
Log "atlas.graph.index.search.solr.wait-searcher" only when index backend is Solr. 
This PR removes the extra log which gives an error in case we are using elasticsearch as index backend and have not solr config in application properties. Also, the above config is already getting logged at line 350.