### PR TITLE
ATLAS-4530 : Add docValues="false" in _root_ field

### DIFF
--- a/dev-support/atlas-docker/config/solr/schema.xml
+++ b/dev-support/atlas-docker/config/solr/schema.xml
@@ -98,7 +98,7 @@
    <!-- points to the root document of a block of nested documents. Required for nested
       document support, may be removed otherwise
    -->
-   <field name="_root_" type="string" indexed="true" stored="false"/>
+   <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
 
    <!-- Only remove the "id" field if you have a very good reason to. While not strictly
      required, it is highly recommended. A <uniqueKey> is present in almost all Solr 

--- a/distro/src/conf/solr/schema.xml
+++ b/distro/src/conf/solr/schema.xml
@@ -98,7 +98,7 @@
    <!-- points to the root document of a block of nested documents. Required for nested
       document support, may be removed otherwise
    -->
-   <field name="_root_" type="string" indexed="true" stored="false"/>
+   <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
 
    <!-- Only remove the "id" field if you have a very good reason to. While not strictly
      required, it is highly recommended. A <uniqueKey> is present in almost all Solr 

--- a/repository/src/test/resources/solr/core-template/schema.xml
+++ b/repository/src/test/resources/solr/core-template/schema.xml
@@ -98,7 +98,7 @@
    <!-- points to the root document of a block of nested documents. Required for nested
       document support, may be removed otherwise
    -->
-   <field name="_root_" type="string" indexed="true" stored="false"/>
+   <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
 
    <!-- Only remove the "id" field if you have a very good reason to. While not strictly
      required, it is highly recommended. A <uniqueKey> is present in almost all Solr

--- a/test-tools/src/main/resources/solr/core-template/schema.xml
+++ b/test-tools/src/main/resources/solr/core-template/schema.xml
@@ -98,7 +98,7 @@
    <!-- points to the root document of a block of nested documents. Required for nested
       document support, may be removed otherwise
    -->
-   <field name="_root_" type="string" indexed="true" stored="false"/>
+   <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
 
    <!-- Only remove the "id" field if you have a very good reason to. While not strictly
      required, it is highly recommended. A <uniqueKey> is present in almost all Solr


### PR DESCRIPTION
Issue from https://issues.apache.org/jira/browse/ATLAS-4530
We should add `docValues="false"` in `_root_` field.
Reference solr link https://solr.apache.org/guide/8_9/indexing-nested-documents.html#schema-configuration