### PR TITLE
fix flaky test, testGetTopTermsRandom3 & 5

### DIFF
--- a/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
+++ b/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class AtlasJanusGraphIndexClientTest {
@@ -131,7 +132,7 @@ public class AtlasJanusGraphIndexClientTest {
 
     private Map<String, AtlasJanusGraphIndexClient.TermFreq>  generateTerms(int ... termFreqs) {
         int i =0;
-        Map<String, AtlasJanusGraphIndexClient.TermFreq> terms = new HashMap<>();
+        Map<String, AtlasJanusGraphIndexClient.TermFreq> terms = new LinkedHashMap<>();
         for(int count: termFreqs) {
             AtlasJanusGraphIndexClient.TermFreq termFreq1 = new AtlasJanusGraphIndexClient.TermFreq(Integer.toString(i++), count);
             terms.put(termFreq1.getTerm(), termFreq1);


### PR DESCRIPTION
Similar situation to [PR149](https://github.com/apache/atlas/pull/149),  testGetTopTermsRandom3 and testGetTopTermsRandom5 will express non-deterministic behavior due to the nature of HashMap. 