### PR TITLE
ATLAS-4993: Ensure ${HOME}/.m2 directory exists before starting Atlas build

### DIFF
--- a/dev-support/atlas-docker/README.md
+++ b/dev-support/atlas-docker/README.md
@@ -44,8 +44,8 @@ Docker files in this folder create docker images and run them to build Apache At
 
 6. Build and deploy Apache Atlas in containers using docker-compose
 
-   6.1. Execute following command to build Apache Atlas:
-
+   6.1. Ensure that the `${HOME}/.m2` directory exists and Execute following command to build Apache Atlas:
+        mkdir -p ${HOME}/.m2
         docker-compose -f docker-compose.atlas-base.yml -f docker-compose.atlas-build.yml up
 
    Time taken to complete the build might vary (upto an hour), depending on status of ${HOME}/.m2 directory cache.


### PR DESCRIPTION
ATLAS-4993: Ensure ${HOME}/.m2 directory exists before starting Atlas build

## What changes were proposed in this pull request?

Updated the README to ensure the `${HOME}/.m2` directory exists before starting the Atlas build process.

Instead of adding a separate step, Step **6.1** now includes:
mkdir -p ${HOME}/.m2

before starting the build.  
This prevents permission errors without requiring a full recursive `chown`, which could slow down the process.

## How was this patch tested?

- Manually verified that:
  - The `${HOME}/.m2` directory is created if missing.
  - The Atlas build process runs without `.m2` directory-related permission issues.
  - The fix does not introduce significant delays in the build process.
