### PR TITLE
ATLAS-5026: Remove getProperty call when calling setProperty

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasGraphUtilsV2.java
@@ -232,30 +232,13 @@ public class AtlasGraphUtilsV2 {
             propertyName = encodePropertyKey(propertyName);
         }
 
-        Object existingValue = element.getProperty(propertyName, Object.class);
-
         if (value == null) {
-            if (existingValue != null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Removing property {} from {}", propertyName, toString(element));
-                }
-
-                element.removeProperty(propertyName);
-            }
+            element.removeProperty(propertyName);
         } else {
-            if (!value.equals(existingValue)) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Setting property {} in {}", propertyName, toString(element));
-                }
-
-                if (value instanceof Date) {
-                    Long encodedValue = ((Date) value).getTime();
-
-                    element.setProperty(propertyName, encodedValue);
-                } else {
-                    element.setProperty(propertyName, value);
-                }
+            if (value instanceof Date) {
+                value = ((Date) value).getTime();
             }
+            element.setProperty(propertyName, value);
         }
     }
 


### PR DESCRIPTION
ATLAS-5026: Remove getProperty call when calling setProperty

When we set properties of the vertex (entity) we do a getProperty call as well. Since this is not required and will slow down the inserting or updating of property of an entity, we will need to remove the getProperty call.

Tests Planned:
1. PC Build Passed: https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1855/
2. Manual Tests
3. Functional Tests