### PR TITLE
ATLAS-5015: UI: when server response date fields as '0', UI shows as …

### DIFF
--- a/dashboardv2/public/js/utils/CommonViewFunction.js
+++ b/dashboardv2/public/js/utils/CommonViewFunction.js
@@ -291,7 +291,7 @@ define(['require', 'utils/Utils', 'modules/Modal', 'utils/Messages', 'utils/Enum
             if (defEntity && defEntity.typeName) {
                 var defEntityType = defEntity.typeName.toLocaleLowerCase();
                 if (defEntityType === 'date') {
-                    keyValue = moment(keyValue)._isValid ? Utils.formatDate({ date: keyValue }) : null;
+                    keyValue = moment(keyValue).isValid() ? Utils.formatDate({ date: keyValue }) : null;
                 } else if (_.isObject(keyValue)) {
                     keyValue = extractObject({ "keyValue": keyValue, "key": key, 'defEntity': defEntity });
                 }

--- a/dashboardv2/public/js/utils/Utils.js
+++ b/dashboardv2/public/js/utils/Utils.js
@@ -953,7 +953,11 @@ define(['require', 'utils/Globals', 'pnotify', 'utils/Messages', 'utils/Enums', 
         var dateValue = null,
             dateFormat = Globals.dateTimeFormat,
             isValidDate = false;
-        if (options && options.date) {
+
+        if (options && !options.date) {
+            return null;
+        }
+        else  {
             dateValue = options.date;
             if (dateValue !== "-") {
                 dateValue = parseInt(dateValue);
@@ -961,7 +965,7 @@ define(['require', 'utils/Globals', 'pnotify', 'utils/Messages', 'utils/Enums', 
                     dateValue = options.date;
                 }
                 dateValue = moment(dateValue);
-                if (dateValue._isValid) {
+                if (dateValue.isValid) {
                     isValidDate = true;
                     dateValue = dateValue.format(dateFormat);
                 }

--- a/dashboardv3/public/js/utils/CommonViewFunction.js
+++ b/dashboardv3/public/js/utils/CommonViewFunction.js
@@ -291,7 +291,7 @@ define(['require', 'utils/Utils', 'modules/Modal', 'utils/Messages', 'utils/Enum
             if (defEntity && defEntity.typeName) {
                 var defEntityType = defEntity.typeName.toLocaleLowerCase();
                 if (defEntityType === 'date') {
-                    keyValue = moment(keyValue)._isValid ? Utils.formatDate({ date: keyValue }) : null;
+                    keyValue = moment(keyValue).isValid() ? Utils.formatDate({ date: keyValue }) : null;
                 } else if (_.isObject(keyValue)) {
                     keyValue = extractObject({ "keyValue": keyValue, "key": key, 'defEntity': defEntity });
                 }

--- a/dashboardv3/public/js/utils/Utils.js
+++ b/dashboardv3/public/js/utils/Utils.js
@@ -971,7 +971,10 @@ define(['require', 'utils/Globals', 'pnotify', 'utils/Messages', 'utils/Enums', 
         var dateValue = null,
             dateFormat = Globals.dateTimeFormat,
             isValidDate = false;
-        if (options && options.date) {
+        if (options && !options.date) {
+            return null;
+        }
+        else  {
             dateValue = options.date;
             if (dateValue !== "-") {
                 dateValue = parseInt(dateValue);
@@ -979,7 +982,7 @@ define(['require', 'utils/Globals', 'pnotify', 'utils/Messages', 'utils/Enums', 
                     dateValue = options.date;
                 }
                 dateValue = moment(dateValue);
-                if (dateValue._isValid) {
+                if (dateValue.isValid) {
                     isValidDate = true;
                     dateValue = dateValue.format(dateFormat);
                 }


### PR DESCRIPTION
…current time.

## What changes were proposed in this pull request?

ATLAS-5015 UI: when server response date fields as '0', UI shows as current time.

## How was this patch tested?

manually did sanity testing



PC: [ATLAS-5015](https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1813/)