### PR TITLE
ATLAS-4823: Calling quick search REST with "_ALL_ENTITY_TYPES" does not return aggregationMetrics results

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasSolrQueryBuilder.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasSolrQueryBuilder.java
@@ -151,11 +151,14 @@ public class AtlasSolrQueryBuilder {
 
         Set<String> typesToSearch = new HashSet<>();
         for (AtlasEntityType type : entityTypes) {
-
-            if (includeSubtypes) {
-                typesToSearch.addAll(type.getTypeAndAllSubTypes());
+            if (type == AtlasEntityType.getEntityRoot()) {
+                typesToSearch.add("*");
             } else {
-                typesToSearch.add(type.getTypeName());
+                if (includeSubtypes) {
+                    typesToSearch.addAll(type.getTypeAndAllSubTypes());
+                } else {
+                    typesToSearch.add(type.getTypeName());
+                }
             }
         }
 


### PR DESCRIPTION
jira issue: https://issues.apache.org/jira/browse/ATLAS-4823

the processing of entityTypes used `__ENTITY_ROOT`, resulting in incorrect filtering in Solr queries.
Modify the judgment to when `type == AtlasEntityType.getEntityRoot()`, using filter to `*`
