### PR TITLE
ATLAS-4995: When user doesn't have permission on one glossary , /glos…

### DIFF
--- a/dashboardv2/public/js/views/glossary/GlossaryLayoutView.js
+++ b/dashboardv2/public/js/views/glossary/GlossaryLayoutView.js
@@ -244,6 +244,7 @@ define(['require',
             },
             getGlossary: function() {
                 this.changeLoaderState(true);
+                this.glossaryCollection.url = UrlLinks.glossaryApiUrl() + '?skipFailedEntities=true';
                 this.glossaryCollection.fetch({ reset: true });
             },
             generateCategoryData: function(options) {

--- a/dashboardv3/public/js/views/glossary/GlossaryLayoutView.js
+++ b/dashboardv3/public/js/views/glossary/GlossaryLayoutView.js
@@ -210,6 +210,7 @@ define(['require',
                 }
             },
             getGlossary: function() {
+                this.glossaryCollection.url = UrlLinks.glossaryApiUrl() + '?skipFailedEntities=true';
                 this.glossaryCollection.fetch({ reset: true });
             },
             generateCategoryData: function(options) {


### PR DESCRIPTION
…sary call throws exception , blocking authorization for all glossaries

## What changes were proposed in this pull request?

Added parameter `skipFailedEntities=true` to glossary (GET) api URL for listing glossaries. This flag will skip any glossaries not having adequate access permissions, fairly returning other entries. 

## How was this patch tested?

Manual testing