### PR TITLE
ATLAS-4924: When client and server are on different timezones, search…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/SearchProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/SearchProcessor.java
@@ -55,8 +55,10 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -201,7 +203,7 @@ public abstract class SearchProcessor {
         SearchParameters.Operator op       = criteria.getOperator();
         String                    attrVal  = criteria.getAttributeValue();
         FilterCriteria            ret      = new FilterCriteria();
-        final LocalDateTime       now      = LocalDateTime.now();
+        final LocalDateTime now = LocalDateTime.now(Clock.systemUTC());
         final LocalDateTime       startTime;
         final LocalDateTime       endTime;
 
@@ -295,7 +297,9 @@ public abstract class SearchProcessor {
                 }
             }
         } else {
-            attrVal = Timestamp.valueOf(startTime).getTime() + ATTRIBUTE_VALUE_DELIMITER + Timestamp.valueOf(endTime).getTime();
+            Instant startTimeInstant = startTime.toInstant(ZoneOffset.UTC);
+            Instant endTimeInstant = endTime.toInstant(ZoneOffset.UTC);
+            attrVal = startTimeInstant.toEpochMilli() + ATTRIBUTE_VALUE_DELIMITER + endTimeInstant.toEpochMilli();
         }
 
         ret.setAttributeName(attrName);

--- a/repository/src/test/java/org/apache/atlas/discovery/EntitySearchProcessorTest.java
+++ b/repository/src/test/java/org/apache/atlas/discovery/EntitySearchProcessorTest.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertEquals;
@@ -88,6 +89,7 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         setupTestData();
         createJapaneseEntityWithDescription();
         createChineseEntityWithDescription();
+        FORMATTED_DATE.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
     @Test


### PR DESCRIPTION
…Filter gives incorrect results using time-range operator

## What changes were proposed in this pull request?

**Issue** : When client timezone is UTC and server is on PST timezone, search filters process the result according to the system timezone i.e PST and hence, the results are wrongly fetched. This is an intermittent issue as, if the entities were created according to PST time zones then the search filter could have fetched proper results.

**Analysis**: The issue with using relative date filters like TODAY or YESTERDAY in Apache Atlas typically arises from differences in time zone handling or the way Atlas interprets these filters. 
Atlas stores all timestamps in UTC, but the UI or API may interpret TODAY or YESTERDAY based on the local server time zone. For instance, if the server is in a different time zone from the user, TODAY may refer to different times than expected, causing mismatched results.

**Approach** : date and time conversions uses the UTC time zone

## How was this patch tested?
Manual testing
Modified EntitySearchProcessorTest file and verified successful execution of all tests within
Pre-commit : https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1874
