### PR TITLE
ATLAS-4863: NPE while deleting BusinessMetadata

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
@@ -404,7 +404,7 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
                 String      vertexPropertyName  = AtlasStructType.AtlasAttribute.generateVertexPropertyName(businessMetadataDef, attributeDef, qualifiedName);
                 Set<String> applicableTypes     = AtlasJson.fromJson(attributeDef.getOption(AtlasBusinessMetadataDef.ATTR_OPTION_APPLICABLE_ENTITY_TYPES), Set.class);
 
-                if (isBusinessAttributePresent(vertexPropertyName, applicableTypes)) {
+                if (CollectionUtils.isNotEmpty(applicableTypes) && isBusinessAttributePresent(vertexPropertyName, applicableTypes)) {
                     throw new AtlasBaseException(AtlasErrorCode.TYPE_HAS_REFERENCES, typeName);
                 }
             }

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2Test.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2Test.java
@@ -263,6 +263,23 @@ public class AtlasBusinessMetadataDefStoreV2Test {
     }
 
     @Test
+    public void deleteBusinessMetadataDefWithNoAssignedTypes() throws AtlasBaseException {
+        createBusinessMetadataTypesWithoutAssignedTypes(businessMetadataName);
+        for (AtlasBusinessMetadataDef atlasBusinessMetaDataDef : typesDefs.getBusinessMetadataDefs()) {
+            if (atlasBusinessMetaDataDef.getName().equals(businessMetadataName)) {
+                typesDefs = new AtlasTypesDef(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                        Collections.emptyList());
+                typesDefs.setBusinessMetadataDefs(Arrays.asList(atlasBusinessMetaDataDef));
+                typeDefStore.deleteTypesDef(typesDefs);
+            }
+        }
+
+        for (AtlasBusinessMetadataDef businessMetadataDef : typeRegistry.getAllBusinessMetadataDefs()) {
+            Assert.assertNotEquals(businessMetadataDef.getName(), businessMetadataName);
+        }
+    }
+
+    @Test
     public void updateBusinessMetadataDefs() throws AtlasBaseException {
         createBusinessMetadataTypes(businessMetadataName);
         AtlasBusinessMetadataDef businessMetadataDef = findBusinessMetadataDef(businessMetadataName);
@@ -410,6 +427,23 @@ public class AtlasBusinessMetadataDefStoreV2Test {
 
         TestUtilsV2.populateSystemAttributes(businessMetadataDef1);
 
+        return businessMetadataDef1;
+    }
+
+    private void createBusinessMetadataTypesWithoutAssignedTypes(String businessMetadataName) throws AtlasBaseException {
+        List<AtlasBusinessMetadataDef> businessMetadataDefs = new ArrayList(typesDefs.getBusinessMetadataDefs());
+        businessMetadataDefs.add(createBusinessMetadataDefWithoutAssignedTypes(businessMetadataName));
+        typesDefs.setBusinessMetadataDefs(businessMetadataDefs);
+        AtlasTypesDef createdTypesDef = typeDefStore.createTypesDef(typesDefs);
+
+        Assert.assertEquals(createdTypesDef.getBusinessMetadataDefs(), businessMetadataDefs, "Data integrity issue while persisting");
+    }
+
+    private AtlasBusinessMetadataDef createBusinessMetadataDefWithoutAssignedTypes(String businessMetadataName) {
+        AtlasBusinessMetadataDef businessMetadataDef1 = new AtlasBusinessMetadataDef(businessMetadataName, "test_no_attributes", null);
+        addBusinessAttribute(businessMetadataDef1, "test_businessMetadata_attribute1", Collections.emptySet(), "int",
+                AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE);
+        TestUtilsV2.populateSystemAttributes(businessMetadataDef1);
         return businessMetadataDef1;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix for : If businessMetadata is created without adding any applicable types (Assigned Entity types), NullPointerException is thrown when we try to delete that particular businessmetadata.

## How was this patch tested?
Unit test case is added for the same.