### PR TITLE
[MINOR] remove akka.version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,6 @@
         <scala.macros.version>2.0.1</scala.macros.version>
         <json.version>3.2.11</json.version>
         <log4j.version>1.2.17</log4j.version>
-        <akka.version>2.3.7</akka.version>
         <spray.version>1.3.1</spray.version>
         <gson.version>2.5</gson.version>
         <fastutil.version>6.5.16</fastutil.version>


### PR DESCRIPTION
Doesn't seem to be used. This version is very out of date if it is - especially since Akka now has a Category X license.