### PR TITLE
ATLAS-5005 : Basic search entity filter validation

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -179,6 +179,9 @@ public enum AtlasErrorCode {
     LINEAGE_ON_DEMAND_NOT_ENABLED(400, "ATLAS-400-00-100", "Lineage on demand config: {0} is not enabled"),
     INVALID_TOPIC_NAME(400, "ATLAS-400-00-101", "Unsupported topic name : {0}"),
     UNSUPPORTED_TYPE_NAME(400, "ATLAS-400-00-102", "Unsupported {0} name. Names such as 'description','version','options','name','servicetype' are not supported"),
+    INVALID_OPERATOR(400, "ATLAS-400-00-103", "Invalid operator specified for attribute: {0}"),
+    BLANK_NAME_ATTRIBUTE(400, "ATLAS-400-00-104", "Name Attribute can't be empty!"),
+    BLANK_VALUE_ATTRIBUTE(400, "ATLAS-400-00-105", "Value Attribute can't be empty!"),
 
     UNAUTHORIZED_ACCESS(403, "ATLAS-403-00-001", "{0} is not authorized to perform {1}"),
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -885,7 +885,56 @@ public class DiscoveryREST {
             if (StringUtils.isNotEmpty(parameters.getQuery()) && parameters.getQuery().length() > maxFullTextQueryLength) {
                 throw new AtlasBaseException(AtlasErrorCode.INVALID_QUERY_LENGTH, Constants.MAX_FULLTEXT_QUERY_STR_LENGTH);
             }
+
+            validateEntityFilter(parameters);
         }
+    }
+
+    private void validateEntityFilter(SearchParameters parameters) throws AtlasBaseException {
+        FilterCriteria entityFilter = parameters.getEntityFilters();
+
+        if (entityFilter == null) {
+            return;
+        }
+
+        if (entityFilter.getCriterion() != null &&
+                !entityFilter.getCriterion().isEmpty()) {
+            if (entityFilter.getCondition() == null || StringUtils.isEmpty(entityFilter.getCondition().toString())) {
+                throw new AtlasBaseException("Condition (AND/OR) must be specified when using multiple filters.");
+            }
+
+            for (FilterCriteria filterCriteria : entityFilter.getCriterion()) {
+                if (filterCriteria.getOperator() == null) {
+                    throw new AtlasBaseException(AtlasErrorCode.INVALID_OPERATOR, filterCriteria.getAttributeName());
+                }
+
+                if (StringUtils.isBlank(filterCriteria.getAttributeName())) {
+                    throw new AtlasBaseException(AtlasErrorCode.BLANK_NAME_ATTRIBUTE);
+                }
+
+                if (requiresValue(filterCriteria.getOperator()) && StringUtils.isBlank(filterCriteria.getAttributeValue())) {
+                    throw new AtlasBaseException(AtlasErrorCode.BLANK_VALUE_ATTRIBUTE);
+                }
+            }
+        }
+        else {
+            if (entityFilter.getOperator() == null) {
+                throw new AtlasBaseException(AtlasErrorCode.INVALID_OPERATOR, entityFilter.getAttributeName());
+            }
+
+            if (StringUtils.isBlank(entityFilter.getAttributeName())) {
+                throw new AtlasBaseException(AtlasErrorCode.BLANK_NAME_ATTRIBUTE);
+            }
+
+            if (requiresValue(entityFilter.getOperator()) && StringUtils.isBlank(entityFilter.getAttributeValue())) {
+                throw new AtlasBaseException(AtlasErrorCode.BLANK_VALUE_ATTRIBUTE);
+            }
+        }
+    }
+
+    private boolean requiresValue(SearchParameters.Operator operator) {
+        return operator != SearchParameters.Operator.IS_NULL
+                && operator != SearchParameters.Operator.NOT_NULL;
     }
 
     private void validateSearchParameters(QuickSearchParameters parameters) throws AtlasBaseException {

--- a/webapp/src/test/java/org/apache/atlas/web/integration/BasicSearchIT.java
+++ b/webapp/src/test/java/org/apache/atlas/web/integration/BasicSearchIT.java
@@ -130,27 +130,6 @@ public class BasicSearchIT extends BaseResourceIT {
         };
     }
 
