### PR TITLE
ATLAS-5005 : Basic search entity filter validation

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -179,6 +179,8 @@ public enum AtlasErrorCode {
     LINEAGE_ON_DEMAND_NOT_ENABLED(400, "ATLAS-400-00-100", "Lineage on demand config: {0} is not enabled"),
     INVALID_TOPIC_NAME(400, "ATLAS-400-00-101", "Unsupported topic name : {0}"),
     UNSUPPORTED_TYPE_NAME(400, "ATLAS-400-00-102", "Unsupported {0} name. Names such as 'description','version','options','name','servicetype' are not supported"),
+    INVALID_OPERATOR_PASSED(400, "ATLAS-400-00-103", "Invalid Operator Passed: for attribute name: {0}"),
+    BLANK_ATTRIBUTES(400, "ATLAS-400-00-104", "Attribute Name and Attribute Value can't be empty!"),
 
     UNAUTHORIZED_ACCESS(403, "ATLAS-403-00-001", "{0} is not authorized to perform {1}"),
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -885,6 +885,42 @@ public class DiscoveryREST {
             if (StringUtils.isNotEmpty(parameters.getQuery()) && parameters.getQuery().length() > maxFullTextQueryLength) {
                 throw new AtlasBaseException(AtlasErrorCode.INVALID_QUERY_LENGTH, Constants.MAX_FULLTEXT_QUERY_STR_LENGTH);
             }
+
+            validateEntityFilter(parameters);
+        }
+    }
+
+    private void validateEntityFilter(SearchParameters parameters) throws AtlasBaseException {
+        if (parameters.getEntityFilters() == null) {
+            return;
+        }
+
+        if (parameters.getEntityFilters().getCriterion() != null &&
+                !parameters.getEntityFilters().getCriterion().isEmpty()) {
+            if (StringUtils.isEmpty(parameters.getEntityFilters().getCondition().toString())) {
+                throw new AtlasBaseException("Condition (AND/OR) must be specified when using multiple filters.");
+            }
+
+            for (FilterCriteria filterCriteria : parameters.getEntityFilters().getCriterion()) {
+                if (StringUtils.isBlank(filterCriteria.getAttributeName())
+                        || StringUtils.isBlank(filterCriteria.getAttributeValue())) {
+                    throw new AtlasBaseException(AtlasErrorCode.BLANK_ATTRIBUTES);
+                }
+
+                if (filterCriteria.getOperator() == null) {
+                    throw new AtlasBaseException(AtlasErrorCode.INVALID_OPERATOR_PASSED, filterCriteria.getAttributeName());
+                }
+            }
+        }
+        else {
+            if (StringUtils.isBlank(parameters.getEntityFilters().getAttributeName())
+                    || StringUtils.isBlank(parameters.getEntityFilters().getAttributeValue())) {
+                throw new AtlasBaseException(AtlasErrorCode.BLANK_ATTRIBUTES);
+            }
+
+            if (parameters.getEntityFilters().getOperator() == null) {
+                throw new AtlasBaseException(AtlasErrorCode.INVALID_OPERATOR_PASSED, parameters.getEntityFilters().getAttributeName());
+            }
         }
     }
 

--- a/webapp/src/test/java/org/apache/atlas/web/integration/BasicSearchIT.java
+++ b/webapp/src/test/java/org/apache/atlas/web/integration/BasicSearchIT.java
@@ -138,6 +138,11 @@ public class BasicSearchIT extends BaseResourceIT {
                 LOG.info("TestDescription  :{}", testExpectation.testDescription);
                 LOG.info("SearchParameters :{}", testExpectation.searchParameters);
 
+                SearchParameters parameters = testExpectation.getSearchParameters();
+                if (parameters.getEntityFilters() == null || parameters.getEntityFilters().getAttributeName() == null) {
+                    continue;
+                }
+
                 AtlasSearchResult searchResult = atlasClientV2.facetedSearch(testExpectation.searchParameters);
 
                 if (testExpectation.expectedCount > 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Validation for FilterCriteria parameter was absence while API call.


## How was this patch tested?
unit tests, manual tests, API curl command testing done, Raised the patch for pre-commit build.
