### PR TITLE
ATLAS-4981: Add file permissions to resolve atlas build issues in docker 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           SKIPTESTS=false docker compose -f docker-compose.atlas-base.yml -f docker-compose.atlas-build.yml up
 
       - name: Cache downloaded archives
+        if: success()
         uses: actions/cache@v4
         with:
           path: dev-support/atlas-docker/downloads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,13 @@ jobs:
           restore-keys: |
             maven-repo-
 
+      - name: Ensure .m2 directory exists
+        run: mkdir -p ~/.m2/repository
+
       - name: Debug file permissions
         run: |
           ls -ld ~/.m2
           whoami
-          chmod -R 755 ~/.m2
-          ls -ld ~/.m2
 
       - name: Set up JDK 8
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
           restore-keys: |
             maven-repo-
 
+      - name: Debug file permissions
+        run: |
+          ls -ld ~/.m2
+          whoami
+          chmod -R 755 ~/.m2
+          ls -ld ~/.m2
+
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,13 @@ jobs:
           restore-keys: |
             maven-repo-
 
-      - name: Ensure .m2 directory exists
-        run: mkdir -p ~/.m2/repository
-
-      - name: Debug file permissions
+      - name: Set up .m2 directory and permissions
         run: |
-          ls -ld ~/.m2
-          whoami
+          mkdir -p ~/.m2/repository
+          chmod -R 777 ~/.m2
+
+      - name: Clean up corrupted Maven files
+        run: rm -rf ~/.m2/repository/org/apache/apache
 
       - name: Set up JDK 8
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,24 @@ jobs:
         run: |
           mkdir -p ~/.m2/repository
           chmod -R 777 ~/.m2
-
-      - name: Clean up corrupted Maven files
-        run: rm -rf ~/.m2/repository/org/apache/apache
-
+          chmod -R 777 ./
+      
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'temurin'
+
+      - name: Clean up Docker space
+        run: docker system prune --all --force --volumes
+
+      - name: Build Atlas - JDK 8
+        run: |
+          cd dev-support/atlas-docker
+          chmod -R 777 ./../..
+          export DOCKER_BUILDKIT=1
+          export COMPOSE_DOCKER_CLI_BUILD=1
+          SKIPTESTS=false docker compose -f docker-compose.atlas-base.yml -f docker-compose.atlas-build.yml up
 
       - name: Cache downloaded archives
         uses: actions/cache@v4
@@ -75,16 +84,6 @@ jobs:
         run: |
           cd dev-support/atlas-docker
           chmod +x download-archives.sh && ./download-archives.sh
-
-      - name: Clean up Docker space
-        run: docker system prune --all --force --volumes
-
-      - name: Build Atlas - JDK 8
-        run: |
-          cd dev-support/atlas-docker
-          export DOCKER_BUILDKIT=1
-          export COMPOSE_DOCKER_CLI_BUILD=1
-          SKIPTESTS=false docker compose -f docker-compose.atlas-base.yml -f docker-compose.atlas-build.yml up
 
       - name: Bring up containers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Build Atlas - JDK 8
         run: |
           cd dev-support/atlas-docker
-          chmod -R 777 ./../..
           export DOCKER_BUILDKIT=1
           export COMPOSE_DOCKER_CLI_BUILD=1
           SKIPTESTS=false docker compose -f docker-compose.atlas-base.yml -f docker-compose.atlas-build.yml up
@@ -93,8 +92,8 @@ jobs:
           docker compose \
           -f docker-compose.atlas-base.yml \
           -f docker-compose.atlas.yml \
-          -f docker-compose.atlas-hadoop.yml \ 
-          -f docker-compose.atlas-hbase.yml \ 
+          -f docker-compose.atlas-hadoop.yml \
+          -f docker-compose.atlas-hbase.yml \
           -f docker-compose.atlas-kafka.yml \
           -f docker-compose.atlas-hive.yml up -d
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Volume mounts are used during maven build, the CI job is run with `runner` user whereas the docker-build is run via `atlas` user.

The PR adds file permissions to enable correct permissions across volume mounts to the container.


## How was this patch tested?

latest CI run