### PR TITLE
ATLAS-4991: Support running IT tests while building Atlas through docker

### DIFF
--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -86,7 +86,7 @@ else
   done
 fi
 
-mvn ${ARG_PROFILES} ${ARG_SKIPTESTS} -DskipDocs clean package
+mvn ${ARG_PROFILES} ${ARG_SKIPTESTS} -DskipDocs clean install
 
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-server.tar.gz     /home/atlas/dist/
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-hive-hook.tar.gz  /home/atlas/dist/


### PR DESCRIPTION
## What changes were proposed in this pull request?

change mvn package to install, to run integration tests while building Atlas through docker

## How was this patch tested?

manually