### PR TITLE
ATLAS-5034 : Entities not created in Atlas when hive table created on top of OFS/O3FS bucket/volume

### DIFF
--- a/common/src/test/java/org/apache/atlas/utils/AtlasPathExtractorUtilTest.java
+++ b/common/src/test/java/org/apache/atlas/utils/AtlasPathExtractorUtilTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -100,10 +101,22 @@ public class AtlasPathExtractorUtilTest {
         assertNotNull(entity);
         verifyOzoneKeyEntity(entity, validator);
 
-        assertEquals(entityWithExtInfo.getReferredEntities().size(), 2);
+        if (entity.getTypeName() == OZONE_KEY) {
+            verifyReferredAndKnownEntities(entityWithExtInfo, extractorContext, validator, validator.knownEntitiesCountTillKey, 2);
+        }
+        else if (entity.getTypeName() == OZONE_BUCKET) {
+            verifyReferredAndKnownEntities(entityWithExtInfo, extractorContext, validator, validator.knownEntitiesCountTillBucket, 2);
+        }
+        else if (entity.getTypeName() == OZONE_VOLUME) {
+            verifyReferredAndKnownEntities(entityWithExtInfo, extractorContext, validator, validator.knownEntitiesCountTillVolume, 1);
+        }
+    }
+
+    private void verifyReferredAndKnownEntities(AtlasEntityWithExtInfo entityWithExtInfo, PathExtractorContext extractorContext, OzoneKeyValidator validator, int  knownEntitiesCountTillVolume, int referredEntitiesSize) {
+        assertEquals(entityWithExtInfo.getReferredEntities().size(), referredEntitiesSize);
         verifyOzoneEntities(entityWithExtInfo.getReferredEntities(), validator);
 
-        assertEquals(extractorContext.getKnownEntities().size(), validator.knownEntitiesCount);
+        assertEquals(extractorContext.getKnownEntities().size(), knownEntitiesCountTillVolume);
         verifyOzoneEntities(extractorContext.getKnownEntities(), validator);
     }
 
