### PR TITLE
Fix flaky test(testGenerateSolrQueryString2TypeNames)

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasSolrQueryBuilder.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasSolrQueryBuilder.java
@@ -149,7 +149,7 @@ public class AtlasSolrQueryBuilder {
                     .append(typeIndexFieldName)
                     .append(":(");
 
-        Set<String> typesToSearch = new HashSet<>();
+        Set<String> typesToSearch = new LinkedHashSet<>();
         for (AtlasEntityType type : entityTypes) {
 
             if (includeSubtypes) {

--- a/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
+++ b/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class AtlasJanusGraphIndexClientTest {
@@ -131,7 +132,7 @@ public class AtlasJanusGraphIndexClientTest {
 
     private Map<String, AtlasJanusGraphIndexClient.TermFreq>  generateTerms(int ... termFreqs) {
         int i =0;
-        Map<String, AtlasJanusGraphIndexClient.TermFreq> terms = new HashMap<>();
+        Map<String, AtlasJanusGraphIndexClient.TermFreq> terms = new LinkedHashMap<>();
         for(int count: termFreqs) {
             AtlasJanusGraphIndexClient.TermFreq termFreq1 = new AtlasJanusGraphIndexClient.TermFreq(Integer.toString(i++), count);
             terms.put(termFreq1.getTerm(), termFreq1);


### PR DESCRIPTION
Similar situation to [PR149](https://github.com/apache/atlas/pull/149), testGenerateSolrQueryString2TypeNames has non-deterministic behavior due to HashSet. I changed HashSet to LinkedHashSet for a serializable order. 

