### PR TITLE
Updated repository location for restlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -850,6 +850,13 @@
     </modules>
 
     <repositories>
+         <repository>
+            <id>restlet</id>
+            <url>https://maven.restlet.talend.com/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>central</id>
             <url>https://repo1.maven.org/maven2</url>


### PR DESCRIPTION
The URL for the restlet maven repository seems to have permanently changed and the TLS certificate on the old repo as expired. This blocks building Atlas because the TLS certificate of the repo is not valid. I've added the new location for the repository to pom.xml and this works around the issue.