### PR TITLE
fix: remove searchfilter params for TypeDef GET

### DIFF
--- a/intg/src/main/python/apache_atlas/client/typedef.py
+++ b/intg/src/main/python/apache_atlas/client/typedef.py
@@ -48,11 +48,11 @@ class TypeDefClient:
     def __init__(self, client):
         self.client = client
 
-    def get_all_typedefs(self, search_filter):
-        return self.client.call_api(TypeDefClient.GET_ALL_TYPE_DEFS, AtlasTypesDef, search_filter.params)
+    def get_all_typedefs(self):
+        return self.client.call_api(TypeDefClient.GET_ALL_TYPE_DEFS, AtlasTypesDef)
 
-    def get_all_typedef_headers(self, search_filter):
-        return self.client.call_api(TypeDefClient.GET_ALL_TYPE_DEF_HEADERS, list, search_filter.params)
+    def get_all_typedef_headers(self):
+        return self.client.call_api(TypeDefClient.GET_ALL_TYPE_DEF_HEADERS, list)
 
     def type_with_guid_exists(self, guid):
         try:


### PR DESCRIPTION
following TypeDef GET requests don't need params

- /v2/types/typedefs
- /v2/types/typedefs/headers

Change has been tested. 
