### PR TITLE
ATLAS-4982: Define description/topics/merge strategy for the github repository with .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
+
+github:
+  description: "Apache Atlas - Open Metadata Management and Governance capabilities across the Hadoop platform and beyond"
+  homepage: https://atlas.apache.org
+  labels:
+    - apache
+    - atlas
+    - graphdb
+    - java
+    - javascript
+    - python
+    - docker
+  autolink_jira:
+    - ATLAS
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+  notifications:
+    commits: commits@atlas.apache.org
+    issues: dev@atlas.apache.org
+    pullrequests: dev@atlas.apache.org
+    pullrequests_comment: dev@atlas.apache.org
+    jira_options: worklog link label
+  protected_branches:
+    master: {}


### PR DESCRIPTION
Current .asf.yaml notification settings for atlas.git can be viewed at: https://gitbox.apache.org/schemes.cgi?atlas.

The PR changes:
- settings, adds branch protection on master and fixes the labels
- autolink jira with every commit
- adds description and homepage

