### PR TITLE
Propose a fix to potential flaky test under testGenerateSearchWeightString

### DIFF
--- a/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
+++ b/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
@@ -23,7 +23,9 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
+
 
 public class AtlasJanusGraphIndexClientTest {
 
@@ -112,7 +114,7 @@ public class AtlasJanusGraphIndexClientTest {
 
     @Test
     public void testGenerateSearchWeightString() {
-        Map<String, Integer> fields = new HashMap<>();
+        Map<String, Integer> fields = new LinkedHashMap<>();
         fields.put("one", 10);
         fields.put("two", 1);
         fields.put("three", 15);

--- a/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
+++ b/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-
 public class AtlasJanusGraphIndexClientTest {
 
     @Test


### PR DESCRIPTION
Hi, I detect a flaky test under testGenerateSearchWeightString using NonDex(https://github.com/TestingResearchIllinois/NonDex). The problem was caused by the non-deterministic behavior of HashMap, and I used LinkedHashMap to solve that.  Please let me know if I need to follow some process to propose the fix, or you want to discuss more about this PR. Thanks!