-    @DataProvider
-    public Object[][] invalidOperatorTestFiles() {
-        return new String[][] {
-                {"search-parameters/operator"}
-        };
-    }
-
-    @DataProvider
-    public Object[][] emptyNameAttributeTestFiles() {
-        return new String[][] {
-                {"search-parameters/attribute-name"}
-        };
-    }
-
-    @DataProvider
-    public Object[][] emptyValueAttributeTestFiles() {
-        return new String[][] {
-                {"search-parameters/attribute-value"}
-        };
-    }
-
     @Test(dataProvider = "basicSearchJSONNames")
     public void testDiscoveryWithSearchParameters(String jsonFile) {
         try {
@@ -248,18 +227,21 @@ public class BasicSearchIT extends BaseResourceIT {
         }
     }
 
-    @Test(dataProvider = "invalidOperatorTestFiles")
-    public void testAttributeSearchInvalidOperator(String jsonFile) {
+    @Test
+    public void testAttributeSearchInvalidOperator() {
+        String jsonFile = "search-parameters/operator";
         runNegativeSearchTest(jsonFile, "ATLAS-400-00-103", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getOperator() != null);
     }
 
-    @Test(dataProvider = "emptyNameAttributeTestFiles")
-    public void testAttributeSearchEmptyNameAttribute(String jsonFile) {
+    @Test
+    public void testAttributeSearchEmptyNameAttribute() {
+        String jsonFile = "search-parameters/attribute-name";
         runNegativeSearchTest(jsonFile, "ATLAS-400-00-104", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getAttributeName() != null);
     }
 
-    @Test(dataProvider = "emptyValueAttributeTestFiles")
-    public void testAttributeSearchEmptyValueAttribute(String jsonFile) {
+    @Test
+    public void testAttributeSearchEmptyValueAttribute() {
+        String jsonFile = "search-parameters/attribute-value";
         runNegativeSearchTest(jsonFile, "ATLAS-400-00-105", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getAttributeValue() != null);
     }
 

--- a/webapp/src/test/java/org/apache/atlas/web/integration/BasicSearchIT.java
+++ b/webapp/src/test/java/org/apache/atlas/web/integration/BasicSearchIT.java
@@ -229,20 +229,17 @@ public class BasicSearchIT extends BaseResourceIT {
 
     @Test
     public void testAttributeSearchInvalidOperator() {
-        String jsonFile = "search-parameters/operator";
-        runNegativeSearchTest(jsonFile, "ATLAS-400-00-103", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getOperator() != null);
+        runNegativeSearchTest("search-parameters/operator", "ATLAS-400-00-103", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getOperator() != null);
     }
 
     @Test
     public void testAttributeSearchEmptyNameAttribute() {
-        String jsonFile = "search-parameters/attribute-name";
-        runNegativeSearchTest(jsonFile, "ATLAS-400-00-104", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getAttributeName() != null);
+        runNegativeSearchTest("search-parameters/attribute-name", "ATLAS-400-00-104", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getAttributeName() != null);
     }
 
     @Test
     public void testAttributeSearchEmptyValueAttribute() {
-        String jsonFile = "search-parameters/attribute-value";
-        runNegativeSearchTest(jsonFile, "ATLAS-400-00-105", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getAttributeValue() != null);
+        runNegativeSearchTest("search-parameters/attribute-value", "ATLAS-400-00-105", parameters -> parameters.getEntityFilters() != null && parameters.getEntityFilters().getAttributeValue() != null);
     }
 
     public void runNegativeSearchTest(String jsonFile, String expectedErrorCode, java.util.function.Predicate<SearchParameters> paramFilter) {

--- a/webapp/src/test/resources/json/search-parameters/attribute-name.json
+++ b/webapp/src/test/resources/json/search-parameters/attribute-name.json
@@ -1,0 +1,34 @@
+[  {
+  "testDescription": "hive_table contains testtable or retentionSize != 0",
+  "searchParameters": {
+    "typeName": "hive_table",
+    "excludeDeletedEntities": true,
+    "classification": "",
+    "query": "",
+    "limit": 25,
+    "offset": 0,
+    "entityFilters": {
+      "attributeName": "",
+      "attributeValue": "",
+      "condition" : "AND",
+      "criterion" : [
+        {
+          "attributeName": "",
+          "operator": "eq",
+          "attributeValue": "testtable"
+        },
+        {
+          "attributeName": "retention",
+          "operator": "neq",
+          "attributeValue": "0"
+        }
+      ]
+    },
+    "tagFilters": null,
+    "attributes": [
+      ""
+    ]
+  },
+  "expectedCount": 0
+}
+]

--- a/webapp/src/test/resources/json/search-parameters/attribute-value.json
+++ b/webapp/src/test/resources/json/search-parameters/attribute-value.json
@@ -1,0 +1,34 @@
+[  {
+  "testDescription": "hive_table contains testtable or retentionSize != 0",
+  "searchParameters": {
+    "typeName": "hive_table",
+    "excludeDeletedEntities": true,
+    "classification": "",
+    "query": "",
+    "limit": 25,
+    "offset": 0,
+    "entityFilters": {
+      "attributeName": "name",
+      "attributeValue": "",
+      "condition" : "AND",
+      "criterion" : [
+        {
+          "attributeName": "name",
+          "operator": "eq",
+          "attributeValue": ""
+        },
+        {
+          "attributeName": "retention",
+          "operator": "neq",
+          "attributeValue": ""
+        }
+      ]
+    },
+    "tagFilters": null,
+    "attributes": [
+      ""
+    ]
+  },
+  "expectedCount": 0
+}
+]

--- a/webapp/src/test/resources/json/search-parameters/operator.json
+++ b/webapp/src/test/resources/json/search-parameters/operator.json
@@ -1,0 +1,102 @@
+[  {
+  "testDescription": "hive_table contains testtable or retentionSize != 0",
+  "searchParameters": {
+    "typeName": "hive_table",
+    "excludeDeletedEntities": true,
+    "classification": "",
+    "query": "",
+    "limit": 25,
+    "offset": 0,
+    "entityFilters": {
+      "attributeName": "name",
+      "attributeValue": "testtable",
+      "condition" : "AND",
+      "criterion" : [
+        {
+          "attributeName": "name",
+          "operator": "invalid_contains",
+          "attributeValue": "testtable"
+        },
+        {
+          "attributeName": "retention",
+          "operator": "neq",
+          "attributeValue": "0"
+        }
+      ]
+    },
+    "tagFilters": null,
+    "attributes": [
+      ""
+    ]
+  },
+  "expectedCount": 0
+},
+
+  {
+    "testDescription": "hive_table contains testtable or retentionSize != 0",
+    "searchParameters": {
+      "typeName": "hive_table",
+      "excludeDeletedEntities": true,
+      "classification": "",
+      "query": "",
+      "limit": 25,
+      "offset": 0,
+      "entityFilters": {
+        "attributeName": "name",
+        "attributeValue": "testtable",
+        "condition" : "OR",
+        "criterion" : [
+          {
+            "attributeName": "name",
+            "operator": "invalid_eq",
+            "attributeValue": "testtable"
+          },
+          {
+            "attributeName": "retention",
+            "operator": "invalid_eq",
+            "attributeValue": "0"
+          }
+        ]
+      },
+      "tagFilters": null,
+      "attributes": [
+        ""
+      ]
+    },
+    "expectedCount": 0
+  },
+
+  {
+    "testDescription": "hive_table contains testtable or retentionSize != 0",
+    "searchParameters": {
+      "typeName": "hive_table",
+      "excludeDeletedEntities": true,
+      "classification": "",
+      "query": "",
+      "limit": 25,
+      "offset": 0,
+      "entityFilters": {
+        "attributeName": "name",
+        "attributeValue": "testtable",
+        "condition" : "OR",
+        "criterion" : [
+          {
+            "attributeName": "name",
+            "operator": "invalid_neq",
+            "attributeValue": "testtable"
+          },
+          {
+            "attributeName": "retention",
+            "operator": "invalid_contains",
+            "attributeValue": "0"
+          }
+        ]
+      },
+      "tagFilters": null,
+      "attributes": [
+        ""
+      ]
+    },
+    "expectedCount": 0
+  }
+]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Validation for FilterCriteria parameter was absence while API call.

## How was this patch tested?

unit tests, manual tests, API curl command testing done, Raised the patch for pre-commit build.
PC:- https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1803/console