### PR TITLE
ATLAS-5024: Improve fetching edges of the vertex

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -1142,14 +1142,13 @@ public final class GraphHelper {
 
         for (int numRetries = 0; numRetries < maxRetries; numRetries++) {
             try {
-                LOG.debug("Running edge creation attempt {}", numRetries);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Running edge creation attempt {}", numRetries);
+                }
 
-                if (inVertex.hasEdges(AtlasEdgeDirection.IN, edgeLabel) && outVertex.hasEdges(AtlasEdgeDirection.OUT, edgeLabel)) {
-                    AtlasEdge edge = graph.getEdgeBetweenVertices(outVertex, inVertex, edgeLabel);
-
-                    if (edge != null) {
-                        return edge;
-                    }
+                AtlasEdge edge = graph.getEdgeBetweenVertices(outVertex, inVertex, edgeLabel);
+                if (edge != null) {
+                    return edge;
                 }
 
                 return addEdge(outVertex, inVertex, edgeLabel);


### PR DESCRIPTION
ATLAS-5024:  Improve fetching edges of the vertex

Extending [ATLAS-4803](https://reviews.apache.org/r/74713/bugs/ATLAS-4803/)

Relationship attributes, classifications of a particular entity(vertex) as vertices which is linked with an edge.

Hence while performing classifications/relationship, edges are fetched.

AtlasVertex.hasEdges() checks whether a particular vertex has any edges.
This method is used in some cases, followed by getting the edges of that vertex through query.

Action:
If there are many edges of a particular vertex, time spent on checking hasEdge can also take much time. hence it can be removed

Tests Planned:
1. PC Build successful:[Link]( https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1855/)
2. Manual tests
3. Functional tests