### PR TITLE
[WIP] ATLAS-4789 adds couchbase hook

### DIFF
--- a/addons/couchbase-bridge/pom.xml
+++ b/addons/couchbase-bridge/pom.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>apache-atlas</artifactId>
+        <groupId>org.apache.atlas</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+    <artifactId>couchbase-bridge</artifactId>
+    <description>Apache Atlas Couchbase Bridge Module</description>
+    <name>Apache Atlas Couchbase Bridge</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.1.1-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>com.couchbase.client</groupId>
+            <artifactId>java-client</artifactId>
+            <version>3.4.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.couchbase.client</groupId>
+            <artifactId>dcp-client</artifactId>
+            <version>0.44.0</version>
+        </dependency>
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>atlas-client-v2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>atlas-notification</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>dist</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-hook</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/dependency/hook/couchbase/atlas-couchbase-plugin-impl</outputDirectory>
+                                    <overWriteReleases>false</overWriteReleases>
+                                    <overWriteSnapshots>false</overWriteSnapshots>
+                                    <overWriteIfNewer>true</overWriteIfNewer>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>${project.artifactId}</artifactId>
+                                            <version>${project.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>atlas-client-common</artifactId>
+                                            <version>${project.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>atlas-client-v2</artifactId>
+                                            <version>${project.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>atlas-notification</artifactId>
+                                            <version>${project.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>atlas-common</artifactId>
+                                            <version>${project.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.apache.kafka</groupId>
+                                            <artifactId>kafka_${kafka.scala.binary.version}</artifactId>
+                                            <version>${kafka.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.apache.kafka</groupId>
+                                            <artifactId>kafka-clients</artifactId>
+                                            <version>${kafka.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>com.sun.jersey</groupId>
+                                            <artifactId>jersey-json</artifactId>
+                                            <version>${jersey.version}</version>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.doxia</groupId>
+                        <artifactId>doxia-module-twiki</artifactId>
+                        <version>${doxia.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.doxia</groupId>
+                        <artifactId>doxia-core</artifactId>
+                        <version>${doxia.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateProjectInfo>false</generateProjectInfo>
+                    <generateReports>false</generateReports>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <inherited>false</inherited>
+                <executions>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/addons/couchbase-bridge/src/README.md
+++ b/addons/couchbase-bridge/src/README.md
@@ -1,0 +1,27 @@
+# Apache Atlas Couchbase bridge
+This bridge connects to a Couchbase cluster using DCP protocol 
+and performs real-time analysis and metadata extraction from stored on the cluster documents.
+The extracted metadata is then sent to Atlas via its REST API
+
+## Configuration
+The bridge uses environment variables for configuration.
+
+### Atlas REST API
+| Environment variable | Description                                                                                                                       | Default Value            |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------------------|
+| ATLAS_URL            | Atlas REST API url                                                                                                                | "http://localhost:21000" |
+| ATLAS_USERNAME       | Atlas REST API username                                                                                                           | "admin"                  |
+| ATLAS_PASSWORD       | Atlas REST API password                                                                                                           | "admin"                  |
+
+### Couchbase DCP connection
+| Environment variable | Description                                                                                                                       | Default Value            |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------------------|
+| CB_CLUSTER           | Couchbase Cluster connection string                                                                                               | "couchbase://localhost"  |
+| CB_USERNAME          | Couchbase Cluster username                                                                                                        | "Administrator"          |
+| CB_PASSWORD          | Couchbase Cluster password                                                                                                        | "password"               |
+| CB_ENABLE_TLS        | Use TLS                                                                                                                           | false                    |
+| CB_BUCKET            | Couchbase bucket to monitor                                                                                                       | "default"                |
+| CB_COLLECTIONS       | Comma-separated list of collections to monitor with each collection listed as <scope>.<collection>                                |                          |
+| DCP_PORT             | DCP port to use                                                                                                                   | 11210                    |
+| DCP_FIELD_THRESHOLD  | A threshold that indicates in what percentage of analyzed messages per collection  a field must appear before it is sent to Atlas | 0                        |
+| DCP_SAMPLE_RATIO     | Percentage of DCP messages to be analyzed in form of a short between 0 and 1.                                                     | 1                        |

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/AtlasConfig.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/AtlasConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector;
+
+import org.apache.atlas.AtlasClientV2;
+
+import java.util.Map;
+
+public class AtlasConfig {
+
+    private static final Map<String, String> ENV = System.getenv();
+
+    private static AtlasClientV2 client;
+
+    public static String[] urls() {
+        return new String[] {ENV.getOrDefault("ATLAS_URL", "http://localhost:21000")};
+    }
+
+    public static String username() {
+        return ENV.getOrDefault("ATLAS_USERNAME", "admin");
+    }
+
+    public static String password() {
+        return ENV.getOrDefault("ATLAS_PASSWORD", "admin");
+    }
+
+    public static String[] auth() {
+        return new String[] {username(), password()};
+    }
+
+    public static AtlasClientV2 client() {
+        if (client == null) {
+            client = new AtlasClientV2(urls(), auth());
+        }
+
+        return client;
+    }
+
+    static void client(AtlasClientV2 client) {
+        AtlasConfig.client = client;
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/CBConfig.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/CBConfig.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector;
+
+import com.couchbase.client.dcp.Client;
+import com.couchbase.client.dcp.SecurityConfig;
+import com.couchbase.client.java.Cluster;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CBConfig {
+    private static final Map<String, String> ENV = System.getenv();
+
+    private static final Integer DCP_FIELD_MIN_OCCUR = Integer.valueOf(ENV.getOrDefault("DCP_FIELD_MIN_OCCUR", "0"));
+
+    private static Client mockDcpClient;
+    private static Cluster cluster;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CBConfig.class);
+
+    private static final Float DCP_SAMPLE_RATIO = Float.valueOf(ENV.getOrDefault("DCP_SAMPLE_RATIO", "1"));
+
+    private static final Short DCP_FIELD_THRESHOLD = Short.valueOf(ENV.getOrDefault("DCP_FIELD_THRESHOLD", "0"));
+
+    public static String address() {
+        return ENV.getOrDefault("CB_CLUSTER", "couchbase://localhost");
+    }
+
+    public static String username() {
+        return ENV.getOrDefault("CB_USERNAME", "Administrator");
+    }
+
+    public static String password() {
+        return ENV.getOrDefault("CB_PASSWORD", "password");
+    }
+
+    public static String bucket() {
+        return ENV.getOrDefault("CB_BUCKET", "default");
+    }
+
+    public static Collection<String> collections() {
+        String collections = ENV.get("CB_COLLECTIONS");
+        if (collections == null) {
+            return null;
+        }
+
+        return Arrays.stream(collections.split(","))
+                .map(String::trim)
+                .collect(Collectors.toList());
+    }
+
+    public static String dcpPort() {
+        return ENV.getOrDefault("DCP_PORT", "11210");
+    }
+    /**
+     * @return Percentage of DCP messages to be analyzed in form of a short between 0 and 1.
+     */
+    public static Float dcpSampleRatio() {
+        return DCP_SAMPLE_RATIO;
+    }
+
+    /**
+     * @return a threshold that indicates in what percentage of analyzed messages per collection a field must appear before it is sent to Atlas
+     */
+    public static Short dcpFieldThreshold() {
+        return DCP_FIELD_THRESHOLD;
+    }
+
+    public static Integer dcpFieldMinOccurences() {
+        return DCP_FIELD_MIN_OCCUR;
+    }
+
+    public static Cluster cluster() {
+        if (cluster == null) {
+            cluster = Cluster.connect(
+                    address(), username(), password()
+            );
+        }
+        return cluster;
+    }
+
+    public static Client dcpClient() {
+        if (mockDcpClient != null) {
+            LOGGER.debug("Using mock DCP client");
+            return mockDcpClient;
+        }
+
+
+        Client.Builder builder = Client.builder()
+                .collectionsAware(true)
+                .seedNodes(String.format("%s:%s",address(),dcpPort()))
+                .connectionString(address())
+                .credentials(username(), password());
+        String bucket = bucket();
+        if (!(bucket == null || bucket.equals("*") || bucket.isEmpty())) {
+            LOGGER.debug("Monitoring bucket `{}`", bucket);
+            builder.bucket(bucket);
+            Collection<String> collections = collections();
+            if (collections != null && !collections.isEmpty()) {
+                LOGGER.debug("Monitoring collections: {}", String.join(", ", collections));
+                builder.collectionNames(collections);
+            }
+        }
+
+        if (enableTLS()) {
+            LOGGER.debug("Using native TLS");
+            builder.securityConfig(SecurityConfig.builder().enableNativeTls(true).build());
+        }
+
+        return builder.build();
+    }
+
+    private static boolean enableTLS() {
+        return Boolean.parseBoolean(ENV.getOrDefault("CB_ENABLE_TLS", "false"));
+    }
+
+    protected static void dcpClient(Client mockDcpClient) {
+        CBConfig.mockDcpClient = mockDcpClient;
+
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/CouchbaseHook.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/CouchbaseHook.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector;
+
+import com.couchbase.atlas.connector.entities.CouchbaseBucket;
+import com.couchbase.atlas.connector.entities.CouchbaseCluster;
+import com.couchbase.atlas.connector.entities.CouchbaseCollection;
+import com.couchbase.atlas.connector.entities.CouchbaseField;
+import com.couchbase.atlas.connector.entities.CouchbaseFieldType;
+import com.couchbase.atlas.connector.entities.CouchbaseScope;
+import com.couchbase.client.core.deps.io.netty.buffer.ByteBuf;
+import com.couchbase.client.dcp.Client;
+import com.couchbase.client.dcp.ControlEventHandler;
+import com.couchbase.client.dcp.DataEventHandler;
+import com.couchbase.client.dcp.StreamFrom;
+import com.couchbase.client.dcp.StreamTo;
+import com.couchbase.client.dcp.highlevel.internal.CollectionIdAndKey;
+import com.couchbase.client.dcp.highlevel.internal.CollectionsManifest;
+import com.couchbase.client.dcp.message.DcpMutationMessage;
+import com.couchbase.client.dcp.message.MessageUtil;
+import com.couchbase.client.dcp.transport.netty.ChannelFlowController;
+import com.couchbase.client.java.json.JsonObject;
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.hook.AtlasHook;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.notification.HookNotification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CouchbaseHook extends AtlasHook implements ControlEventHandler, DataEventHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(CouchbaseHook.class);
+    protected static CouchbaseHook INSTANCE;
+    protected static Client DCP;
+    protected static AtlasClientV2 ATLAS;
+    private CouchbaseCluster clusterEntity;
+    private CouchbaseBucket bucketEntity;
+
+    private static Consumer<List<AtlasEntity>> createInterceptor;
+    private static Consumer<List<AtlasEntity>> updateInterceptor;
+
+    private static boolean loop = true;
+
+    /**
+     * START HERE
+     *
+     * @param args
+     */
+    public static void main(String[] args) {
+        // create instances of DCP client,
+        DCP = CBConfig.dcpClient();
+        // Atlas client,
+        ATLAS = AtlasConfig.client();
+        // and DCP handler
+        INSTANCE = new CouchbaseHook();
+        // register DCP handler with DCP client
+        DCP.controlEventHandler(INSTANCE);
+        DCP.dataEventHandler(INSTANCE);
+
+        // Connect to the cluster
+        DCP.connect().block();
+        LOG.info("DCP client connected.");
+        // Ensure the existence of corresponding
+        // CouchbaseCluster, CouchbaseBucket, CouchbaseScope
+        // entities and store them in local cache
+        INSTANCE.initializeAtlasContext();
+        // Start listening to DCP
+        DCP.initializeState(StreamFrom.NOW, StreamTo.INFINITY).block();
+        System.out.println("Starting the stream...");
+        DCP.startStreaming().block();
+        System.out.println("Started the stream.");
+        // And then just loop the loop
+        try {
+            while (loop) {
+                Thread.sleep(1000);
+            }
+        } catch (InterruptedException e) {
+
+        } finally {
+            DCP.disconnect().block();
+        }
+    }
+
+    /**
+     * Ensures the existence of CouchbaseCluster,
+     * CouchbaseBucket and Couchbase scope entities
+     * and stores them into local cache
+     */
+    private void initializeAtlasContext() {
+        LOG.debug("Creating cluster/bucket/scope entities");
+
+        clusterEntity = new CouchbaseCluster()
+                .name(CBConfig.address())
+                .url(CBConfig.address())
+                .get();
+
+        bucketEntity = new CouchbaseBucket()
+                .name(CBConfig.bucket())
+                .cluster(clusterEntity)
+                .get();
+
+        List<AtlasEntity> entitiesToCreate = new ArrayList<>();
+        if (!clusterEntity.exists(ATLAS)) {
+            entitiesToCreate.add(clusterEntity.atlasEntity(ATLAS));
+        }
+
+        if (!bucketEntity.exists(ATLAS)) {
+            entitiesToCreate.add(bucketEntity.atlasEntity(ATLAS));
+        }
+
+        if (!entitiesToCreate.isEmpty()) {
+            createEntities(entitiesToCreate);
+        }
+    }
+
+    private void createEntities(List<AtlasEntity> entities) {
+        if (createInterceptor != null) {
+            createInterceptor.accept(entities);
+            return;
+        }
+        AtlasEntity.AtlasEntitiesWithExtInfo info = new AtlasEntity.AtlasEntitiesWithExtInfo(entities);
+        HookNotification.EntityCreateRequestV2 requestV2 = new HookNotification.EntityCreateRequestV2("couchbase", info);
+        notifyEntities(Arrays.asList(requestV2), null);
+    }
+
+    private void updateEntities(List<AtlasEntity> entities) {
+        if (updateInterceptor != null) {
+            updateInterceptor.accept(entities);
+            return;
+        }
+        AtlasEntity.AtlasEntitiesWithExtInfo info = new AtlasEntity.AtlasEntitiesWithExtInfo(entities);
+        HookNotification.EntityUpdateRequestV2 requestV2 = new HookNotification.EntityUpdateRequestV2("couchbase", info);
+        notifyEntities(Arrays.asList(requestV2), null);
+    }
+
+    @Override
+    public void onEvent(ChannelFlowController flowController, ByteBuf event) {
+        // Probabilistic sampling
+        if (Math.random() > CBConfig.dcpSampleRatio()) {
+            LOG.debug("Skipping DCP message.");
+            return;
+        }
+        if (DcpMutationMessage.is(event)) {
+            try {
+                // Borrowed from Couchbeans :)
+                // Gathering some information about the message.
+                CollectionIdAndKey ckey = MessageUtil.getCollectionIdAndKey(event, true);
+                CollectionsManifest.CollectionInfo collectionInfo = collectionInfo(MessageUtil.getVbucket(event), ckey.collectionId());
+                String collectionName = collectionInfo.name();
+                String scopeName = collectionInfo.scope().name();
+
+                LOG.debug("Received DCP mutation message for scope '{}' and collection '{}'", scopeName, collectionName);
+
+                CouchbaseScope scopeEntity = bucketEntity.scope(scopeName);
+                // Because Atlas doesn't support upserts,
+                // we need to send new entites in a separate message
+                // from already existing ones
+                List<AtlasEntity> toCreate = new ArrayList<>();
+                List<AtlasEntity> toUpdate = new ArrayList<>();
+                if (!scopeEntity.exists(ATLAS)) {
+                    toCreate.add(scopeEntity.atlasEntity(ATLAS));
+                    LOG.debug("Creating scope: {}", scopeEntity.qualifiedName());
+                } else {
+                    toUpdate.add(scopeEntity.atlasEntity(ATLAS));
+                    LOG.debug("Updating scope: {}", scopeEntity.qualifiedName());
+                }
+                CouchbaseCollection collectionEntity = scopeEntity.collection(collectionName);
+                // Let's record this attempt to analyze a collection document
+                // so that we can calculate field frequencies
+                // when filtering them via DCP_FIELD_THRESHOLD
+                collectionEntity.incrementAnalyzedDocuments();
+                // and then schedule it to be sent to Atlas
+                if (!collectionEntity.exists(ATLAS)) {
+                    toCreate.add(collectionEntity.atlasEntity(ATLAS));
+                } else {
+                    toUpdate.add(collectionEntity.atlasEntity(ATLAS));
+                }
+
+                Map<String, Object> document = JsonObject.fromJson(DcpMutationMessage.contentBytes(event)).toMap();
+
+                System.out.println(String.format("Document keys: %s", document.keySet()));
+                // for each field in the document...
+                document.entrySet().stream()
+                        // transform the field into CouchbaseField either by loading corresponding entity or by creating it
+                        .filter(e -> e.getValue() != null)
+                        .flatMap(entry -> processField(collectionEntity, (Collection<String>) Collections.EMPTY_LIST, null, entry.getKey(), entry.getValue()))
+                        // update document counter on the field entity
+                        .peek(CouchbaseField::incrementDocumentCount)
+                        // Only passes fields that either already in Atlas or pass DCP_FIELD_THRESHOLD setting
+                        .filter(field -> field.exists(ATLAS) || field.documentCount() / (float) collectionEntity.documentsAnalyzed() > CBConfig.dcpFieldThreshold())
+                        // Schedule the entity either for creation or to be updated in Atlas
+                        .forEach(field -> {
+                            if (field.exists(ATLAS)) {
+                                toUpdate.add(field.atlasEntity(ATLAS));
+                            } else {
+                                toCreate.add(field.atlasEntity(ATLAS));
+                            }
+                        });
+
+                createEntities(toCreate);
+                updateEntities(toUpdate);
+
+                System.out.println("Notified Atlas");
+            } catch (Exception e) {
+                LOG.error("Failed to process DCP message", e);
+            }
+        }
+    }
+
+    /**
+     * Constructs a {@link CouchbaseField} from field information
+     *
+     * @param collectionEntity the {@link CouchbaseCollection} to which the field belongs
+     * @param path             the path to the field inside the collection document excluding the field itself
+     * @param parent           the parent field, if present or null
+     * @param name             the name of the field
+     * @param value            the value for the field from received document
+     * @return constructed or loaded from Atlas {@link CouchbaseField}
+     */
+    private static Stream<CouchbaseField> processField(CouchbaseCollection collectionEntity, Collection<String> path, @Nullable CouchbaseField parent, String name, Object value) {
+        // Let's figure out what type does this field have
+        CouchbaseFieldType fieldType = CouchbaseFieldType.infer(value);
+        // The full field path as it will be stored in Atlas
+        final Collection<String> fieldPath = new ArrayList<>(path);
+        fieldPath.add(name);
+        // constructing the field entity and loading it from cache or Atlas, if previously stored there
+        CouchbaseField rootField = new CouchbaseField()
+                .name(name)
+                .fieldPath(fieldPath.stream().collect(Collectors.joining(".")))
+                .fieldType(fieldType)
+                .collection(collectionEntity)
+                .parentField(parent)
+                .get();
+        // return value
+        Stream<CouchbaseField> result = Stream.of(rootField);
+        // Recursive transformation of embedded object fields
+        if (fieldType == CouchbaseFieldType.OBJECT) {
+            // Normalizing the value
+            if (value instanceof JsonObject) {
+                value = ((JsonObject) value).toMap();
+            }
+            if (value instanceof Map) {
+                // Append embedded field entities to the resulting Stream
+                result = Stream.concat(
+                        result,
+                        ((Map<String, ?>) value).entrySet().stream()
+                                // recursion
+                                .flatMap(entity -> processField(collectionEntity, fieldPath, rootField, entity.getKey(), entity.getValue()))
+                );
+            } else {
+                throw new IllegalArgumentException(String.format("Incorrect value type '%s' for field type 'object': a Map was expected instead.", value.getClass()));
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public String getMessageSource() {
+        return "couchbase";
+    }
+
+    /**
+     * Looks up the collection name by its vbucket identifier
+     *
+     * @param vbucket
+     * @param collid
+     * @return the name of the collection
+     */
+    private static CollectionsManifest.CollectionInfo collectionInfo(int vbucket, long collid) {
+        return DCP.sessionState()
+                .get(vbucket)
+                .getCollectionsManifest()
+                .getCollection(collid);
+    }
+
+    protected static void setEntityInterceptors(Consumer<List<AtlasEntity>> createInterceptor, Consumer<List<AtlasEntity>> updateInterceptor) {
+        CouchbaseHook.createInterceptor = createInterceptor;
+        CouchbaseHook.updateInterceptor = updateInterceptor;
+    }
+
+    static void loop(boolean loop) {
+        CouchbaseHook.loop = loop;
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/TypeGenerator.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/TypeGenerator.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector;
+
+import com.couchbase.atlas.connector.entities.CouchbaseBucket;
+import com.couchbase.atlas.connector.entities.CouchbaseCluster;
+import com.couchbase.atlas.connector.entities.CouchbaseCollection;
+import com.couchbase.atlas.connector.entities.CouchbaseField;
+import com.couchbase.atlas.connector.entities.CouchbaseFieldType;
+import com.couchbase.atlas.connector.entities.CouchbaseScope;
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.AtlasServiceException;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
+import org.apache.atlas.model.typedef.AtlasEntityDef;
+import org.apache.atlas.model.typedef.AtlasEnumDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipDef;
+import org.apache.atlas.model.typedef.AtlasTypesDef;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+public class TypeGenerator {
+
+    private static AtlasClientV2 client;
+
+    public static void main(String[] args) {
+        client = AtlasConfig.client();
+
+        AtlasTypesDef types = new AtlasTypesDef();
+
+        types.getEnumDefs().add(CouchbaseFieldType.atlasEnumDef());
+        types.getEntityDefs().addAll(Arrays.asList(
+                CouchbaseField.atlasEntityDef(),
+                CouchbaseCollection.atlasEntityDef(),
+                CouchbaseScope.atlasEntityDef(),
+                CouchbaseBucket.atlasEntityDef(),
+                CouchbaseCluster.atlasEntityDef()
+        ));
+
+        types.getRelationshipDefs().addAll(CouchbaseField.atlasRelationshipDefs());
+        types.getRelationshipDefs().addAll(CouchbaseCollection.atlasRelationshipDefs());
+        types.getRelationshipDefs().addAll(CouchbaseScope.atlasRelationshipDefs());
+        types.getRelationshipDefs().addAll(CouchbaseBucket.atlasRelationshipDefs());
+        types.getRelationshipDefs().addAll(CouchbaseCluster.atlasRelationshipDefs());
+        recreate(types);
+    }
+
+    private static void recreate(AtlasTypesDef atd) {
+        try {
+            client.createAtlasTypeDefs(atd);
+        } catch (AtlasServiceException e) {
+            try {
+                client.updateAtlasTypeDefs(atd);
+            } catch (AtlasServiceException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    private static boolean exists(AtlasRelationshipDef atlasRelationshipDef) {
+        try {
+            return client.getRelationshipDefByName(atlasRelationshipDef.getName()) != null;
+        } catch (AtlasServiceException e) {
+            if (e.getMessage().contains("404")) {
+                return false;
+            }
+            throw new RuntimeException("Failed to check if relationship definition " + atlasRelationshipDef.getName() + " exists", e);
+        }
+    }
+
+    private static boolean exists(AtlasEntityDef atlasEntityDef) {
+        try {
+            return client.getEntityDefByName(atlasEntityDef.getName()) != null;
+        } catch (AtlasServiceException e) {
+            if (e.getMessage().contains("404")) {
+                return false;
+            }
+            throw new RuntimeException("Failed to check if entity type definition " + atlasEntityDef.getName() + " exists", e);
+        }
+    }
+
+    private static boolean exists(AtlasEnumDef atlasEnumDef) {
+        try {
+            return client.getEnumDefByName(atlasEnumDef.getName()) != null;
+        } catch (AtlasServiceException e) {
+            if (e.getMessage().contains("404")) {
+                return false;
+            }
+            throw new RuntimeException("Failed to check if enum definition " + atlasEnumDef.getName() + " exists", e);
+        }
+    }
+
+    private static void deleteExisting(AtlasTypesDef atd) {
+        AtlasTypesDef existing = new AtlasTypesDef();
+        atd.getRelationshipDefs().stream().filter(TypeGenerator::exists).map(AtlasBaseTypeDef::getName).forEach(typeName -> {
+            try {
+                client.deleteRelationshipByGuid(client.getRelationshipDefByName(typeName).getGuid());
+            } catch (AtlasServiceException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        existing.setRelationshipDefs(Collections.EMPTY_LIST);
+        existing.setEnumDefs(atd.getEnumDefs().stream().filter(TypeGenerator::exists).collect(Collectors.toList()));
+        existing.setEntityDefs(atd.getEntityDefs().stream().filter(TypeGenerator::exists).collect(Collectors.toList()));
+
+        try {
+            client.deleteAtlasTypeDefs(existing);
+        } catch (AtlasServiceException e) {
+            if (!e.getMessage().contains("404")) {
+                throw new RuntimeException("Failed to delete " + atd.toString(), e);
+            }
+        }
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseAtlasEntity.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseAtlasEntity.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector.entities;
+
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.AtlasServiceException;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.typedef.AtlasStructDef;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Base class for all couchbase atlas models
+ * The class uses "Self-Builder" pattern:
+ * 1. First, create the "builder" instance of the class
+ * 2. Populate the identifying fields of the class (check the `qualifiedName` method of the entity for the list)
+ *          (all setters return the instance just as a Builder would)
+ * 3. Call `get()` method to resolve the instance and replace it with previously loaded from Atlas data (if present)
+ *
+ * Example:
+ * ```java
+ *  clusterEntity = new CouchbaseCluster()
+ *      .name(CBConfig.address())
+ *      .url(CBConfig.address())
+ *      .get();
+ * ```
+ *
+ * @param <E> extending class
+ */
+public abstract class CouchbaseAtlasEntity<E extends CouchbaseAtlasEntity<?>> {
+    private static final Map<Class, Map<String, AtlasEntity>> ENTITY_BY_TYPE_AND_ID = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<Class, Map<String, CouchbaseAtlasEntity>> MODEL_BY_TYPE_AND_ID = Collections.synchronizedMap(new HashMap<>());
+    private String name;
+
+    public String name() {
+        return name;
+    }
+
+    public E name(String name) {
+        this.name = name;
+        return (E) this;
+    }
+
+    /**
+     * Loads or creates corresponding Atlas Entity and marks this model as existing in Atlas
+     *
+     * @param atlas
+     * @return
+     */
+    public AtlasEntity atlasEntity(AtlasClientV2 atlas) {
+        AtlasEntity atlasEntity = atlasEntity()
+                .filter(entity -> entity.getGuid().charAt(0) != '-')
+                .orElseGet(() ->
+                        cache(load(atlas)
+                                .orElseGet(() ->
+                                        atlasEntity()
+                                        .orElseGet(() -> new AtlasEntity(atlasTypeName())))
+                        )
+                );
+
+        atlasEntity.setAttribute("name", name);
+        atlasEntity.setAttribute("qualifiedName", qualifiedName());
+
+        updateAtlasEntity(atlasEntity);
+
+        return atlasEntity;
+    }
+
+    protected abstract String qualifiedName();
+
+    /**
+     * Looks up precreated atlas entity in the entity cache
+     * @return Optional of the cached entity
+     */
+    public Optional<AtlasEntity> atlasEntity() {
+        return cachedEntity().map(atlasEntity -> {
+            updateAtlasEntity(atlasEntity);
+            return atlasEntity;
+        });
+    }
+
+    /**
+     * Checks whether the model has the Atlas Entity created for it
+     * by looking it up in the entity cache.
+     * NOTE: this method does not check if the entity has been saved in Atlas so,
+     *      it will return true when the entity is already created and cached but is yet to be sent to Atlas
+     *
+     * This method is _mostly_ used in related objects when setting relationship field to ensure that related
+     *      model has an AtlasEntity that can be referenced when storing relationship information.
+     *
+     * @return true if the entity found
+     */
+    protected boolean exists() {
+        return cachedEntity().isPresent();
+    }
+
+    public abstract String atlasTypeName();
+
+    public abstract UUID id();
+
+    /**
+     * Invoked when the entity needs to be updated with values from the model
+     * @param entity the entity to write the values into
+     */
+    protected void updateAtlasEntity(AtlasEntity entity) {
+        // override me
+    }
+
+    /**
+     * Invoked when the model needs to be updated with values from the entity
+     * @param entity the entity to read the values from
+     */
+    protected void updateJavaModel(AtlasEntity entity) {
+        // override me
+    }
+
+    /**
+     * Loads the entity for this model from Atlas and stores it in the entity cache
+     * @param client Atlas client to use
+     * @return loaded entity
+     */
+    private Optional<AtlasEntity> load(AtlasClientV2 client) {
+        try {
+            Map<String, String> query = new HashMap<>();
+            query.put("qualifiedName", qualifiedName());
+            AtlasEntity atlasEntity = client.getEntityByAttribute(atlasTypeName(), query).getEntity();
+
+            if (atlasEntity != null) {
+                cache(atlasEntity);
+                if (atlasEntity.hasAttribute("name")) {
+                    this.name = (String) atlasEntity.getAttribute("name");
+                }
+                updateJavaModel(atlasEntity);
+                return Optional.of(atlasEntity);
+            }
+        } catch (AtlasServiceException e) {
+            if (e.getStatus().getStatusCode() != 404) {
+                throw new RuntimeException(e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Puts an entity into the entity cache
+     * @param atlasEntity the entity to cache
+     * @return the same entity
+     */
+    private AtlasEntity cache(AtlasEntity atlasEntity) {
+        if (!ENTITY_BY_TYPE_AND_ID.containsKey(getClass())) {
+            ENTITY_BY_TYPE_AND_ID.put(getClass(), new HashMap<>());
+        }
+
+        ENTITY_BY_TYPE_AND_ID.get(getClass()).put(id().toString(), atlasEntity);
+        return atlasEntity;
+    }
+
+    /**
+     * Looks up the entity in the cache
+     * @return Optional of cached entity
+     */
+    private Optional<AtlasEntity> cachedEntity() {
+        return Optional.ofNullable(ENTITY_BY_TYPE_AND_ID.getOrDefault(getClass(), (Map<String, AtlasEntity>) Collections.EMPTY_MAP).getOrDefault(id().toString(), null));
+    }
+
+    /**
+     * First checks if the entity has been loaded and cached and, if not, then tries to load it from Atlas
+     * @param atlas Atlas client to use
+     * @return true if the entity found either in cache or in Atlas
+     */
+    public boolean exists(AtlasClientV2 atlas) {
+        if (!exists()) {
+            return load(atlas).isPresent();
+        }
+        return true;
+    }
+
+    /**
+     * Returns pre-cached model with provided identifiers or caches this model and returns it
+     *
+     * @return the model
+     */
+    public E get() {
+        Class<E> type = (Class<E>) getClass();
+        String id = id().toString();
+
+        // ensure valid cache structure
+        if (!MODEL_BY_TYPE_AND_ID.containsKey(type)) {
+            MODEL_BY_TYPE_AND_ID.put(type, Collections.synchronizedMap(new HashMap<>()));
+        }
+
+        // put the model into the cache, if not already present
+        Map<String, CouchbaseAtlasEntity> modelsById = MODEL_BY_TYPE_AND_ID.get(type);
+        if (!modelsById.containsKey(id)) {
+            try {
+                modelsById.put(id, this);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return (E) modelsById.get(id);
+    }
+
+    public static void dropCache() {
+        ENTITY_BY_TYPE_AND_ID.clear();
+        MODEL_BY_TYPE_AND_ID.clear();
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseBucket.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseBucket.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector.entities;
+
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.typedef.AtlasEntityDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipEndDef;
+import org.apache.atlas.model.typedef.AtlasStructDef;
+import org.apache.atlas.type.AtlasTypeUtil;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class CouchbaseBucket extends CouchbaseAtlasEntity<CouchbaseBucket> {
+    public static final String TYPE_NAME = "couchbase_bucket";
+    private CouchbaseCluster cluster;
+    private transient Map<String, CouchbaseScope> scopes = Collections.synchronizedMap(new HashMap<>());
+
+    @Override
+    public AtlasEntity atlasEntity(AtlasClientV2 atlas) {
+        AtlasEntity entity = super.atlasEntity(atlas);
+        entity.setRelationshipAttribute("cluster", cluster.atlasEntity(atlas));
+        return entity;
+    }
+
+    @Override
+    protected String qualifiedName() {
+        return String.format("%s/%s", cluster.qualifiedName(), name());
+    }
+
+    public CouchbaseBucket() {
+
+    }
+
+    public CouchbaseCluster cluster() {
+        return cluster;
+    }
+
+    public CouchbaseBucket cluster(CouchbaseCluster cluster) {
+        this.cluster = cluster;
+        return this;
+    }
+
+    public static AtlasEntityDef atlasEntityDef() {
+        AtlasEntityDef definition = AtlasTypeUtil.createClassTypeDef(
+                "couchbase_bucket",
+                new HashSet<>()
+        );
+
+        definition.getSuperTypes().add("Asset");
+        definition.setServiceType("couchbase");
+        definition.setTypeVersion("0.1");
+
+        List<AtlasStructDef.AtlasAttributeDef> attributes = definition.getAttributeDefs();
+
+        return definition;
+    }
+
+    public static Collection<? extends AtlasRelationshipDef> atlasRelationshipDefs() {
+        return Arrays.asList(
+                new AtlasRelationshipDef(
+                        "couchbase_bucket_scopes",
+                        "",
+                        "0.1",
+                        "couchbase",
+                        AtlasRelationshipDef.RelationshipCategory.AGGREGATION,
+                        AtlasRelationshipDef.PropagateTags.ONE_TO_TWO,
+                        new AtlasRelationshipEndDef(
+                                "couchbase_bucket",
+                                "scopes",
+                                AtlasStructDef.AtlasAttributeDef.Cardinality.SET,
+                                true
+                        ),
+                        new AtlasRelationshipEndDef(
+                                "couchbase_scope",
+                                "bucket",
+                                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE,
+                                false
+                        )
+                )
+        );
+    }
+
+    @Override
+    public String atlasTypeName() {
+        return TYPE_NAME;
+    }
+
+    @Override
+    public UUID id() {
+        return UUID.nameUUIDFromBytes(String.format("%s:%s:%s", atlasTypeName(), cluster().id(), name()).getBytes(Charset.defaultCharset()));
+    }
+
+    public CouchbaseScope scope(String name) {
+        if (!scopes.containsKey(name)) {
+            scopes.put(name, new CouchbaseScope()
+                    .bucket(this)
+                    .name(name)
+                    .get()
+            );
+        }
+
+        return scopes.get(name);
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseCluster.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseCluster.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector.entities;
+
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.typedef.AtlasEntityDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipEndDef;
+import org.apache.atlas.model.typedef.AtlasStructDef;
+import org.apache.atlas.type.AtlasTypeUtil;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public class CouchbaseCluster extends CouchbaseAtlasEntity<CouchbaseCluster> {
+    public static final String TYPE_NAME = "couchbase_cluster";
+    private String url;
+
+    public String url() {
+        return url;
+    }
+
+    public CouchbaseCluster url(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public static AtlasEntityDef atlasEntityDef() {
+        AtlasEntityDef definition = AtlasTypeUtil.createClassTypeDef(
+                "couchbase_cluster",
+                new HashSet<>()
+        );
+
+        definition.getSuperTypes().add("Asset");
+        definition.setServiceType("couchbase");
+        definition.setTypeVersion("0.1");
+
+        List<AtlasStructDef.AtlasAttributeDef> attributes = definition.getAttributeDefs();
+
+        attributes.add(new AtlasStructDef.AtlasAttributeDef(
+                "url",
+                "string",
+                false,
+                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE,
+                1,
+                1,
+                true,
+                true,
+                true,
+                Collections.EMPTY_LIST
+        ));
+
+        return definition;
+    }
+
+    public static Collection<? extends AtlasRelationshipDef> atlasRelationshipDefs() {
+        return Arrays.asList(
+                new AtlasRelationshipDef(
+                        "couchbase_cluster_buckets",
+                        "",
+                        "0.1",
+                        "couchbase",
+                        AtlasRelationshipDef.RelationshipCategory.AGGREGATION,
+                        AtlasRelationshipDef.PropagateTags.ONE_TO_TWO,
+                        new AtlasRelationshipEndDef(
+                                "couchbase_cluster",
+                                "buckets",
+                                AtlasStructDef.AtlasAttributeDef.Cardinality.SET,
+                                true
+                        ),
+                        new AtlasRelationshipEndDef(
+                                "couchbase_bucket",
+                                "cluster",
+                                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE,
+                                false
+                        )
+                )
+        );
+    }
+
+    @Override
+    public String atlasTypeName() {
+        return TYPE_NAME;
+    }
+
+    @Override
+    public UUID id() {
+        return UUID.nameUUIDFromBytes(String.format("%s:%s", atlasTypeName(), url()).getBytes(Charset.defaultCharset()));
+    }
+
+    @Override
+    public AtlasEntity atlasEntity(AtlasClientV2 atlas) {
+        AtlasEntity entity = super.atlasEntity(atlas);
+        entity.setAttribute("url", url());
+        return entity;
+    }
+
+    @Override
+    protected String qualifiedName() {
+        return url();
+    }
+
+    @Override
+    protected void updateJavaModel(AtlasEntity entity) {
+        if (entity.hasAttribute("url")) {
+            this.url = (String) entity.getAttribute("url");
+        }
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseCollection.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseCollection.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector.entities;
+
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.typedef.AtlasEntityDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipEndDef;
+import org.apache.atlas.model.typedef.AtlasStructDef;
+import org.apache.atlas.type.AtlasTypeUtil;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+public class CouchbaseCollection extends CouchbaseAtlasEntity<CouchbaseCollection> {
+
+    private CouchbaseScope scope;
+
+    private long documentsAnalyzed;
+
+    public static AtlasEntityDef atlasEntityDef() {
+        AtlasEntityDef definition = AtlasTypeUtil.createClassTypeDef("couchbase_collection", new HashSet<>());
+
+        definition.getSuperTypes().add("DataSet");
+        definition.setServiceType("couchbase");
+        definition.setTypeVersion("0.1");
+        definition.setOption("schemaElementsAttribute", "fields");
+
+        List<AtlasStructDef.AtlasAttributeDef> attributes = definition.getAttributeDefs();
+
+        attributes.add(new AtlasStructDef.AtlasAttributeDef(
+                "documentsAnalyzed",
+                "long",
+                false,
+                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE,
+                1,
+                1,
+                false,
+                false,
+                false,
+                Collections.EMPTY_LIST
+        ));
+
+        return definition;
+    }
+
+    public static Collection<? extends AtlasRelationshipDef> atlasRelationshipDefs() {
+        return Arrays.asList(new AtlasRelationshipDef("couchbase_collection_fields", "", "0.1", "couchbase", AtlasRelationshipDef.RelationshipCategory.AGGREGATION, AtlasRelationshipDef.PropagateTags.ONE_TO_TWO, new AtlasRelationshipEndDef("couchbase_collection", "fields", AtlasStructDef.AtlasAttributeDef.Cardinality.SET, true), new AtlasRelationshipEndDef("couchbase_field", "collection", AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE, false)));
+    }
+
+    public CouchbaseCollection scope(CouchbaseScope scope) {
+        this.scope = scope;
+        return this;
+    }
+
+    @Override
+    public AtlasEntity atlasEntity(AtlasClientV2 atlas) {
+        AtlasEntity entity = super.atlasEntity(atlas);
+        entity.setRelationshipAttribute("scope", scope.atlasEntity(atlas));
+        return entity;
+    }
+
+    @Override
+    protected void updateAtlasEntity(AtlasEntity entity) {
+        entity.setAttribute("documentsAnalyzed", documentsAnalyzed);
+    }
+
+    @Override
+    protected void updateJavaModel(AtlasEntity entity) {
+        documentsAnalyzed = (Integer) entity.getAttribute("documentsAnalyzed");
+    }
+
+    public long documentsAnalyzed() {
+        return documentsAnalyzed;
+    }
+
+    public CouchbaseCollection incrementAnalyzedDocuments() {
+        this.documentsAnalyzed++;
+        return this;
+    }
+
+    @Override
+    protected String qualifiedName() {
+        return String.format("%s/%s", scope.qualifiedName(), name());
+    }
+
+    @Override
+    public String atlasTypeName() {
+        return "couchbase_collection";
+    }
+
+    @Override
+    public UUID id() {
+        return UUID.nameUUIDFromBytes(String.format("%s:%s:%s", atlasTypeName(), scope().id().toString(), name()).getBytes(Charset.defaultCharset()));
+    }
+
+    public CouchbaseScope scope() {
+        return this.scope;
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseField.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseField.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector.entities;
+
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.typedef.AtlasEntityDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipDef;
+import org.apache.atlas.model.typedef.AtlasRelationshipEndDef;
+import org.apache.atlas.model.typedef.AtlasStructDef;
+import org.apache.atlas.type.AtlasTypeUtil;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+public class CouchbaseField extends CouchbaseAtlasEntity<CouchbaseField> {
+    public static final String TYPE_NAME = "couchbase_field";
+    private CouchbaseFieldType fieldType;
+    private String fieldPath;
+    private long documentCount = 0;
+
+    private CouchbaseField parentField;
+
+    private CouchbaseCollection collection;
+
+    public CouchbaseField() {
+
+    }
+
+    public static Collection<? extends AtlasRelationshipDef> atlasRelationshipDefs() {
+        return Arrays.asList(
+                new AtlasRelationshipDef(
+                        "couchbase_field_fields",
+                        "",
+                        "0.1",
+                        "couchbase",
+                        AtlasRelationshipDef.RelationshipCategory.AGGREGATION,
+                        AtlasRelationshipDef.PropagateTags.ONE_TO_TWO,
+                        new AtlasRelationshipEndDef(
+                                "couchbase_field",
+                                "objectFields",
+                                AtlasStructDef.AtlasAttributeDef.Cardinality.SET,
+                                true
+                        ),
+                        new AtlasRelationshipEndDef(
+                                "couchbase_field",
+                                "parentField",
+                                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE,
+                                false
+                        )
+                )
+        );
+    }
+
+    public CouchbaseFieldType fieldType() {
+        return fieldType;
+    }
+
+    public CouchbaseField fieldType(CouchbaseFieldType fieldType) {
+        this.fieldType = fieldType;
+        return this;
+    }
+
+    public String fieldPath() {
+        return fieldPath;
+    }
+
+    public CouchbaseField fieldPath(String fieldPath) {
+        this.fieldPath = fieldPath;
+        return this;
+    }
+
+    public long documentCount() {
+        return documentCount;
+    }
+
+    public CouchbaseField documentCount(long documentCount) {
+        this.documentCount = documentCount;
+        return this;
+    }
+
+    public void incrementDocumentCount() {
+        this.documentCount++;
+    }
+
+    public CouchbaseCollection collection() {
+        return collection;
+    }
+
+    public CouchbaseField collection(CouchbaseCollection collection) {
+        this.collection = collection;
+        return this;
+    }
+
+    public static AtlasEntityDef atlasEntityDef() {
+        AtlasEntityDef definition = AtlasTypeUtil.createClassTypeDef(
+                TYPE_NAME,
+                new HashSet<>()
+        );
+
+        definition.setTypeVersion("0.1");
+        definition.getSuperTypes().add("DataSet");
+        definition.setServiceType("couchbase");
+        List<AtlasStructDef.AtlasAttributeDef> attributes = definition.getAttributeDefs();
+
+        attributes.add(new AtlasStructDef.AtlasAttributeDef(
+                "fieldType",
+                "couchbase_field_type",
+                false,
+                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE,
+                1,
+                1,
+                false,
+                true,
+                false,
+                Collections.emptyList()
+        ));
+
+        attributes.add(new AtlasStructDef.AtlasAttributeDef(
+                "fieldPath",
+                "string",
+                false,
+                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE,
+                1,
+                1,
+                false,
+                true,
+                false,
+                Collections.emptyList()
+        ));
+
+        attributes.add((new AtlasStructDef.AtlasAttributeDef(
+                "documentCount",
+                "long",
+                false,
+                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE,
+                1,
+                1,
+                false,
+                false,
+                false,
+                Collections.emptyList()
+        )));
+
+        return definition;
+    }
+
+    @Override
+    public AtlasEntity atlasEntity(AtlasClientV2 atlas) {
+        AtlasEntity entity = super.atlasEntity(atlas);
+        entity.setRelationshipAttribute("collection", collection.atlasEntity(atlas));
+        if (parentField != null) {
+            entity.setRelationshipAttribute("parentField", parentField.atlasEntity(atlas));
+        }
+        return entity;
+    }
+
+    @Override
+    protected void updateAtlasEntity(AtlasEntity entity) {
+        entity.setAttribute("fieldType", fieldType.toString());
+        entity.setAttribute("fieldPath", fieldPath);
+        entity.setAttribute("documentCount", documentCount);
+    }
+
+    @Override
+    protected String qualifiedName() {
+        return String.format("%s/%s:%s", collection.qualifiedName(), fieldPath(), fieldType());
+    }
+
+    @Override
+    public String atlasTypeName() {
+        return TYPE_NAME;
+    }
+
+    @Override
+    public UUID id() {
+        return UUID.nameUUIDFromBytes(qualifiedName().getBytes(Charset.defaultCharset()));
+    }
+
+    public CouchbaseField parentField() {
+        return parentField;
+    }
+
+    public CouchbaseField parentField(CouchbaseField parent) {
+        this.parentField = parent;
+        return this;
+    }
+}

--- a/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseFieldType.java
+++ b/addons/couchbase-bridge/src/main/java/com/couchbase/atlas/connector/entities/CouchbaseFieldType.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector.entities;
+
+import com.couchbase.client.core.error.InvalidArgumentException;
+import com.couchbase.client.java.json.JsonObject;
+import org.apache.atlas.model.typedef.AtlasEnumDef;
+import org.apache.atlas.type.AtlasTypeUtil;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public enum CouchbaseFieldType {
+    BOOLEAN,
+    NUMBER,
+    STRING,
+    ARRAY,
+    OBJECT,
+    BINARY;
+
+    public static CouchbaseFieldType infer(@Nonnull Object value) {
+        if (value instanceof Map || value instanceof JsonObject) {
+            return OBJECT;
+        } else if (value instanceof Collection || value.getClass().isArray()) {
+            if (value.getClass().isArray() && Byte.class.isAssignableFrom(value.getClass().getComponentType())) {
+                return BINARY;
+            }
+            return ARRAY;
+        } else if (value instanceof Number) {
+            return NUMBER;
+        } else if (value instanceof Boolean) {
+            return BOOLEAN;
+        } else if (value instanceof String) {
+            String sValue = (String) value;
+            if ("true".equalsIgnoreCase(sValue) || "false".equalsIgnoreCase(sValue)) {
+                return BOOLEAN;
+            }
+            try {
+                Double.parseDouble(sValue);
+                return NUMBER;
+            } catch (NumberFormatException nfe) {
+                return STRING;
+            }
+        }
+
+        throw new IllegalArgumentException("Failed to infer type");
+    }
+
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase(Locale.getDefault());
+    }
+
+    public static AtlasEnumDef atlasEnumDef() {
+        return AtlasTypeUtil.createEnumTypeDef(
+                "couchbase_field_type",
+                "",
+                new AtlasEnumDef.AtlasEnumElementDef("boolean", "", 0),
+                new AtlasEnumDef.AtlasEnumElementDef("number", "", 1),
+                new AtlasEnumDef.AtlasEnumElementDef("string", "", 2),
+                new AtlasEnumDef.AtlasEnumElementDef("array", "", 3),
+                new AtlasEnumDef.AtlasEnumElementDef("object", "", 4),
+                new AtlasEnumDef.AtlasEnumElementDef("binary", "", 5)
+        );
+    }
+}

--- a/addons/couchbase-bridge/src/main/resources/atlas-application.properties
+++ b/addons/couchbase-bridge/src/main/resources/atlas-application.properties
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/addons/couchbase-bridge/src/test/java/com/couchbase/atlas/connector/CouchbaseHookTest.java
+++ b/addons/couchbase-bridge/src/test/java/com/couchbase/atlas/connector/CouchbaseHookTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector;
+
+import com.couchbase.atlas.connector.entities.CouchbaseAtlasEntity;
+import com.couchbase.atlas.connector.entities.CouchbaseBucket;
+import com.couchbase.atlas.connector.entities.CouchbaseCluster;
+import com.couchbase.atlas.connector.entities.CouchbaseScope;
+import com.couchbase.client.dcp.Client;
+import com.couchbase.client.dcp.StreamFrom;
+import com.couchbase.client.dcp.StreamTo;
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+public class CouchbaseHookTest {
+
+    private Client mockDcpClient() {
+        Client mockDcpClient = Mockito.mock(Client.class);
+        Mockito.when(mockDcpClient.connect()).thenReturn(Mono.empty());
+        Mockito.when(mockDcpClient.initializeState(StreamFrom.NOW, StreamTo.INFINITY)).thenReturn(Mono.empty());
+        Mockito.when(mockDcpClient.startStreaming()).thenReturn(Mono.empty());
+        Mockito.when(mockDcpClient.disconnect()).thenReturn(Mono.empty());
+        return mockDcpClient;
+    }
+
+    private AtlasClientV2 mockAtlasClient(boolean returnEntities) throws Exception {
+        AtlasClientV2 mockAtlasClient = Mockito.mock(AtlasClientV2.class);
+        final String clusterName = "couchbase://localhost";
+        final String bucketName = String.format("%s/%s", clusterName, "default");
+        final String scopeName = String.format("%s/%s", bucketName, "_default");
+
+        Mockito.when(mockAtlasClient.getEntityByAttribute(Mockito.eq(CouchbaseCluster.TYPE_NAME), Mockito.anyMap())).thenAnswer(iom -> {
+            Map<String, String> query = iom.getArgument(1);
+            Assert.assertEquals(clusterName, query.get("qualifiedName"));
+            return new AtlasEntity.AtlasEntityWithExtInfo(returnEntities ? Mockito.mock(AtlasEntity.class) : null);
+        });
+
+        Mockito.when(mockAtlasClient.getEntityByAttribute(Mockito.eq(CouchbaseBucket.TYPE_NAME), Mockito.anyMap())).thenAnswer(iom -> {
+            Map<String, String> query = iom.getArgument(1);
+            Assert.assertEquals(bucketName, query.get("qualifiedName"));
+            return new AtlasEntity.AtlasEntityWithExtInfo(returnEntities ? Mockito.mock(AtlasEntity.class) : null);
+        });
+
+        Mockito.when(mockAtlasClient.getEntityByAttribute(Mockito.eq(CouchbaseScope.TYPE_NAME), Mockito.anyMap())).thenAnswer(iom -> {
+            Map<String, String> query = iom.getArgument(1);
+            Assert.assertEquals(scopeName, query.get("qualifiedName"));
+            return new AtlasEntity.AtlasEntityWithExtInfo(returnEntities ? Mockito.mock(AtlasEntity.class) : null);
+        });
+
+        return mockAtlasClient;
+    }
+
+    @Test
+    public void testMain() throws Exception {
+        Client mockDcpClient = mockDcpClient();
+        CBConfig.dcpClient(mockDcpClient);
+        AtlasClientV2 mockAtlasClient = mockAtlasClient(false);
+        AtlasConfig.client(mockAtlasClient);
+
+        AtomicInteger createCalled = new AtomicInteger();
+        Consumer<List<AtlasEntity>> createEntitiesInterceptor = ents -> {
+            createCalled.getAndIncrement();
+            Assert.assertEquals(ents.size(), 2);
+        };
+        Consumer<List<AtlasEntity>> updateEntitiesInterceptor = ents -> {
+            Assert.assertTrue(false);
+        };
+
+        CouchbaseHook.setEntityInterceptors(createEntitiesInterceptor, updateEntitiesInterceptor);
+        CouchbaseHook.loop(false);
+        // AAAAAND, ACTION (missing entities)
+        CouchbaseHook.main(new String[0]);
+
+        Mockito.verify(mockDcpClient, Mockito.times(1)).connect();
+        Assert.assertEquals(1, createCalled.get());
+        // 2 times: 1 time when we call exists(ATLAS) and second time when we request the entity
+        validateAtlasInvocations(mockAtlasClient, 3, 2, 0);
+
+        // simulate existing entities situation
+        mockAtlasClient = mockAtlasClient(true);
+        AtlasConfig.client(mockAtlasClient);
+        CouchbaseAtlasEntity.dropCache();
+
+        // ACTION AGAIN, this time with mock entities in mock Atlas
+        CouchbaseHook.main(new String[0]);
+
+        Mockito.verify(mockDcpClient, Mockito.times(2)).connect();
+        Assert.assertEquals(1, createCalled.get());
+        // 1 time and then it should be cached
+        validateAtlasInvocations(mockAtlasClient, 1, 1, 0);
+
+        testEvents(CouchbaseHook.INSTANCE);
+    }
+
+    public void testEvents(CouchbaseHook listener) {
+
+    }
+
+    private void validateAtlasInvocations(AtlasClientV2 mockAtlasClient, int cluster, int bucket, int scope) throws Exception {
+        Mockito.verify(mockAtlasClient, Mockito.times(cluster)).getEntityByAttribute(
+                Mockito.eq(CouchbaseCluster.TYPE_NAME),
+                Mockito.anyMap()
+        );
+        Mockito.verify(mockAtlasClient, Mockito.times(bucket)).getEntityByAttribute(
+                Mockito.eq(CouchbaseBucket.TYPE_NAME),
+                Mockito.anyMap()
+        );
+        Mockito.verify(mockAtlasClient, Mockito.times(scope)).getEntityByAttribute(
+                Mockito.eq(CouchbaseScope.TYPE_NAME),
+                Mockito.anyMap()
+        );
+    }
+}

--- a/addons/couchbase-bridge/src/test/java/com/couchbase/atlas/connector/entities/CouchbaseAtlasEntityTest.java
+++ b/addons/couchbase-bridge/src/test/java/com/couchbase/atlas/connector/entities/CouchbaseAtlasEntityTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.atlas.connector.entities;
+
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Tests atlas entity loading and caching
+ */
+public class CouchbaseAtlasEntityTest {
+    final static String QUALIFIED_NAME = "testEntityQualifiedName";
+    final static String TYPE_NAME = "testEntityTypeName";
+    final static UUID ID = UUID.randomUUID();
+
+    public class TestEntity extends CouchbaseAtlasEntity<TestEntity> {
+
+        @Override
+        protected String qualifiedName() {
+            return QUALIFIED_NAME;
+        }
+
+        @Override
+        public String atlasTypeName() {
+            return TYPE_NAME;
+        }
+
+        @Override
+        public UUID id() {
+            return ID;
+        }
+    }
+
+    @Test
+    public void testEntityLoading() throws Exception {
+        final AtlasClientV2 ac = Mockito.mock(AtlasClientV2.class);
+        final AtlasEntity ae = Mockito.mock(AtlasEntity.class);
+
+        Mockito.when(ae.getAttribute(Mockito.eq("qualifiedName")))
+                .thenReturn(QUALIFIED_NAME);
+
+        Mockito.when(
+                ac.getEntityByAttribute(
+                        Mockito.eq(TYPE_NAME),
+                        Mockito.anyMap()
+                )
+        ).thenAnswer(iom -> {
+            Map<String, String> query = iom.getArgument(1);
+            Assert.assertTrue(query.containsKey("qualifiedName"));
+            Assert.assertEquals(QUALIFIED_NAME, query.get("qualifiedName"));
+            return new AtlasEntity.AtlasEntityWithExtInfo(ae);
+        });
+
+        TestEntity subject = Mockito.spy(new TestEntity());
+        // exists must return false at this point as we've just created the model but it doesn't have the corresponding AtlasEntity
+        // and the cache should be empty
+        Assert.assertFalse(subject.exists());
+        Assert.assertSame(subject, subject.get());
+        Assert.assertFalse(subject.exists());
+        // ditto
+        Assert.assertTrue(!subject.atlasEntity().isPresent());
+        // Because our client mock should return the mock entity, exists with Atlas check should find the entity,
+        // cache it, and return true
+        Assert.assertTrue(subject.exists(ac));
+        // and call the method to update our model
+        Mockito.verify(subject, Mockito.times(1)).updateJavaModel(Mockito.eq(ae));
+        // Let's validate that exists with Atlas check did, in fact, query our atlas mock for the entity
+        Mockito.verify(ac, Mockito.times(1)).getEntityByAttribute(Mockito.eq(TYPE_NAME), Mockito.anyMap());
+        // the entity should exist in cache
+        Assert.assertTrue(subject.exists());
+        // and exists with Atlas check should use it
+        Assert.assertTrue(subject.exists(ac));
+        // so, let's verify that the item was pulled not from atlas (from cache will be the only option left)
+        Mockito.verify(ac, Mockito.times(1)).getEntityByAttribute(Mockito.eq(TYPE_NAME), Mockito.anyMap());
+
+        // This method should return filled Optional with our mocked entity pulled from cache
+        // And, no matter how many times we call, the result should be the same (but let's make sure that we call it at least twice)
+        int timesToLoadEntity = 2 + (int) (Math.random() * 98);
+        for (int i = 0; i < timesToLoadEntity; i++) {
+            Assert.assertSame(ae, subject.atlasEntity().get());
+        }
+        // verify that atlas entity was updated every time we requested it
+        Mockito.verify(subject, Mockito.times(timesToLoadEntity)).updateAtlasEntity(Mockito.eq(ae));
+        // verify that the model was not updated when we requested the entity second time
+        Mockito.verify(subject, Mockito.times(1)).updateJavaModel(Mockito.eq(ae));
+    }
+}

--- a/addons/couchbase-bridge/src/test/resources/log4j.xml
+++ b/addons/couchbase-bridge/src/test/resources/log4j.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d %-5p - [%t:%x] ~ %m (%C{1}:%L)%n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <level value="DEBUG"/>
+        <appender-ref ref="console"/>
+    </root>
+
+</log4j:configuration>

--- a/distro/src/main/assemblies/atlas-couchbase-hook-package.xml
+++ b/distro/src/main/assemblies/atlas-couchbase-hook-package.xml
@@ -25,14 +25,8 @@
     <id>couchbase-hook</id>
     <baseDirectory>apache-atlas-couchbase-hook-${project.version}</baseDirectory>
     <fileSets>
-        <!-- addons/couchbase-->
         <fileSet>
-            <directory>../addons/couchbase-bridge/target/dependency/bridge</directory>
-            <outputDirectory>bridge</outputDirectory>
-        </fileSet>
-
-        <fileSet>
-            <directory>../addons/falcon-bridge/target/dependency/hook</directory>
+            <directory>../addons/couchbase-bridge/target/dependency/hook</directory>
             <outputDirectory>hook</outputDirectory>
         </fileSet>
 

--- a/pom.xml
+++ b/pom.xml
@@ -847,6 +847,7 @@
         <module>addons/impala-hook-api</module>
         <module>addons/impala-bridge-shim</module>
         <module>addons/impala-bridge</module>
+        <module>addons/couchbase-bridge</module>
 
         <module>distro</module>
         <module>atlas-examples</module>
@@ -1610,6 +1611,12 @@
             <dependency>
                 <groupId>org.apache.atlas</groupId>
                 <artifactId>impala-bridge-shim</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.atlas</groupId>
+                <artifactId>couchbase-bridge</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
This adds a Couchbase hook that connects to a Couchbase cluster via DCP and sends cluster metadata onto an Atlas instance using REST APIs.

This is not ready for review, but need to create a PR to check if the SLA have been signed by Couchbase yet.