### PR TITLE
Fix logging placeholders and add null check in rollback

### DIFF
--- a/repository/src/main/java/org/apache/atlas/GraphTransactionInterceptor.java
+++ b/repository/src/main/java/org/apache/atlas/GraphTransactionInterceptor.java
@@ -196,15 +196,20 @@ public class GraphTransactionInterceptor implements MethodInterceptor {
 
     private void doRollback(boolean logRollback, final Throwable t) {
         if (logRollback) {
-            if (logException(t)) {
-                LOG.error("graph rollback due to exception ", t);
+            if (t != null) {
+                if (logException(t)) {
+                    LOG.error("graph rollback due to exception: {}", t);
+                } else {
+                    LOG.error("graph rollback due to exception {}: {}", t.getClass().getSimpleName(), t.getMessage());
+                }
             } else {
-                LOG.error("graph rollback due to exception {}:{}", t.getClass().getSimpleName(), t.getMessage());
+                LOG.error("graph rollback due to unknown exception.");
             }
         }
 
         graph.rollback();
     }
+
 
     public static void lockObjectAndReleasePostCommit(final String guid) {
         OBJECT_UPDATE_SYNCHRONIZER.lockObject(guid);


### PR DESCRIPTION
Improve consistency and robustness in rollback logging

- Ensure consistent use of {} placeholders in LOG.error statements
- Add null check for Throwable
- Simplify and clarify the logging logic

This change ensures that exception messages are correctly formatted and that the code handles null exceptions gracefully.