### PR TITLE
ATLAS-4505: Update log4j2 version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -736,7 +736,7 @@
         <kafka.version>2.8.1</kafka.version>
         <keycloak.version>6.0.1</keycloak.version>
         <log4j.version>1.2.17</log4j.version>
-        <log4j2.version>2.13.3</log4j2.version>
+        <log4j2.version>2.15.0</log4j2.version>
         <lucene-solr.version>8.6.3</lucene-solr.version>
         <maven-site-plugin.version>3.7</maven-site-plugin.version>
         <MaxPermGen>512m</MaxPermGen>


### PR DESCRIPTION
fix CVE-2021-44228
https://logging.apache.org/log4j/2.x/security.html
