### PR TITLE
ATLAS-4159 Update Apache Storm to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -763,7 +763,7 @@
         <spring.security.version>5.5.1</spring.security.version>
         <spring.version>5.3.8</spring.version>
         <sqoop.version>1.4.6.2.3.99.0-195</sqoop.version>
-        <storm.version>2.2.0</storm.version>
+        <storm.version>2.3.0</storm.version>
         <surefire.forkCount>2C</surefire.forkCount>
         <surefire.version>2.18.1</surefire.version>
         <testng.version>6.9.4</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -763,7 +763,7 @@
         <spring.security.version>5.5.1</spring.security.version>
         <spring.version>5.3.8</spring.version>
         <sqoop.version>1.4.6.2.3.99.0-195</sqoop.version>
-        <storm.version>2.1.0</storm.version>
+        <storm.version>2.2.0</storm.version>
         <surefire.forkCount>2C</surefire.forkCount>
         <surefire.version>2.18.1</surefire.version>
         <testng.version>6.9.4</testng.version>


### PR DESCRIPTION
It comes with a newer RocksDB JNI that supports Linux ARM64