@@ -270,6 +283,15 @@ public class AtlasPathExtractorUtilTest {
                 {new OzoneKeyValidator(OZONE_SCHEME, "ozone1/volume1/bucket1/quarter_one/sales/",
                         "quarter_one", "ozone1/volume1/bucket1/quarter_one",
                         "sales", "ozone1/volume1/bucket1/quarter_one/sales")},
+                {new OzoneKeyValidator(OZONE_SCHEME, "ozone1745922163/volume1/bucket1/mykey1/key.text",
+                        "mykey1", "ozone1745922163/volume1/bucket1/mykey1",
+                        "key.text", "ozone1745922163/volume1/bucket1/mykey1/key.text")},
+
+                {new OzoneKeyValidator(OZONE_SCHEME, "ozone1/volume1/bucket1",
+                        "bucket1", "volume1.bucket1")},
+
+                {new OzoneKeyValidator(OZONE_SCHEME, "ozone1/volume1",
+                        "volume1", "volume1")},
 
                 {new OzoneKeyValidator(OZONE_3_SCHEME, "bucket1.volume1.ozone1/files/file.txt",
                         "files", "bucket1.volume1.ozone1/files",
@@ -285,6 +307,15 @@ public class AtlasPathExtractorUtilTest {
                 {new OzoneKeyValidator(OZONE_3_SCHEME, "bucket1.volume1.ozone1/quarter_one/sales/",
                         "quarter_one", "bucket1.volume1.ozone1/quarter_one",
                         "sales", "bucket1.volume1.ozone1/quarter_one/sales")},
+                {new OzoneKeyValidator(OZONE_3_SCHEME, "bucket1.volume1.ozone1/",
+                        "bucket1", "volume1.bucket1")},
+
+                {new OzoneKeyValidator(OZONE_3_SCHEME, "bucket1.volume1.ozone1/key1/key1.txt/",
+                        "key1", "bucket1.volume1.ozone1/key1",
+                        "key1.txt", "bucket1.volume1.ozone1/key1/key1.txt") },
+
+                {new OzoneKeyValidator(OZONE_3_SCHEME, "bucket1.volume1/key1/",
+                        "key1", "bucket1.volume1/key1")}
         };
     }
 
@@ -309,8 +340,18 @@ public class AtlasPathExtractorUtilTest {
     }
 
     private void verifyOzoneKeyEntity(AtlasEntity entity, OzoneKeyValidator validator) {
-        assertEquals(entity.getTypeName(), OZONE_KEY);
-        assertTrue(validator.validateNameQName(entity));
+        if (Objects.equals(entity.getTypeName(), OZONE_KEY)) {
+            assertEquals(entity.getTypeName(), OZONE_KEY);
+            assertTrue(validator.validateNameQName(entity));
+        }
+        else if (Objects.equals(entity.getTypeName(), OZONE_BUCKET)) {
+            assertEquals(entity.getTypeName(), OZONE_BUCKET);
+            assertTrue(validator.validateNameQName(entity));
+        }
+        else if (Objects.equals(entity.getTypeName(), OZONE_VOLUME)) {
+            assertEquals(entity.getTypeName(), OZONE_VOLUME);
+            assertTrue(validator.validateNameQName(entity));
+        }
     }
 
     private void verifyHDFSEntity(AtlasEntity entity, boolean toLowerCase) {
@@ -476,23 +517,28 @@ public class AtlasPathExtractorUtilTest {
     private static class OzoneKeyValidator {
         private final String              scheme;
         private final String              location;
-        private final int                 knownEntitiesCount;
+        private final int                 knownEntitiesCountTillKey;
+        private final int                 knownEntitiesCountTillBucket;
+        private final int                 knownEntitiesCountTillVolume;
         private final Map<String, String> nameQNamePairs;
 
         public OzoneKeyValidator(String scheme, String location, String... pairs) {
-            this.scheme             = scheme;
-            this.location           = location;
-            this.nameQNamePairs     = getPairMap(scheme, pairs);
-            this.knownEntitiesCount = nameQNamePairs.size() + 2;
+            this.scheme                       = scheme;
+            this.location                     = location;
+            this.nameQNamePairs               = getPairMap(scheme, pairs);
+            this.knownEntitiesCountTillKey    = nameQNamePairs.size() + 2;
+            this.knownEntitiesCountTillBucket = nameQNamePairs.size() + 1;
+            this.knownEntitiesCountTillVolume = nameQNamePairs.size();
         }
 
         public boolean validateNameQName(AtlasEntity entity) {
-            String name = (String) entity.getAttribute(ATTRIBUTE_NAME);
-
-            if (this.nameQNamePairs.containsKey(name)) {
-                String qName = (String) entity.getAttribute(ATTRIBUTE_QUALIFIED_NAME);
-
-                return qName.equals(this.nameQNamePairs.get(name));
+            for (Map.Entry<String, String> nameQName : nameQNamePairs.entrySet()) {
+                if (this.nameQNamePairs.containsKey(nameQName.getKey())) {
+                    String qName = (String) entity.getAttribute(ATTRIBUTE_QUALIFIED_NAME);
+                    if (qName.equals(nameQName.getValue())) {
+                        return true;
+                    }
+                }
             }
 
             return false;

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -105,6 +105,7 @@ public enum AtlasErrorCode {
     SAVED_SEARCH_CHANGE_USER(400, "ATLAS-400-00-056", "saved-search {0} can not be moved from user {1} to {2}"),
     INVALID_QUERY_PARAM_LENGTH(400, "ATLAS-400-00-057", "Length of query param {0} exceeds the limit"),
     INVALID_QUERY_LENGTH(400, "ATLAS-400-00-058", "Invalid query length, update {0} to change the limit"),
+    INCORRECT_OZONE_PATH(400, "ATLAS-400-00-058", "Empty Ozone Path"),
     // DSL related error codes
     INVALID_DSL_QUERY(400, "ATLAS-400-00-059", "Invalid DSL query: {0} | Reason: {1}. Please refer to Atlas DSL grammar for more information"),
     INVALID_DSL_GROUPBY(400, "ATLAS-400-00-05A", "DSL Semantic Error - GroupBy attribute {0} is non-primitive"),

--- a/webapp/src/test/resources/template_metadata.csv
+++ b/webapp/src/test/resources/template_metadata.csv
@@ -1,2 +1,2 @@
 TypeName,UniqueAttributeValue,BusinessAttributeName,BusinessAttributeValue,UniqueAttributeName[optional]
-hive_table_v2,tableY2Q72pP2Do,bmWithAllTypes.attr8,"Awesome Attribute 1",qualifiedName
+hive_table_v2,tableFzES76TLTJ,bmWithAllTypes.attr8,"Awesome Attribute 1",qualifiedName


### PR DESCRIPTION
ATLAS-5034 JIRA LINK : https://issues.apache.org/jira/browse/ATLAS-5034

## What changes were proposed in this pull request?
Changes:
1. Initially, able to create hive table for ofs and o3fs when keys were specified on UI
2. After changes, we can create hive entity for ofs for multiple keys. Hive table can be created on top of keys[full qualified path], bucket[qualified path till buckets, no key mentioned] and volume[qualified path till volume, no bucket and key mentioned] for OFS.
3. After changes, for O3FS, hive table can be created on top of keys[full qualified path], buckets[no keys mentioned] 

## How was this patch tested?
1. PC test - Pre Commit Test:
Link: https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1892/
Conclusion: Success

2. Full maven build including TestCases

3. Manually tested after the code changes, wrt diff use cases for ofs and o3fs for hive table creation on UI
