### PR TITLE
ATLAS-4785: Fix incorrect references in AtlasClientV2 label methods

### DIFF
--- a/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
+++ b/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
@@ -588,7 +588,7 @@ public class AtlasClientV2 extends AtlasBaseClient {
     public void addLabels(String typeName, Map<String, String> uniqAttributes, Set<String> labels) throws AtlasServiceException {
         MultivaluedMap<String, String> queryParams = attributesToQueryParams(uniqAttributes);
 
-        callAPI(formatPathParameters(API_V2.SET_LABELS_BY_UNIQUE_ATTRIBUTE, typeName), (Class<?>) null, labels, queryParams);
+        callAPI(formatPathParameters(API_V2.ADD_LABELS_BY_UNIQUE_ATTRIBUTE, typeName), (Class<?>) null, labels, queryParams);
     }
 
     public void removeLabels(String entityGuid, Set<String> labels) throws AtlasServiceException {
@@ -608,7 +608,7 @@ public class AtlasClientV2 extends AtlasBaseClient {
     public void setLabels(String typeName, Map<String, String> uniqAttributes, Set<String> labels) throws AtlasServiceException {
         MultivaluedMap<String, String> queryParams = attributesToQueryParams(uniqAttributes);
 
-        callAPI(formatPathParameters(API_V2.ADD_LABELS_BY_UNIQUE_ATTRIBUTE, typeName), (Class<?>) null, labels, queryParams);
+        callAPI(formatPathParameters(API_V2.SET_LABELS_BY_UNIQUE_ATTRIBUTE, typeName), (Class<?>) null, labels, queryParams);
     }
 
 


### PR DESCRIPTION
`AtlasClientV2.addLabels` by unique attribute method and `AtlasClientV2.setLabels` by unique attribute method use incorrect `API_V2`.