### PR TITLE
ATLAS-4848: Atlas 'updateTime' parameter is not updated when term is …

### DIFF
--- a/repository/src/main/java/org/apache/atlas/glossary/GlossaryTermUtils.java
+++ b/repository/src/main/java/org/apache/atlas/glossary/GlossaryTermUtils.java
@@ -61,6 +61,7 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static org.apache.atlas.bulkimport.BulkImportResponse.ImportStatus.FAILED;
+import static org.apache.atlas.repository.graph.GraphHelper.updateModificationMetadata;
 
 public class GlossaryTermUtils extends GlossaryUtils {
     private static final Logger LOG = LoggerFactory.getLogger(GlossaryTermUtils.class);
@@ -131,6 +132,8 @@ public class GlossaryTermUtils extends GlossaryUtils {
             LOG.debug("Assigning term guid={}, to entity guid = {}", glossaryTerm.getGuid(), objectId.getGuid());
 
             createRelationship(defineTermAssignment(glossaryTerm.getGuid(), objectId));
+            AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(objectId.getGuid());
+            updateModificationMetadata(vertex);
         }
 
         LOG.debug("<== GlossaryTermUtils.processTermAssignments()");
@@ -162,6 +165,8 @@ public class GlossaryTermUtils extends GlossaryUtils {
 
                 if (CollectionUtils.isNotEmpty(assignedEntities) && isRelationshipGuidSame(existingTermRelation, relatedObjectId)) {
                     relationshipStore.deleteById(relatedObjectId.getRelationshipGuid(), true);
+                    AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(relatedObjectId.getGuid());
+                    updateModificationMetadata(vertex);
                 } else {
                     throw new AtlasBaseException(AtlasErrorCode.INVALID_TERM_DISSOCIATION, relatedObjectId.getRelationshipGuid(), glossaryTerm.getGuid(), relatedObjectId.getGuid());
                 }


### PR DESCRIPTION
…added

## What changes were proposed in this pull request?

This patch modifies the `updateTime` property of AtlasEntity to reflect the change whenever a term is assigned and dissociated

The changes addresses an issue where, upon assigning a term to a hive_table entity, the entity's `updateTime` attribute was not being refreshed. As a result, the incremental export mechanism—relying on the change marker based on _updateTime_—failed to capture the term update on subsequent runs, causing the term to be omitted during incremental export.

The test case `GlossaryServiceTest.testTermAssignmentAndDissociation `was modified to verify the mentioned changes

## How was this patch tested?

Manual testing:  Verified that after a term is assigned to or removed from an entity, the `updateTime` attribute is explicitly updated as a result. Also verified that the updated _updateTime_ value is recognised by the incremental export process, thereby including the new term assignment in the export.

Verified and confirmed that the mentioned test execution is working as desired 

PreCommit : https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1881
