### PR TITLE
ATLAS-4586:Upgrade frontend-maven-plugin to 1.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1783,7 +1783,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.11.3</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
PTAL: Atlas is using frontend-maven-plugin version 1.4 upgrading it to 1.11.3, because with the M1 you need to use version 1.11.0 (or newer) of this plugin.  
https://github.com/eirslett/frontend-maven-plugin/issues/952
