### PR TITLE
[ATLAS-4759] Do not suppress HTTP 503 error in Python client

### DIFF
--- a/intg/src/main/python/apache_atlas/client/base_client.py
+++ b/intg/src/main/python/apache_atlas/client/base_client.py
@@ -113,6 +113,4 @@ class AtlasClient:
         elif response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
             log.error("Atlas Service unavailable. HTTP Status: %s", HTTPStatus.SERVICE_UNAVAILABLE)
 
-            return None
-        else:
-            raise AtlasServiceException(api, response)
+        raise AtlasServiceException(api, response)


### PR DESCRIPTION
This kind of error should never be suppressed