### PR TITLE
ATLAS-5045: [React UI] Adding detail page view for Glossary

### DIFF
--- a/dashboard/src/api/apiMethods/__tests__/glossaryApiMethod.test.ts
+++ b/dashboard/src/api/apiMethods/__tests__/glossaryApiMethod.test.ts
@@ -40,7 +40,8 @@ import {
 	assignTermstoCategory,
 	assignGlossaryType,
 	removeTermorCategory,
-	deleteGlossaryorType
+	deleteGlossaryorType,
+	deleteCategory
 } from '../glossaryApiMethod'
 import { _delete, _get, _post, _put } from '../apiMethod'
 // Import URL helpers - they will be mocked
@@ -57,7 +58,8 @@ import {
 	assignTermtoEntitiesUrl,
 	assignTermtoCategoryUrl,
 	assignGlossaryTypeUrl,
-	removeTermorCatgeoryUrl
+	removeTermorCatgeoryUrl,
+	deleteCategoryUrl
 } from '../../../api/apiUrlLinks/glossaryUrl'
 
 // Mock dependencies
@@ -81,21 +83,23 @@ const mockAssignTermtoEntitiesUrl = jest.fn((termId: string) => `/api/glossary/t
 const mockAssignTermtoCategoryUrl = jest.fn((categoryId: string) => `/api/glossary/category/${categoryId}`)
 const mockAssignGlossaryTypeUrl = jest.fn((guid: string) => `/api/glossary/type/${guid}`)
 const mockRemoveTermorCatgeoryUrl = jest.fn((guid: string, type: string) => `/api/glossary/${type}/${guid}`)
+const mockDeleteCategoryUrl = jest.fn((guid: string) => `/api/glossary/category/${guid}`)
 
 jest.mock('../../../api/apiUrlLinks/glossaryUrl', () => ({
-	removeTermUrl: (...args: any[]) => mockRemoveTermUrl(...args),
-	glossaryUrl: (...args: any[]) => mockGlossaryUrl(...args),
-	glossaryImportTempUrl: (...args: any[]) => mockGlossaryImportTempUrl(...args),
-	glossaryImportUrl: (...args: any[]) => mockGlossaryImportUrl(...args),
-	glossaryTypeUrl: (...args: any[]) => mockGlossaryTypeUrl(...args),
-	createTermorCategoryUrl: (...args: any[]) => mockCreateTermorCategoryUrl(...args),
-	editGlossaryUrl: (...args: any[]) => mockEditGlossaryUrl(...args),
-	editTermorCategoryUrl: (...args: any[]) => mockEditTermorCategoryUrl(...args),
-	deleteGlossaryorTermUrl: (...args: any[]) => mockDeleteGlossaryorTermUrl(...args),
-	assignTermtoEntitiesUrl: (...args: any[]) => mockAssignTermtoEntitiesUrl(...args),
-	assignTermtoCategoryUrl: (...args: any[]) => mockAssignTermtoCategoryUrl(...args),
-	assignGlossaryTypeUrl: (...args: any[]) => mockAssignGlossaryTypeUrl(...args),
-	removeTermorCatgeoryUrl: (...args: any[]) => mockRemoveTermorCatgeoryUrl(...args)
+	removeTermUrl: (...args: any[]) => (mockRemoveTermUrl as any)(...args),
+	glossaryUrl: (...args: any[]) => (mockGlossaryUrl as any)(...args),
+	glossaryImportTempUrl: (...args: any[]) => (mockGlossaryImportTempUrl as any)(...args),
+	glossaryImportUrl: (...args: any[]) => (mockGlossaryImportUrl as any)(...args),
+	glossaryTypeUrl: (...args: any[]) => (mockGlossaryTypeUrl as any)(...args),
+	createTermorCategoryUrl: (...args: any[]) => (mockCreateTermorCategoryUrl as any)(...args),
+	editGlossaryUrl: (...args: any[]) => (mockEditGlossaryUrl as any)(...args),
+	editTermorCategoryUrl: (...args: any[]) => (mockEditTermorCategoryUrl as any)(...args),
+	deleteGlossaryorTermUrl: (...args: any[]) => (mockDeleteGlossaryorTermUrl as any)(...args),
+	assignTermtoEntitiesUrl: (...args: any[]) => (mockAssignTermtoEntitiesUrl as any)(...args),
+	assignTermtoCategoryUrl: (...args: any[]) => (mockAssignTermtoCategoryUrl as any)(...args),
+	assignGlossaryTypeUrl: (...args: any[]) => (mockAssignGlossaryTypeUrl as any)(...args),
+	removeTermorCatgeoryUrl: (...args: any[]) => (mockRemoveTermorCatgeoryUrl as any)(...args),
+	deleteCategoryUrl: (...args: any[]) => (mockDeleteCategoryUrl as any)(...args)
 }))
 
 describe('glossaryApiMethod', () => {
@@ -117,7 +121,7 @@ describe('glossaryApiMethod', () => {
 		mockPost.mockResolvedValue(mockResponse)
 		mockPut.mockResolvedValue(mockResponse)
 		mockDelete.mockResolvedValue(mockResponse)
-		
+
 		// Reset URL helper mocks to return correct values
 		mockRemoveTermUrl.mockImplementation((termId: string) => `/api/glossary/term/${termId}`)
 		mockGlossaryUrl.mockImplementation(() => '/api/glossary')
@@ -132,6 +136,7 @@ describe('glossaryApiMethod', () => {
 		mockAssignTermtoCategoryUrl.mockImplementation((categoryId: string) => `/api/glossary/category/${categoryId}`)
 		mockAssignGlossaryTypeUrl.mockImplementation((guid: string) => `/api/glossary/type/${guid}`)
 		mockRemoveTermorCatgeoryUrl.mockImplementation((guid: string, type: string) => `/api/glossary/${type}/${guid}`)
+		mockDeleteCategoryUrl.mockImplementation((guid: string) => `/api/glossary/category/${guid}`)
 	})
 
 	describe('removeTerm', () => {
@@ -294,6 +299,20 @@ describe('glossaryApiMethod', () => {
 
 			expect(mockAssignGlossaryTypeUrl).toHaveBeenCalledWith(guid)
 			expect(mockDelete).toHaveBeenCalledWith('/api/glossary/type/type-123', {
+				method: 'DELETE',
+				params: {}
+			})
+			expect(result).toEqual(mockResponse)
+		})
+	})
+
+	describe('deleteCategory', () => {
+		it('should call _delete with correct URL for deleting category', async () => {
+			const guid = 'category-123'
+			const result = await deleteCategory(guid)
+
+			expect(mockDeleteCategoryUrl).toHaveBeenCalledWith(guid)
+			expect(mockDelete).toHaveBeenCalledWith('/api/glossary/category/category-123', {
 				method: 'DELETE',
 				params: {}
 			})

--- a/dashboard/src/api/apiMethods/glossaryApiMethod.ts
+++ b/dashboard/src/api/apiMethods/glossaryApiMethod.ts
@@ -28,7 +28,8 @@ import {
   glossaryTypeUrl,
   glossaryUrl,
   removeTermorCatgeoryUrl,
-  removeTermUrl
+  removeTermUrl,
+  deleteCategoryUrl
 } from "../apiUrlLinks/glossaryUrl";
 import { _delete, _get, _post, _put } from "./apiMethod";
 
@@ -142,6 +143,13 @@ const deleteGlossaryorType = (guid: string) => {
     params: {}
   });
 };
+
+const deleteCategory = (guid: string) => {
+  return _delete(deleteCategoryUrl(guid), {
+    method: "DELETE",
+    params: {}
+  });
+};
 const assignTermstoEntites = (
   termId: string,
   data: { guid: string; relationshipGuid: string }
@@ -194,5 +202,6 @@ export {
   assignTermstoCategory,
   assignGlossaryType,
   removeTermorCategory,
-  deleteGlossaryorType
+  deleteGlossaryorType,
+  deleteCategory
 };

--- a/dashboard/src/api/apiUrlLinks/__tests__/glossaryUrl.test.ts
+++ b/dashboard/src/api/apiUrlLinks/__tests__/glossaryUrl.test.ts
@@ -47,7 +47,8 @@ import {
 	assignTermtoEntitiesUrl,
 	assignTermtoCategoryUrl,
 	assignGlossaryTypeUrl,
-	removeTermorCatgeoryUrl
+	removeTermorCatgeoryUrl,
+	deleteCategoryUrl
 } from '../glossaryUrl'
 import { getBaseApiUrl } from '../commonApiUrl'
 
@@ -185,6 +186,26 @@ describe('glossaryUrl', () => {
 		it('should handle empty guid', () => {
 			const result = deleteGlossaryorTermUrl('')
 			expect(result).toBe('/mock-base-url/api/atlas/v2/glossary/')
+		})
+	})
+
+	describe('deleteCategoryUrl', () => {
+		it('should return correct URL for deleting category', () => {
+			const guid = 'guid-123'
+			const result = deleteCategoryUrl(guid)
+
+			expect(mockGetBaseApiUrl).toHaveBeenCalledWith('urlV2')
+			expect(result).toBe('/mock-base-url/api/atlas/v2/glossary/category/guid-123')
+		})
+
+		it('should handle different guid values', () => {
+			const result = deleteCategoryUrl('guid-456')
+			expect(result).toBe('/mock-base-url/api/atlas/v2/glossary/category/guid-456')
+		})
+
+		it('should handle empty guid', () => {
+			const result = deleteCategoryUrl('')
+			expect(result).toBe('/mock-base-url/api/atlas/v2/glossary/category/')
 		})
 	})
 

--- a/dashboard/src/api/apiUrlLinks/glossaryUrl.ts
+++ b/dashboard/src/api/apiUrlLinks/glossaryUrl.ts
@@ -37,6 +37,9 @@ const glossaryImportUrl = () => {
 };
 
 const glossaryTypeUrl = (glossaryType: string, guid: string) => {
+  if (glossaryType == "glossary") {
+    return `${glossaryUrl()}/${guid}`;
+  }
   return `${glossaryUrl()}/${glossaryType}/${guid}`;
 };
 
@@ -73,6 +76,10 @@ const assignGlossaryTypeUrl = (guid: string) => {
   return termUrl;
 };
 
+const deleteCategoryUrl = (guid: string) => {
+  return getBaseApiUrl("urlV2") + `/glossary/category/${guid}`;
+};
+
 const removeTermorCatgeoryUrl = (guid: string, glossaryType: string) => {
   let termUrl = getBaseApiUrl("urlV2") + `/glossary/${glossaryType}/${guid}`;
   return termUrl;
@@ -91,4 +98,5 @@ export {
   assignTermtoCategoryUrl,
   assignGlossaryTypeUrl,
   removeTermorCatgeoryUrl,
+  deleteCategoryUrl
 };

--- a/dashboard/src/components/Modal.tsx
+++ b/dashboard/src/components/Modal.tsx
@@ -98,6 +98,9 @@ export const CustomModal: React.FC<CustomModalProps> = ({
           aria-labelledby="customized-dialog-title"
           aria-busy={isLoading}
           open={open}
+          disableEnforceFocus
+          disableAutoFocus
+          disableRestoreFocus
           sx={{
             "& .MuiDialog-paper": {
               // maxWidth: "80% !important",

--- a/dashboard/src/components/ShowMore/ShowMoreView.tsx
+++ b/dashboard/src/components/ShowMore/ShowMoreView.tsx
@@ -120,19 +120,19 @@ const ShowMoreView = ({
       } else if (title == "Terms" || title == "Category") {
         let selectedTerm = !isEmpty(data)
           ? data?.find(
-              (obj: {
-                qualifiedName: string;
-                displayText: string;
-                termGuid: string;
-              }) => {
-                if (
-                  (obj.qualifiedName || obj.displayText) ==
-                  currentValue.selectedValue
-                ) {
-                  return obj;
-                }
+            (obj: {
+              qualifiedName: string;
+              displayText: string;
+              termGuid: string;
+            }) => {
+              if (
+                (obj.qualifiedName || obj.displayText) ==
+                currentValue.selectedValue
+              ) {
+                return obj;
               }
-            )
+            }
+          )
           : {};
 
         if (isEmpty(gType)) {
@@ -190,8 +190,8 @@ const ShowMoreView = ({
   const checkSuperTypes = (classificationName: string) => {
     var tagObj = !isEmpty(classificationDefs)
       ? classificationDefs.find((obj: { name: string }) => {
-          return obj.name == classificationName;
-        })
+        return obj.name == classificationName;
+      })
       : {};
 
     return !isEmpty(tagObj?.superTypes)
@@ -203,10 +203,10 @@ const ShowMoreView = ({
 
   const getTagParentList = (name: string) => {
     let tagObj = !isEmpty(classificationDefs)
-        ? classificationDefs?.find((obj: { name: string }) => {
-            return obj.name == name;
-          })
-        : {},
+      ? classificationDefs?.find((obj: { name: string }) => {
+        return obj.name == name;
+      })
+      : {},
       tagParents = tagObj ? tagObj?.["superTypes"] : null,
       parentName = name;
     if (tagParents && tagParents.length) {
@@ -255,14 +255,16 @@ const ShowMoreView = ({
 
     if (title == "Terms" || title == "Category") {
       const { termGuid, categoryGuid }: any = data || {};
-      const searchParams = new URLSearchParams(location.search);
-
-      searchParams.set("gtype", title == "Terms" ? "term" : "category");
-      searchParams.set("viewType", title == "Terms" ? "term" : "category");
-      searchParams.set("fromView", "entity");
+      const searchParams = new URLSearchParams();
 
       let gTypeGuid =
         (title == "Terms" ? termGuid : categoryGuid) || data?.guid;
+
+      searchParams.set("gid", gTypeGuid);
+      searchParams.set("gtype", title == "Terms" ? "term" : "category");
+      searchParams.set("viewType", title == "Terms" ? "term" : "category");
+      searchParams.set("fromView", "entity");
+      searchParams.set("searchType", "basic");
 
       return (
         <Link
@@ -312,12 +314,12 @@ const ShowMoreView = ({
                   onDelete={
                     !isEmpty(removeApiMethod) && !isDeleteIcon
                       ? () => {
-                          // Handle undefined displayKey by extracting a string value
-                          const deleteValue = obj[displayKey] || obj.displayText || obj.text || obj.name || '';
-                          handleDelete(deleteValue);
-                        }
+                        // Handle undefined displayKey by extracting a string value
+                        const deleteValue = obj[displayKey] || obj.displayText || obj.text || obj.name || '';
+                        handleDelete(deleteValue);
+                      }
                       : isDeleteIcon && obj.count > 1
-                      ? () => {
+                        ? () => {
                           const searchParams = new URLSearchParams();
                           searchParams.set("tabActive", "classification");
                           searchParams.set("filter", obj.typeName);
@@ -326,7 +328,7 @@ const ShowMoreView = ({
                             search: searchParams.toString()
                           });
                         }
-                      : undefined
+                        : undefined
                   }
                   size="small"
                   variant="outlined"
@@ -407,11 +409,10 @@ const ShowMoreView = ({
               sx={{ fontWeight: 600 }}
             >
               {!isEmpty(currentEntity)
-                ? `${currentValue.assetName} ${
-                    !isEmpty(currentEntity?.typeName)
-                      ? `(${currentEntity.typeName})`
-                      : ""
-                  }`
+                ? `${currentValue.assetName} ${!isEmpty(currentEntity?.typeName)
+                  ? `(${currentEntity.typeName})`
+                  : ""
+                }`
                 : ""}
             </Typography>{" "}
             ?

--- a/dashboard/src/components/Table/TableLayout.tsx
+++ b/dashboard/src/components/Table/TableLayout.tsx
@@ -75,6 +75,7 @@ import TableRowsLoader from "./TableLoader";
 import AddTag from "@views/Classification/AddTag";
 import FilterQuery from "@components/FilterQuery";
 import TablePagination from "./TablePagination";
+import SkeletonLoader from "@components/SkeletonLoader";
 
 interface IndeterminateCheckboxProps extends Omit<CheckboxProps, "ref"> {
   indeterminate?: boolean;
@@ -207,8 +208,8 @@ const DraggableTableHeader = ({ header, isEmptyRows }: { header: any; isEmptyRow
     width: isEmptyRows
       ? undefined
       : header.column.columnDef?.width != undefined
-      ? header.column.columnDef?.width
-      : header.column.getSize(),
+        ? header.column.columnDef?.width
+        : header.column.getSize(),
     zIndex: isDragging ? 1 : 0
   };
 
@@ -222,17 +223,16 @@ const DraggableTableHeader = ({ header, isEmptyRows }: { header: any; isEmptyRow
     >
       {header.isPlaceholder ? null : (
         <div
-          className={`${
-            header.column.getCanSort() ? "cursor-pointer select-none" : ""
-          } table-header-wrap`}
+          className={`${header.column.getCanSort() ? "cursor-pointer select-none" : ""
+            } table-header-wrap`}
           onClick={header.column.getToggleSortingHandler()}
           title={
             header.column.getCanSort()
               ? header.column.getNextSortingOrder() === "asc"
                 ? "Sort ascending"
                 : header.column.getNextSortingOrder() === "desc"
-                ? "Sort descending"
-                : "Clear sort"
+                  ? "Sort descending"
+                  : "Clear sort"
               : undefined
           }
         >
@@ -391,8 +391,8 @@ const TableLayout: FC<TableProps> = ({
   const [columnOrder, setColumnOrder] = useState<any>(() =>
     !isEmpty(memoizedColumns)
       ? memoizedColumns
-          .map((c: any) => c.id || c.accessorKey)
-          .filter(Boolean)
+        .map((c: any) => c.id || c.accessorKey)
+        .filter(Boolean)
       : []
   );
 
@@ -400,8 +400,8 @@ const TableLayout: FC<TableProps> = ({
     setColumnOrder(
       !isEmpty(memoizedColumns)
         ? memoizedColumns
-            .map((c: any) => c.id || c.accessorKey)
-            .filter(Boolean)
+          .map((c: any) => c.id || c.accessorKey)
+          .filter(Boolean)
         : []
     )
   }, [memoizedColumns])
@@ -413,9 +413,6 @@ const TableLayout: FC<TableProps> = ({
   currentParams.forEach((value, key) => {
     params[key] = value;
   });
-  // Total number of visible table columns including selection/expand controls
-  const totalVisibleColumns =
-    (showRowSelection ? 1 : 0) + (expandRow ? 1 : 0) + columnOrder.length;
   const {
     getHeaderGroups,
     getRowModel,
@@ -468,8 +465,8 @@ const TableLayout: FC<TableProps> = ({
     setColumnOrder(
       !isEmpty(memoizedColumns)
         ? memoizedColumns
-            .map((c: any) => c.id || c.accessorKey)
-            .filter(Boolean)
+          .map((c: any) => c.id || c.accessorKey)
+          .filter(Boolean)
         : []
     );
   }, [existingColumnIds]);
@@ -520,8 +517,8 @@ const TableLayout: FC<TableProps> = ({
   };
   const selectedRow = !isEmpty(getSelectedRowModel()?.rows)
     ? getSelectedRowModel()?.rows?.map((obj) => {
-        return obj.original;
-      })
+      return obj.original;
+    })
     : [];
 
   return (
@@ -561,7 +558,7 @@ const TableLayout: FC<TableProps> = ({
               {isfilterQuery &&
                 (location.pathname == "/search/searchResult" ||
                   location.pathname ==
-                    "/relationship/relationshipSearchresult") && (
+                  "/relationship/relationshipSearchresult") && (
                   <Stack
                     flexWrap="wrap"
                     direction="row"
@@ -631,20 +628,25 @@ const TableLayout: FC<TableProps> = ({
             >
               <MuiTable
                 size="small"
-                className={`table ${expandRow ? "expand-row-table" : ""} ${
-                  memoizedData && memoizedData.length > 0 && expandRow
-                    ? "has-expanded-rows"
-                    : ""
-                }`}
+                className={`table ${expandRow ? "expand-row-table" : ""} ${memoizedData && memoizedData.length > 0 && expandRow
+                  ? "has-expanded-rows"
+                  : ""
+                  }`}
                 sx={{
                   tableLayout: memoizedData.length > 0 ? "fixed" : "auto",
                   width: "100%"
                 }}
               >
                 {/* remove dynamic colgroup for empty state */}
-                {!isFetching && (
-                  <TableHead>
-                    {getHeaderGroups().map((headerGroup) => (
+                <TableHead>
+                  {isFetching ? (
+                    <TableRow className="table-header-row">
+                      <TableCell colSpan={100}>
+                        <SkeletonLoader animation="wave" variant="text" count={1} />
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    getHeaderGroups().map((headerGroup) => (
                       <TableRow
                         hover
                         key={headerGroup.id}
@@ -666,7 +668,7 @@ const TableLayout: FC<TableProps> = ({
                           items={columnOrder}
                           strategy={horizontalListSortingStrategy}
                         >
-                          
+
                           {headerGroup.headers.map((header) =>
                             header.isPlaceholder ? null : (
                               <DraggableTableHeader
@@ -678,15 +680,15 @@ const TableLayout: FC<TableProps> = ({
                           )}
                         </SortableContext>
                       </TableRow>
-                    ))}
-                  </TableHead>
-                )}
+                    ))
+                  )}
+                </TableHead>
                 <TableBody>
                   {isFetching ? (
                     <TableRowsLoader rowsNum={10} />
                   ) : memoizedData.length === 0 && isFetching == false ? (
                     <TableRow>
-                      <TableCell colSpan={Math.max(1, totalVisibleColumns)}>
+                      <TableCell colSpan={100}>
                         <Stack textAlign="center">
                           <Typography fontWeight="600" color="text.secondary">
                             {emptyText}

--- a/dashboard/src/components/Table/TableLoader.tsx
+++ b/dashboard/src/components/Table/TableLoader.tsx
@@ -21,16 +21,7 @@ import { TableCell, TableRow } from "@mui/material";
 const TableRowsLoader = ({ rowsNum }: { rowsNum: number }) => {
   return [...Array(rowsNum)].map((_row, index) => (
     <TableRow key={index}>
-      <TableCell component="th" scope="row">
-        <SkeletonLoader animation="wave" variant="text" count={1} />
-      </TableCell>
-      <TableCell>
-        <SkeletonLoader animation="wave" variant="text" count={1} />
-      </TableCell>
-      <TableCell>
-        <SkeletonLoader animation="wave" variant="text" count={1} />
-      </TableCell>
-      <TableCell>
+      <TableCell colSpan={100}>
         <SkeletonLoader animation="wave" variant="text" count={1} />
       </TableCell>
     </TableRow>

--- a/dashboard/src/components/TreeNodeIcons.tsx
+++ b/dashboard/src/components/TreeNodeIcons.tsx
@@ -83,10 +83,10 @@ const TreeNodeIcons = (props: {
 
   selectedSearchData = !isEmpty(savedSearchData)
     ? savedSearchData?.find((obj: { name: string; guid: string }) => {
-        if (obj.name == node.id) {
-          return obj;
-        }
-      })
+      if (obj.name == node.id) {
+        return obj;
+      }
+    })
     : {};
 
   const handleCloseGlossaryModal = () => {
@@ -202,17 +202,17 @@ const TreeNodeIcons = (props: {
           !isEmpty(node.children) &&
           node.cGuid != undefined)) &&
         !(treeName == "CustomFilters" && node.types == "parent") && (
-        <IconButton
-          onClick={(e) => {
-            handleClickNodeMenu(e);
-          }}
-          className="tree-item-more-label"
-          size="small"
-          data-cy="dropdownMenuButton"
-        >
-          <MoreHorizOutlinedIcon className="treeitem-dropdown-toggle" />
-        </IconButton>
-      )}
+          <IconButton
+            onClick={(e) => {
+              handleClickNodeMenu(e);
+            }}
+            className="tree-item-more-label"
+            size="small"
+            data-cy="dropdownMenuButton"
+          >
+            <MoreHorizOutlinedIcon className="treeitem-dropdown-toggle" />
+          </IconButton>
+        )}
       <Menu
         onClick={(e) => {
           e.stopPropagation();
@@ -232,193 +232,200 @@ const TreeNodeIcons = (props: {
         {((treeName == "Classifications" &&
           !addOnClassification.includes(node.id)) ||
           (treeName == "Glossary" && node.types == "parent")) && (
-          <MenuItem
-            onClick={(e) => {
-              e.stopPropagation();
-              if (
-                treeName == "Classifications" &&
-                !addOnClassification.includes(node.id)
-              ) {
-                setTagModal(true);
-              }
-              if (
-                treeName == "Glossary" &&
-                node.types == "parent" &&
-                isEmptyServicetype
-              ) {
-                setTermModal(true);
-              }
-              if (
-                treeName == "Glossary" &&
-                node.types == "parent" &&
-                !isEmptyServicetype
-              ) {
-                setCategoryModal(true);
-              }
-              handleCloseNode();
-            }}
-            className="sidebar-menu-item"
-            data-cy="createClassification"
-          >
-            <ListItemIcon sx={{ minWidth: "28px !important" }}>
-              <AddIcon fontSize="small" className="menuitem-icon" />
-            </ListItemIcon>
-            <Typography
-              className="menuitem-label"
-              sx={{ fontSize: "0.875rem" }}
+            <MenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                if (
+                  treeName == "Classifications" &&
+                  !addOnClassification.includes(node.id)
+                ) {
+                  setTagModal(true);
+                }
+                if (
+                  treeName == "Glossary" &&
+                  node.types == "parent" &&
+                  isEmptyServicetype
+                ) {
+                  setTermModal(true);
+                }
+                if (
+                  treeName == "Glossary" &&
+                  node.types == "parent" &&
+                  !isEmptyServicetype
+                ) {
+                  setCategoryModal(true);
+                }
+                handleCloseNode();
+              }}
+              className="sidebar-menu-item"
+              data-cy="createClassification"
             >
-              {`Create ${
-                treeName == "Classifications"
+              <ListItemIcon sx={{ minWidth: "28px !important" }}>
+                <AddIcon fontSize="small" className="menuitem-icon" />
+              </ListItemIcon>
+              <Typography
+                className="menuitem-label"
+                sx={{ fontSize: "0.875rem" }}
+              >
+                {`Create ${treeName == "Classifications"
                   ? "Sub-classification"
                   : isEmptyServicetype
-                  ? "Term"
-                  : "Category"
-              }`}
-            </Typography>
-          </MenuItem>
-        )}
+                    ? "Term"
+                    : "Category"
+                  }`}
+              </Typography>
+            </MenuItem>
+          )}
         {((treeName == "Classifications" &&
           !addOnClassification.includes(node.id)) ||
-          (treeName == "Glossary" && isEmptyServicetype)) && (
-          <MenuItem
-            onClick={(_e) => {
-              if (treeName == "Classifications") {
-                const searchParams = new URLSearchParams();
-                const classificationName = node.label
-                  ? node.label.split(" (")[0]
-                  : node.nodeName || node.id;
-                searchParams.set("tag", classificationName);
-                navigate({
-                  pathname: `/tag/tagAttribute/${classificationName}`,
-                  search: searchParams.toString()
-                });
-                setExpandNode(null);
-              }
-              if (treeName == "Glossary" && node.types == "parent") {
-                setGlossaryModal(true);
-                setExpandNode(null);
-              }
-              if (treeName == "Glossary" && node.types == "child") {
-                const searchParams = new URLSearchParams();
-                searchParams.set("gid", node.guid);
-                searchParams.set("term", "term");
-                searchParams.set("gtype", "term");
-                searchParams.set("viewType", "term");
-                searchParams.set("searchType", "basic");
-                searchParams.set("term", `${node.id}@${node.parent}`);
-                navigate({
-                  pathname: `/glossary/${node.cGuid}`,
-                  search: searchParams.toString()
-                });
-                setExpandNode(null);
-              }
-            }}
-            data-cy="createClassification"
-            className="sidebar-menu-item"
-          >
-            <ListItemIcon sx={{ minWidth: "28px !important" }}>
-              <ListAltOutlinedIcon fontSize="small" className="menuitem-icon" />
-            </ListItemIcon>
-            <Typography
-              className="menuitem-label"
-              sx={{ fontSize: "0.875rem" }}
+          treeName == "Glossary") && (
+            <MenuItem
+              onClick={(_e) => {
+                if (treeName == "Classifications") {
+                  const searchParams = new URLSearchParams();
+                  const classificationName = node.label
+                    ? node.label.split(" (")[0]
+                    : node.nodeName || node.id;
+                  searchParams.set("tag", classificationName);
+                  navigate({
+                    pathname: `/tag/tagAttribute/${classificationName}`,
+                    search: searchParams.toString()
+                  });
+                  setExpandNode(null);
+                }
+                if (treeName == "Glossary" && node.types == "parent") {
+                  const searchParams = new URLSearchParams();
+                  searchParams.set("gid", node.guid);
+                  searchParams.set("gtype", "glossary");
+                  searchParams.set("viewType", "glossary");
+                  searchParams.set("searchType", "basic");
+                  navigate({
+                    pathname: `/glossary/${node.guid}`,
+                    search: searchParams.toString()
+                  });
+                  setExpandNode(null);
+                }
+                if (treeName == "Glossary" && node.types == "child") {
+                  const searchParams = new URLSearchParams();
+                  searchParams.set("gid", node.guid);
+                  searchParams.set("term", "term");
+                  searchParams.set("gtype", isEmptyServicetype ? "term" : "category");
+                  searchParams.set("viewType", isEmptyServicetype ? "term" : "category");
+                  searchParams.set("searchType", "basic");
+                  if (isEmptyServicetype) {
+                    const termName = node.id.endsWith(`@${node.parent}`) ? node.id : `${node.id}@${node.parent}`;
+                    searchParams.set("term", termName);
+                  }
+                  navigate({
+                    pathname: `/glossary/${node.cGuid}`,
+                    search: searchParams.toString()
+                  });
+                  setExpandNode(null);
+                }
+              }}
+              data-cy="createClassification"
+              className="sidebar-menu-item"
             >
-              {`View/Edit ${
-                treeName == "Glossary"
-                  ? node.types == "parent"
-                    ? "Glossary"
-                    : "Term"
-                  : ""
-              }`}
-            </Typography>
-          </MenuItem>
-        )}
+              <ListItemIcon sx={{ minWidth: "28px !important" }}>
+                <ListAltOutlinedIcon fontSize="small" className="menuitem-icon" />
+              </ListItemIcon>
+              <Typography
+                className="menuitem-label"
+                sx={{ fontSize: "0.875rem" }}
+              >
+                {treeName === "Classifications"
+                  ? "View/Edit Classification"
+                  : node.types === "parent"
+                    ? "View/Edit Glossary"
+                    : isEmptyServicetype ? "View/Edit Term" : "View/Edit Category"}
+              </Typography>
+            </MenuItem>
+          )}
         {((treeName == "Classifications" &&
           !addOnClassification.includes(node.id)) ||
           (treeName == "Glossary" && node.types == "parent") ||
-          (treeName == "Glossary" &&
-            node.types == "child" &&
-            isEmptyServicetype)) && (
-          // &&
-          //   !isEmpty(gtype)
-          <MenuItem
-            onClick={(_e) => {
-              if (treeName == "Classifications") {
-                setdeleteTagModal(true);
-              }
-              if (treeName == "Glossary") {
-                setDeleteGlossaryModal(true);
-              }
-              handleCloseNode();
-            }}
-            data-cy="createClassification"
-            className="sidebar-menu-item"
-          >
-            <ListItemIcon sx={{ minWidth: "28px !important" }}>
-              <DeleteOutlineOutlinedIcon
-                fontSize="small"
-                className="menuitem-icon"
-              />
-            </ListItemIcon>
-            <Typography
-              className="menuitem-label"
-              sx={{ fontSize: "0.875rem" }}
+          (treeName == "Glossary" && node.types == "child")) && (
+            // &&
+            //   !isEmpty(gtype)
+            <MenuItem
+              onClick={(_e) => {
+                if (treeName == "Classifications") {
+                  setdeleteTagModal(true);
+                }
+                if (treeName == "Glossary") {
+                  setDeleteGlossaryModal(true);
+                }
+                handleCloseNode();
+              }}
+              data-cy="createClassification"
+              className="sidebar-menu-item"
             >
-              {`Delete ${
-                treeName == "Glossary"
+              <ListItemIcon sx={{ minWidth: "28px !important" }}>
+                <DeleteOutlineOutlinedIcon
+                  fontSize="small"
+                  className="menuitem-icon"
+                />
+              </ListItemIcon>
+              <Typography
+                className="menuitem-label"
+                sx={{ fontSize: "0.875rem" }}
+              >
+                {`Delete ${treeName == "Glossary"
                   ? node.types == "parent"
                     ? "Glossary"
-                    : "Term"
+                    : isEmptyServicetype
+                      ? "Term"
+                      : "Category"
                   : ""
-              }`}
-            </Typography>
-          </MenuItem>
-        )}
+                  }`}
+              </Typography>
+            </MenuItem>
+          )}
         {(treeName == "Classifications" ||
           (treeName == "Glossary" &&
             (node.types == "child" || node.types == undefined) &&
             isEmptyServicetype)) && (
-          <MenuItem
-            onClick={(e) => {
-              e.stopPropagation();
-              setExpandNode(null);
-              const searchParams = new URLSearchParams();
-              searchParams.set("searchType", "basic");
-              if (treeName == "Classifications") {
-                let classificationName: string;
-                if (node.label) {
-                  classificationName = node.label.split(" (")[0];
-                } else if (node.nodeName) {
-                  classificationName = node.nodeName;
-                } else {
-                  classificationName = node.id;
+            <MenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                setExpandNode(null);
+                const searchParams = new URLSearchParams();
+                searchParams.set("searchType", "basic");
+                if (treeName == "Classifications") {
+                  let classificationName: string;
+                  if (node.label) {
+                    classificationName = node.label.split(" (")[0];
+                  } else if (node.nodeName) {
+                    classificationName = node.nodeName;
+                  } else {
+                    classificationName = node.id;
+                  }
+                  searchParams.set("tag", classificationName);
+                } else if (treeName == "Glossary") {
+                  const termValue = node.types == "child" && node.parent
+                    ? `${node.id}@${node.parent}`
+                    : node.id;
+                  searchParams.set("term", termValue);
                 }
-                searchParams.set("tag", classificationName);
-              } else if (treeName == "Glossary") {
-                const termValue = node.types == "child" && node.parent
-                  ? `${node.id}@${node.parent}`
-                  : node.id;
-                searchParams.set("term", termValue);
-              }
-              navigate({
-                pathname: "/search/searchResult",
-                search: searchParams.toString()
-              });
-            }}
-            data-cy="createClassification"
-            className="sidebar-menu-item"
-          >
-            <ListItemIcon sx={{ minWidth: "24px !important" }}>
-              <SearchOutlinedIcon fontSize="small" className="menuitem-icon" />
-            </ListItemIcon>
-            <Typography
-              className="menuitem-label"
-              sx={{ fontSize: "0.875rem" }}
+                navigate({
+                  pathname: "/search/searchResult",
+                  search: searchParams.toString()
+                });
+              }}
+              data-cy="createClassification"
+              className="sidebar-menu-item"
             >
-              Search
-            </Typography>
-          </MenuItem>
-        )}
+              <ListItemIcon sx={{ minWidth: "24px !important" }}>
+                <SearchOutlinedIcon fontSize="small" className="menuitem-icon" />
+              </ListItemIcon>
+              <Typography
+                className="menuitem-label"
+                sx={{ fontSize: "0.875rem" }}
+              >
+                Search
+              </Typography>
+            </MenuItem>
+          )}
         {treeName == "Glossary" &&
           !isEmptyServicetype &&
           node.types == "child" &&
@@ -550,7 +557,11 @@ const TreeNodeIcons = (props: {
           open={deleteGlossaryModal}
           onClose={handleCloseDeleteGlossaryModal}
           setExpandNode={setExpandNode}
-          node={node}
+          node={
+            treeName === "Glossary" && node.types === "child" && !isEmptyServicetype
+              ? { ...node, types: "Category" }
+              : node
+          }
           updatedData={updatedData}
         />
       )}

--- a/dashboard/src/components/__tests__/TreeNodeIcons.test.tsx
+++ b/dashboard/src/components/__tests__/TreeNodeIcons.test.tsx
@@ -74,7 +74,7 @@ jest.mock('../../api/apiMethods/savedSearchApiMethod', () => ({
 
 jest.mock('../../utils/Utils', () => ({
 	isEmpty: (val: any) =>
-		val == null || (Array.isArray(val) ? val.length === 0 : val === '') ,
+		val == null || (Array.isArray(val) ? val.length === 0 : val === ''),
 	serverError: jest.fn()
 }))
 
@@ -118,7 +118,7 @@ describe('TreeNodeIcons', () => {
 	})
 
 	it('handles CustomFilters rename flow', async () => {
-		
+
 		const updatedData = jest.fn()
 		render(
 			<TreeNodeIcons
@@ -239,10 +239,40 @@ describe('TreeNodeIcons', () => {
 		expect(screen.getByTestId('delete-glossary')).toBeTruthy()
 	})
 
-	it('opens glossary edit modal for parent', () => {
+	it('opens delete glossary modal for glossary term child', () => {
 		render(
 			<TreeNodeIcons
-				node={{ id: 'Gloss1', types: 'parent', children: [] }}
+				node={{ id: 'Term1', types: 'child', children: [] }}
+				treeName="Glossary"
+				updatedData={jest.fn()}
+				isEmptyServicetype={true}
+			/>
+		)
+
+		fireEvent.click(screen.getByTestId('MoreHorizOutlinedIcon'))
+		fireEvent.click(screen.getByText('Delete Term'))
+		expect(screen.getByTestId('delete-glossary')).toBeTruthy()
+	})
+
+	it('opens delete glossary modal for glossary category child', () => {
+		render(
+			<TreeNodeIcons
+				node={{ id: 'Category1', types: 'child', children: [] }}
+				treeName="Glossary"
+				updatedData={jest.fn()}
+				isEmptyServicetype={false}
+			/>
+		)
+
+		fireEvent.click(screen.getByTestId('MoreHorizOutlinedIcon'))
+		fireEvent.click(screen.getByText('Delete Category'))
+		expect(screen.getByTestId('delete-glossary')).toBeTruthy()
+	})
+
+	it('navigates to glossary view/edit for parent', () => {
+		render(
+			<TreeNodeIcons
+				node={{ id: 'Gloss1', guid: 'gloss1-guid', types: 'parent', children: [] }}
 				treeName="Glossary"
 				updatedData={jest.fn()}
 				isEmptyServicetype={true}
@@ -251,7 +281,10 @@ describe('TreeNodeIcons', () => {
 
 		fireEvent.click(screen.getByTestId('MoreHorizOutlinedIcon'))
 		fireEvent.click(screen.getByText('View/Edit Glossary'))
-		expect(screen.getByTestId('glossary-form')).toBeTruthy()
+		expect(navigateMock).toHaveBeenCalledWith({
+			pathname: '/glossary/gloss1-guid',
+			search: expect.stringContaining('gtype=glossary')
+		})
 	})
 
 	it('navigates to search for classification', () => {
@@ -292,6 +325,29 @@ describe('TreeNodeIcons', () => {
 		expect(navigateMock).toHaveBeenCalledWith({
 			pathname: '/glossary/c1',
 			search: expect.stringContaining('term=Term1%40Gloss') // URL encoded @ symbol
+		})
+	})
+
+	it('navigates to glossary child view/edit without double appending glossary name if term already contains it', () => {
+		render(
+			<TreeNodeIcons
+				node={{
+					id: 'Term1@Gloss',
+					parent: 'Gloss',
+					types: 'child',
+					cGuid: 'c1'
+				}}
+				treeName="Glossary"
+				updatedData={jest.fn()}
+				isEmptyServicetype={true}
+			/>
+		)
+
+		fireEvent.click(screen.getByTestId('MoreHorizOutlinedIcon'))
+		fireEvent.click(screen.getByText('View/Edit Term'))
+		expect(navigateMock).toHaveBeenCalledWith({
+			pathname: '/glossary/c1',
+			search: expect.stringContaining('term=Term1%40Gloss') // Should not be Term1%40Gloss%40Gloss
 		})
 	})
 

--- a/dashboard/src/components/__tests__/commonComponents.test.tsx
+++ b/dashboard/src/components/__tests__/commonComponents.test.tsx
@@ -25,7 +25,8 @@ import { render, screen } from '@testing-library/react'
 let mockReduxState = { typeHeader: { typeHeaderData: [] } }
 
 jest.mock('react-redux', () => ({
-	useSelector: (fn: any) => fn(mockReduxState)
+	useSelector: (fn: any) => fn(mockReduxState),
+	useDispatch: () => jest.fn()
 }))
 
 jest.mock('react-router-dom', () => ({

--- a/dashboard/src/styles/classificationForm.scss
+++ b/dashboard/src/styles/classificationForm.scss
@@ -23,8 +23,8 @@
   min-height: 90px !important;
 }
 
-/* Prevent duplicate toolbars in ReactQuill */
-.classification-form-editor .ql-toolbar:not(:first-of-type) {
+/* Prevent duplicate toolbars in ReactQuill by hiding the zombie toolbars that precede the active one */
+.classification-form-editor .ql-toolbar:has(~ .ql-toolbar) {
   display: none !important;
 }
 

--- a/dashboard/src/views/DetailPage/DetailPageAttributes.tsx
+++ b/dashboard/src/views/DetailPage/DetailPageAttributes.tsx
@@ -23,7 +23,11 @@ import {
   Stack,
   ToggleButton,
   ToggleButtonGroup,
-  Typography
+  Typography,
+  Autocomplete,
+  TextField,
+  Menu,
+  MenuItem
 } from "@mui/material";
 import {
   extractKeyValueFromEntity,
@@ -39,24 +43,30 @@ const getDescriptionForDisplay = (desc: unknown): string => {
   }
   return "";
 };
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useAppSelector } from "@hooks/reducerHook";
 import { toast } from "react-toastify";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import { removeClassification } from "@api/apiMethods/classificationApiMethod";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams, Link } from "react-router-dom";
+import { TableLayout } from "@components/Table/TableLayout";
 import ClassificationForm from "@views/Classification/ClassificationForm";
 import AddUpdateTermForm from "@views/Glossary/AddUpdateTermForm";
 import AddUpdateCategoryForm from "@views/Glossary/AddUpdateCategoryForm";
-import { removeTermorCategory } from "@api/apiMethods/glossaryApiMethod";
-import { StyledPaper } from "@utils/Muiutils";
+import { removeTermorCategory, getGlossaryType } from "@api/apiMethods/glossaryApiMethod";
+import { StyledPaper, Item } from "@utils/Muiutils";
+import AddUpdateGlossaryForm from "@views/Glossary/AddUpdateGlossaryForm";
 import ShowMoreView from "@components/ShowMore/ShowMoreView";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import AddTag from "@views/Classification/AddTag";
 import AddTagAttributes from "@views/Classification/AddTagAttributes";
 import AssignCategory from "@views/Glossary/AssignCategory";
 import AssignTerm from "@views/Glossary/AssignTerm";
+import DeleteGlossary from "@views/Glossary/DeleteGlossary";
 import ShowMoreText from "@components/ShowMore/ShowMoreText";
+
 
 const DetailPageAttribute = ({
   data,
@@ -70,6 +80,7 @@ const DetailPageAttribute = ({
   const [searchParams] = useSearchParams();
   const { guid, tagName, bmguid } = useParams();
   const gtypeParams = searchParams.get("gtype");
+
   const [alignment, setAlignment] = useState<string>("formatted");
   const [tagModal, setTagModal] = useState<boolean>(false);
   const [editTermModal, setEditTermModal] = useState(false);
@@ -80,6 +91,147 @@ const DetailPageAttribute = ({
   const [openAddTermModal, setOpenAddTermModal] = useState<boolean>(false);
 
   const [categoryModal, setCategoryModal] = useState<boolean>(false);
+  const [editGlossaryModal, setEditGlossaryModal] = useState<boolean>(false);
+
+  const [selectedRowItem, setSelectedRowItem] = useState<any>(null);
+  const [editRowModal, setEditRowModal] = useState<boolean>(false);
+  const [deleteRowModal, setDeleteRowModal] = useState<boolean>(false);
+  const [createTermModal, setCreateTermModal] = useState<boolean>(false);
+  const [createCategoryModal, setCreateCategoryModal] = useState<boolean>(false);
+  const [createAnchorEl, setCreateAnchorEl] = useState<null | HTMLElement>(null);
+  const openCreateMenu = Boolean(createAnchorEl);
+
+  const handleCreateClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setCreateAnchorEl(event.currentTarget);
+  };
+  const handleCreateClose = () => {
+    setCreateAnchorEl(null);
+  };
+
+
+  const [isTableLoading, setIsTableLoading] = useState<boolean>(false);
+  const [localTerms, setLocalTerms] = useState<any[]>(data?.terms || []);
+  const [localCategories, setLocalCategories] = useState<any[]>(data?.categories || []);
+
+  const [prevData, setPrevData] = useState<any>(data);
+  if (data !== prevData) {
+    setPrevData(data);
+    setLocalTerms(data?.terms || []);
+    setLocalCategories(data?.categories || []);
+  }
+
+
+  const handleTableUpdate = async (showLoader = true) => {
+    if (gtypeParams && guid) {
+      if (showLoader) setIsTableLoading(true);
+      try {
+        const res = await getGlossaryType(gtypeParams, guid);
+        setLocalTerms(res.data?.terms || []);
+        setLocalCategories(res.data?.categories || []);
+      } finally {
+        if (showLoader) setIsTableLoading(false);
+      }
+    }
+  };
+
+  const [glossaryFilter, setGlossaryFilter] = useState<string>("All");
+
+  const glossaryTermsAndCategories = useMemo(() => {
+    if (gtypeParams !== "glossary") return [];
+    const t = (localTerms || []).map((t: any) => ({ ...t, _itemType: "term" }));
+    const c = (localCategories || []).map((c: any) => ({ ...c, _itemType: "category" }));
+    return [...t, ...c];
+  }, [localTerms, localCategories, gtypeParams]);
+
+  const filteredGlossaryItems = useMemo(() => {
+    if (glossaryFilter === "All") return glossaryTermsAndCategories;
+    if (glossaryFilter === "Terms") return glossaryTermsAndCategories.filter((i: any) => i._itemType === "term");
+    if (glossaryFilter === "Categories") return glossaryTermsAndCategories.filter((i: any) => i._itemType === "category");
+    return glossaryTermsAndCategories;
+  }, [glossaryTermsAndCategories, glossaryFilter]);
+
+  const filterOptions = ["All", "Terms", "Categories"];
+
+  const glossaryTableColumns = useMemo(() => [
+    {
+      accessorKey: "displayText",
+      header: "Name",
+      cell: (info: any) => {
+        const item = info.row.original;
+        const type = item._itemType;
+        const targetGuid = item.termGuid || item.categoryGuid || item.guid || item.id;
+        const href = `/glossary/${targetGuid}?gtype=${type}&view=properties`;
+        return (
+          <Link to={href} className="text-blue text-decoration-none fw-600">
+            {item.displayText}
+          </Link>
+        );
+      }
+    },
+    {
+      accessorKey: "glossaryType",
+      header: "Glossary Type",
+      enableSorting: false,
+      cell: (info: any) => {
+        const type = info.row.original._itemType;
+        return type ? type.charAt(0).toUpperCase() + type.slice(1) : "N/A";
+      }
+    },
+    {
+      accessorKey: "action",
+      header: "Action",
+      enableSorting: false,
+      cell: (info: any) => {
+        const item = info.row.original;
+        const type = item._itemType;
+        return (
+          <Stack direction="row" gap={1}>
+            <LightTooltip title={`Edit ${type === "term" ? "Term" : "Category"}`}>
+              <CustomButton
+                variant="outlined"
+                color="success"
+                className="table-filter-btn assignTag"
+                size="small"
+                onClick={async (e: React.MouseEvent<HTMLElement>) => {
+                  e.stopPropagation();
+                  try {
+                    const targetGuid = item.termGuid || item.categoryGuid || item.guid || item.id;
+                    const res = await getGlossaryType(type, targetGuid);
+                    setSelectedRowItem({ ...item, ...res.data });
+                    setEditRowModal(true);
+                  } catch (err) {
+                    toast.error("Failed to fetch details for editing");
+                  }
+                }}
+              >
+                <EditOutlinedIcon className="table-filter-refresh" />
+              </CustomButton>
+            </LightTooltip>
+
+            <LightTooltip title={`Delete ${type === "term" ? "Term" : "Category"}`}>
+              <CustomButton
+                variant="outlined"
+                color="success"
+                className="table-filter-btn assignTag"
+                size="small"
+                onClick={(e: React.MouseEvent<HTMLElement>) => {
+                  e.stopPropagation();
+                  setSelectedRowItem(item);
+                  setDeleteRowModal(true);
+                }}
+              >
+                <DeleteOutlinedIcon className="table-filter-refresh" />
+              </CustomButton>
+            </LightTooltip>
+          </Stack>
+        );
+      }
+    }
+  ], []);
+
+  const handleCloseEditGlossaryModal = () => {
+    setEditGlossaryModal(false);
+  };
 
   const handleCloseTermModal = () => {
     setOpenAddTermModal(false);
@@ -146,7 +298,19 @@ const DetailPageAttribute = ({
               {name}{" "}
             </Typography>
             {isEmpty(bmguid) && (
-              <LightTooltip title={"Edit Classification"}>
+              <LightTooltip
+                title={
+                  !isEmpty(tagName)
+                    ? "Edit Classification"
+                    : !isEmpty(guid) && gtypeParams == "term"
+                      ? "Edit Term"
+                      : !isEmpty(guid) && gtypeParams == "category"
+                        ? "Edit Category"
+                        : !isEmpty(guid) && gtypeParams == "glossary"
+                          ? "Edit Glossary"
+                          : "Edit"
+                }
+              >
                 <CustomButton
                   variant="outlined"
                   color="success"
@@ -162,6 +326,9 @@ const DetailPageAttribute = ({
                     if (!isEmpty(guid) && gtypeParams == "category") {
                       setEditCategoryModal(true);
                     }
+                    if (!isEmpty(guid) && gtypeParams == "glossary") {
+                      setEditGlossaryModal(true);
+                    }
                   }}
                   data-cy="addTag"
                 >
@@ -175,11 +342,11 @@ const DetailPageAttribute = ({
             style={{
               ...(isEmpty(bmguid)
                 ? {
-                    display: "grid",
-                    gridTemplateColumns: "1fr 1fr",
-                    gridGap: "1rem 2rem",
-                    marginBottom: "0.75rem"
-                  }
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  gridGap: "1rem 2rem",
+                  marginBottom: "0.75rem"
+                }
                 : {})
             }}
           >
@@ -353,7 +520,7 @@ const DetailPageAttribute = ({
                 )
               ))}
             {!isEmpty(gtypeParams) &&
-              gtypeParams == "category" &&
+              (gtypeParams == "category") &&
               (loading ? (
                 <Stack direction="column" spacing={2} alignItems="left">
                   <SkeletonLoader
@@ -365,7 +532,7 @@ const DetailPageAttribute = ({
                 </Stack>
               ) : (
                 !isEmpty(guid) &&
-                gtypeParams == "category" && (
+                (gtypeParams == "category") && (
                   <Stack
                     direction="column"
                     alignItems="flex-start"
@@ -410,17 +577,21 @@ const DetailPageAttribute = ({
                       flex="1"
                       justifyContent="flex-start"
                     >
-                      <ShowMoreView
-                        data={data?.["terms"] || []}
-                        maxVisible={4}
-                        title="Terms"
-                        displayKey="displayText"
-                        isEditView={false}
-                        currentEntity={data}
-                        removeApiMethod={removeTermorCategory}
-                        removeTagsTitle={"Remove Term Assignment"}
-                        id={"Terms"}
-                      />
+                      {isEmpty(data?.["terms"]) ? (
+                        <Typography lineHeight="26px" fontSize="14px">N/A</Typography>
+                      ) : (
+                        <ShowMoreView
+                          data={data?.["terms"] || []}
+                          maxVisible={4}
+                          title="Terms"
+                          displayKey="displayText"
+                          isEditView={false}
+                          currentEntity={data}
+                          removeApiMethod={removeTermorCategory}
+                          removeTagsTitle={"Remove Term Assignment"}
+                          id={"Terms"}
+                        />
+                      )}
                     </Stack>
                   </Stack>
                 )
@@ -437,8 +608,7 @@ const DetailPageAttribute = ({
                   />
                 </Stack>
               ) : (
-                !isEmpty(guid) &&
-                gtypeParams == "term" && (
+                !isEmpty(guid) && (
                   <Stack
                     direction="column"
                     alignItems="flex-start"
@@ -477,17 +647,21 @@ const DetailPageAttribute = ({
                       flex="1"
                       justifyContent="flex-start"
                     >
-                      <ShowMoreView
-                        data={data?.["categories"] || []}
-                        maxVisible={4}
-                        title="Category"
-                        displayKey="displayText"
-                        removeApiMethod={removeTermorCategory}
-                        currentEntity={data}
-                        removeTagsTitle={"Remove Category Assignment"}
-                        isEditView={false}
-                        id={"Category"}
-                      />
+                      {isEmpty(data?.["categories"]) ? (
+                        <Typography lineHeight="26px" fontSize="14px">N/A</Typography>
+                      ) : (
+                        <ShowMoreView
+                          data={data?.["categories"] || []}
+                          maxVisible={4}
+                          title="Category"
+                          displayKey="displayText"
+                          removeApiMethod={removeTermorCategory}
+                          currentEntity={data}
+                          removeTagsTitle={"Remove Category Assignment"}
+                          isEditView={false}
+                          id={"Category"}
+                        />
+                      )}
                     </Stack>
                   </Stack>
                 )
@@ -656,6 +830,78 @@ const DetailPageAttribute = ({
         </StyledPaper>
       </Stack>
 
+      {!isEmpty(gtypeParams) && gtypeParams == "glossary" && (
+        <Item variant="outlined" className="glossary-detail-items" sx={{ mt: 2, p: 2 }}>
+          <Stack>
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              marginBottom="0.5rem"
+              gap="1rem"
+            >
+              <Autocomplete
+                size="small"
+                disablePortal
+                options={filterOptions}
+                value={glossaryFilter}
+                onChange={(_e, newVal) => setGlossaryFilter(newVal as string)}
+                isOptionEqualToValue={(option, value) => option === value}
+                getOptionLabel={(option) => option}
+                disableClearable
+                className="classification-table-autocomplete"
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Terms and Categories"
+                  />
+                )}
+              />
+              {(gtypeParams === "glossary" || gtypeParams === "category") && (
+                <>
+                  <CustomButton
+                    variant="contained"
+                    size="small"
+                    onClick={handleCreateClick}
+                    endIcon={<KeyboardArrowDownIcon />}
+                  >
+                    Create
+                  </CustomButton>
+                  <Menu
+                    anchorEl={createAnchorEl}
+                    open={openCreateMenu}
+                    onClose={handleCreateClose}
+                    anchorOrigin={{
+                      vertical: 'bottom',
+                      horizontal: 'right',
+                    }}
+                    transformOrigin={{
+                      vertical: 'top',
+                      horizontal: 'right',
+                    }}
+                  >
+                    <MenuItem onClick={() => { setCreateCategoryModal(true); handleCreateClose(); }}>Category</MenuItem>
+                    <MenuItem onClick={() => { setCreateTermModal(true); handleCreateClose(); }}>Term</MenuItem>
+                  </Menu>
+                </>
+              )}
+            </Stack>
+            <TableLayout
+              data={filteredGlossaryItems}
+              columns={glossaryTableColumns}
+              columnVisibility={false}
+              columnSort={true}
+              showPagination={true}
+              isFetching={loading || isTableLoading}
+              showRowSelection={false}
+              clientSideSorting={true}
+              isClientSidePagination={true}
+              emptyText="No Records found!"
+            />
+          </Stack>
+        </Item>
+      )}
+
       {tagModal && (
         <ClassificationForm
           open={tagModal}
@@ -691,6 +937,15 @@ const DetailPageAttribute = ({
           dataObj={data}
         />
       )}
+      {editGlossaryModal && (
+        <AddUpdateGlossaryForm
+          open={editGlossaryModal}
+          isAdd={false}
+          onClose={handleCloseEditGlossaryModal}
+          node={{ id: data?.name }}
+          dataObj={data}
+        />
+      )}
       {attributeModal && (
         <AddTagAttributes
           open={attributeModal}
@@ -713,6 +968,91 @@ const DetailPageAttribute = ({
           data={data || {}}
           updateTable={undefined}
           relatedTerm={undefined}
+        />
+      )}
+
+      {editRowModal && selectedRowItem?._itemType === "term" && (
+        <AddUpdateTermForm
+          open={editRowModal}
+          isAdd={false}
+          onClose={() => setEditRowModal(false)}
+          node={undefined}
+          dataObj={{
+            ...selectedRowItem,
+            guid: selectedRowItem.termGuid || selectedRowItem.guid || selectedRowItem.id,
+            name: selectedRowItem.displayText,
+            shortDescription: selectedRowItem.shortDescription || selectedRowItem.description || "",
+            longDescription: selectedRowItem.longDescription || "",
+            anchor: {
+              glossaryGuid: gtypeParams === "glossary" ? (data?.guid || guid) : data?.anchor?.glossaryGuid,
+              displayText: gtypeParams === "glossary" ? data?.name : data?.anchor?.displayText
+            }
+          }}
+        />
+      )}
+
+      {editRowModal && selectedRowItem?._itemType === "category" && (
+        <AddUpdateCategoryForm
+          open={editRowModal}
+          isAdd={false}
+          onClose={() => setEditRowModal(false)}
+          node={undefined}
+          dataObj={{
+            ...selectedRowItem,
+            guid: selectedRowItem.categoryGuid || selectedRowItem.guid || selectedRowItem.id,
+            name: selectedRowItem.displayText,
+            shortDescription: selectedRowItem.shortDescription || selectedRowItem.description || "",
+            longDescription: selectedRowItem.longDescription || "",
+            anchor: {
+              glossaryGuid: gtypeParams === "glossary" ? (data?.guid || guid) : data?.anchor?.glossaryGuid,
+              displayText: gtypeParams === "glossary" ? data?.name : data?.anchor?.displayText
+            }
+          }}
+        />
+      )}
+
+      {deleteRowModal && (
+        <DeleteGlossary
+          open={deleteRowModal}
+          onClose={() => setDeleteRowModal(false)}
+          setExpandNode={undefined}
+          node={{
+            id: selectedRowItem?.displayText,
+            guid: selectedRowItem?.termGuid || selectedRowItem?.guid || selectedRowItem?.id,
+            cGuid: selectedRowItem?.termGuid || selectedRowItem?.categoryGuid || selectedRowItem?.guid || selectedRowItem?.id,
+            types: selectedRowItem?._itemType === "category" ? "Category" : "Term"
+          }}
+          updatedData={handleTableUpdate}
+        />
+      )}
+      {createTermModal && (
+        <AddUpdateTermForm
+          open={createTermModal}
+          isAdd={true}
+          onClose={() => setCreateTermModal(false)}
+          node={{
+            id: data?.name,
+            parent: gtypeParams === "glossary" ? data?.name : data?.anchor?.displayText,
+            guid: data?.guid || guid,
+            cGuid: data?.guid || guid,
+            types: gtypeParams === "glossary" ? "Glossary" : "Category"
+          }}
+          dataObj={undefined}
+        />
+      )}
+      {createCategoryModal && (
+        <AddUpdateCategoryForm
+          open={createCategoryModal}
+          isAdd={true}
+          onClose={() => setCreateCategoryModal(false)}
+          node={{
+            id: data?.name,
+            parent: gtypeParams === "glossary" ? data?.name : data?.anchor?.displayText,
+            guid: data?.guid || guid,
+            cGuid: data?.guid || guid,
+            types: gtypeParams === "glossary" ? "Glossary" : "Category"
+          }}
+          dataObj={undefined}
         />
       )}
     </>

--- a/dashboard/src/views/DetailPage/GlossaryDetails/GlossaryDetailsLayout.tsx
+++ b/dashboard/src/views/DetailPage/GlossaryDetails/GlossaryDetailsLayout.tsx
@@ -56,6 +56,7 @@ const GlossaryDetailLayout = () => {
 
   useEffect(() => {
     let params: any = { gtype: gtype, guid: guid };
+
     dispatchApi(fetchGlossaryDetails(params));
   }, [guid]);
 

--- a/dashboard/src/views/DetailPage/__tests__/DetailPageAttributes.test.tsx
+++ b/dashboard/src/views/DetailPage/__tests__/DetailPageAttributes.test.tsx
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import "@testing-library/jest-dom"
 import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
@@ -50,8 +51,10 @@ jest.mock('@utils/Utils', () => {
 })
 
 const mockUseAppSelector = jest.fn()
+const mockUseAppDispatch = jest.fn(() => jest.fn())
 jest.mock('@hooks/reducerHook', () => ({
 	useAppSelector: (fn: (s: unknown) => unknown) => mockUseAppSelector(fn),
+	useAppDispatch: () => mockUseAppDispatch(),
 }))
 
 jest.mock('@components/ShowMore/ShowMoreText', () => ({
@@ -334,6 +337,13 @@ describe('DetailPageAttribute', () => {
 		fireEvent.click(screen.getByText('close-category'))
 	})
 
+	it('shows edit button when gtype is glossary', () => {
+		mockGtype = 'glossary'
+		mockParams.guid = 'g-glossary'
+		renderComp()
+		expect(document.querySelector('[data-cy="addTag"]')).not.toBeNull()
+	})
+
 	it('hides edit button when bmguid present', () => {
 		mockParams.bmguid = 'bm-1'
 		renderComp()
@@ -366,6 +376,14 @@ describe('DetailPageAttribute', () => {
 		fireEvent.click(screen.getByText('close-assign-term'))
 	})
 
+	it('glossary page shows terms but hides Add Term button', () => {
+		mockGtype = 'glossary'
+		mockParams.guid = 'gc'
+		renderComp()
+		expect(screen.queryByTestId('smv-Terms')).toBeNull()
+		expect(document.querySelector('[data-title="Add Term"]')).toBeNull()
+	})
+
 	it('toast when no glossary terms available for assign term', () => {
 		mockGtype = 'category'
 		mockParams.guid = 'gc'
@@ -390,6 +408,14 @@ describe('DetailPageAttribute', () => {
 		tooltipIconClick('Add Categories')
 		expect(screen.getByTestId('assign-category')).toBeInTheDocument()
 		fireEvent.click(screen.getByText('close-assign-cat'))
+	})
+
+	it('glossary page shows categories but hides Add Categories button', () => {
+		mockGtype = 'glossary'
+		mockParams.guid = 'gt'
+		renderComp()
+		expect(screen.queryByTestId('smv-Category')).toBeNull()
+		expect(document.querySelector('[data-title="Add Categories"]')).toBeNull()
 	})
 
 	it('superTypes section loading and loaded', () => {
@@ -518,7 +544,7 @@ describe('DetailPageAttribute', () => {
 			superTypes: [],
 			subTypes: [],
 		})
-		expect(screen.getByTestId('smv-Terms')).toBeInTheDocument()
+		expect(screen.getAllByText('N/A').length).toBeGreaterThan(0)
 	})
 
 	it('term Categories list tolerates null entity data via optional chaining', () => {
@@ -529,7 +555,7 @@ describe('DetailPageAttribute', () => {
 			superTypes: [],
 			subTypes: [],
 		})
-		expect(screen.getByTestId('smv-Category')).toBeInTheDocument()
+		expect(screen.getAllByText('N/A').length).toBeGreaterThan(0)
 	})
 
 	it('Sub Classifications ShowMore tolerates null entity data', () => {

--- a/dashboard/src/views/Glossary/AddUpdateCategoryForm.tsx
+++ b/dashboard/src/views/Glossary/AddUpdateCategoryForm.tsx
@@ -37,8 +37,9 @@ const AddUpdateCategoryForm = (props: {
   isAdd: any;
   node: Record<string, any> | undefined;
   dataObj: any;
+  updatedData?: any;
 }) => {
-  const { open, onClose, isAdd, node, dataObj } = props;
+  const { open, onClose, isAdd, node, dataObj, updatedData } = props;
   const { id, parent, types, cGuid } = node || {};
   const { guid: glossaryTypeGuid }: any = useParams();
   const dispatchApi = useAppDispatch();
@@ -118,12 +119,21 @@ const AddUpdateCategoryForm = (props: {
       }
       if (isAdd) {
         dispatchApi(fetchGlossaryData());
+        if (gType && glossaryTypeGuid) {
+          let params: any = { gtype: gType, guid: glossaryTypeGuid };
+          dispatchApi(fetchGlossaryDetails(params));
+          dispatchApi(fetchDetailPageData(glossaryTypeGuid as string));
+        }
       } else {
         if (!isEmpty(dataObj)) {
           let params: any = { gtype: gType, guid: glossaryTypeGuid };
           dispatchApi(fetchGlossaryData());
-          dispatchApi(fetchGlossaryDetails(params));
-          dispatchApi(fetchDetailPageData(dataObj.guid as string));
+          if (updatedData) {
+            updatedData();
+          } else {
+            dispatchApi(fetchGlossaryDetails(params));
+            dispatchApi(fetchDetailPageData(dataObj.guid as string));
+          }
         }
       }
       toast.dismiss(toastId.current);

--- a/dashboard/src/views/Glossary/AddUpdateGlossaryForm.tsx
+++ b/dashboard/src/views/Glossary/AddUpdateGlossaryForm.tsx
@@ -57,14 +57,22 @@ const hasSelectedImportFile = (fileData: unknown): boolean => {
 		return true;
 	return false;
 };
+import { useLocation, useParams } from "react-router-dom";
+import { fetchGlossaryDetails } from "@redux/slice/glossaryDetailsSlice";
+import { fetchDetailPageData } from "@redux/slice/detailPageSlice";
 
 const AddUpdateGlossaryForm = (props: {
 	open: any;
 	onClose: any;
 	isAdd: any;
 	node: Record<string, any> | undefined;
+	dataObj?: any;
 }) => {
-	const { open, onClose, isAdd, node } = props;
+	const { open, onClose, isAdd, node, dataObj } = props;
+	const { guid: glossaryGuid } = useParams();
+	const location = useLocation();
+	const searchParams = new URLSearchParams(location.search);
+	const gType: string | undefined | null = searchParams.get("gtype");
 	const dispatch = useAppDispatch();
 	const toastId: any = useRef(null);
 	const { glossaryData }: any = useAppSelector((state: any) => state.glossary);
@@ -75,314 +83,325 @@ const AddUpdateGlossaryForm = (props: {
 		glossaryObj = glossaryData.find((obj: { name: string }) => {
 			return obj.name == id;
 		});
-		const { name, shortDescription, longDescription } = glossaryObj || {};
+		const { name, shortDescription } = glossaryObj || {};
+		const longDescription = dataObj?.longDescription || glossaryObj?.longDescription || "";
 
 		defaultValue["name"] = name;
 		defaultValue["shortDescription"] = shortDescription;
 		defaultValue["longDescription"] = longDescription;
 	}
-	const {
-		control,
-		handleSubmit,
-		setValue,
-		formState: { isSubmitting }
-	} = useForm({
-		defaultValues: isAdd ? {} : defaultValue,
-		mode: "onChange",
-		shouldUnregister: true
-	});
+		const {
+			control,
+			handleSubmit,
+			setValue,
+			formState: { isSubmitting }
+		} = useForm({
+			defaultValues: isAdd ? {} : defaultValue,
+			mode: "onChange",
+			shouldUnregister: true
+		});
 
-	const [glossaryCreateTab, setGlossaryCreateTab] =
-		useState<GlossaryCreateTab>("create");
-	const [importFileData, setImportFileData] = useState<any>([]);
-	const [importProgress, setImportProgress] = useState(0);
-	const [importErrorDetails, setImportErrorDetails] = useState(false);
-	const [importData, setImportData] = useState<any>(null);
-	const [importUploading, setImportUploading] = useState(false);
+		const [glossaryCreateTab, setGlossaryCreateTab] =
+			useState<GlossaryCreateTab>("create");
+		const [importFileData, setImportFileData] = useState<any>([]);
+		const [importProgress, setImportProgress] = useState(0);
+		const [importErrorDetails, setImportErrorDetails] = useState(false);
+		const [importData, setImportData] = useState<any>(null);
+		const [importUploading, setImportUploading] = useState(false);
 
-	const resetImportUi = useCallback(() => {
-		setGlossaryCreateTab("create");
-		setImportFileData([]);
-		setImportProgress(0);
-		setImportErrorDetails(false);
-		setImportData(null);
-		setImportUploading(false);
-	}, []);
-
-	const handleModalClose = useCallback(() => {
-		resetImportUi();
-		onClose();
-	}, [onClose, resetImportUi]);
-
-	useEffect(() => {
-		if (!open) {
-			resetImportUi();
-		}
-	}, [open, resetImportUi]);
-
-	const handleGlossaryCreateTabChange = (
-		_event: MouseEvent<HTMLElement>,
-		next: GlossaryCreateTab | null
-	) => {
-		if (next == null) return;
-		setGlossaryCreateTab(next);
-		if (next === "create") {
+		const resetImportUi = useCallback(() => {
+			setGlossaryCreateTab("create");
 			setImportFileData([]);
 			setImportProgress(0);
 			setImportErrorDetails(false);
 			setImportData(null);
-		}
-	};
+			setImportUploading(false);
+		}, []);
 
-	const handleDownloadTemplate = async () => {
-		try {
-			await downloadGlossaryImportTemplate();
-		} catch {
-			toast.dismiss(toastId.current);
-			toastId.current = toast.error("Could not download template");
-		}
-	};
+		const handleModalClose = useCallback(() => {
+			resetImportUi();
+			onClose();
+		}, [onClose, resetImportUi]);
 
-	const handleImportUpload = async () => {
-		if (!hasSelectedImportFile(importFileData)) return;
-		setImportUploading(true);
-		try {
-			const importResp = await postGlossaryImportFormData(
-				importFileData,
-				(pct) => setImportProgress(pct)
-			);
-			if (importResp.data.failedImportInfoList == undefined) {
+		useEffect(() => {
+			if (!open) {
+				resetImportUi();
+			}
+		}, [open, resetImportUi]);
+
+		const handleGlossaryCreateTabChange = (
+			_event: MouseEvent<HTMLElement>,
+			next: GlossaryCreateTab | null
+		) => {
+			if (next == null) return;
+			setGlossaryCreateTab(next);
+			if (next === "create") {
+				setImportFileData([]);
+				setImportProgress(0);
+				setImportErrorDetails(false);
+				setImportData(null);
+			}
+		};
+
+		const handleDownloadTemplate = async () => {
+			try {
+				await downloadGlossaryImportTemplate();
+			} catch {
+				toast.dismiss(toastId.current);
+				toastId.current = toast.error("Could not download template");
+			}
+		};
+
+		const handleImportUpload = async () => {
+			if (!hasSelectedImportFile(importFileData)) return;
+			setImportUploading(true);
+			try {
+				const importResp = await postGlossaryImportFormData(
+					importFileData,
+					(pct) => setImportProgress(pct)
+				);
+				if (importResp.data.failedImportInfoList == undefined) {
+					toast.dismiss(toastId.current);
+					toastId.current = toast.success(
+						`File: ${importFileData.name} imported successfully`
+					);
+					await dispatch(fetchGlossaryData());
+					handleModalClose();
+					return;
+				}
+				if (importResp.data.failedImportInfoList != undefined) {
+					toast.dismiss(toastId.current);
+					toastId.current = toast.error(
+						importResp.data.failedImportInfoList[0].remarks
+					);
+					setImportErrorDetails(true);
+				}
+				setImportData(importResp.data);
+			} catch (error) {
+				const message = getApiErrorToastMessage(error);
+				if (message === null) {
+					return;
+				}
+				toast.dismiss(toastId.current);
+				toastId.current = toast.error(message);
+			} finally {
+				setImportUploading(false);
+			}
+		};
+
+		const onSubmit = async (formValues: any) => {
+			let formData = { ...formValues };
+			const { guid, qualifiedName } = glossaryObj;
+			const {
+				name,
+				shortDescription,
+				longDescription
+			}: { name: string; shortDescription: string; longDescription: string } =
+				formData;
+			let data: Record<string, string> = {};
+			if (!isAdd) {
+				data["guid"] = guid;
+				data["qualifiedName"] = qualifiedName;
+			}
+			data["name"] = name;
+			data["shortDescription"] = !isEmpty(shortDescription)
+				? shortDescription
+				: "";
+			data["longDescription"] = !isEmpty(longDescription) ? longDescription : "";
+
+			try {
+				if (isAdd) {
+					await createGlossary(data);
+				} else {
+					await editGlossary(guid, data);
+				}
+
+				await dispatch(fetchGlossaryData());
+
+				if (!isAdd && glossaryGuid) {
+					let params: any = { gtype: gType, guid: glossaryGuid };
+					dispatch(fetchGlossaryDetails(params));
+					dispatch(fetchDetailPageData(glossaryGuid as string));
+				}
+
 				toast.dismiss(toastId.current);
 				toastId.current = toast.success(
-					`File: ${importFileData.name} imported successfully`
+					`Glossary ${name} was ${isAdd ? "created" : "updated"} successfully`
 				);
-				await dispatch(fetchGlossaryData());
 				handleModalClose();
-				return;
-			}
-			if (importResp.data.failedImportInfoList != undefined) {
-				toast.dismiss(toastId.current);
-				toastId.current = toast.error(
-					importResp.data.failedImportInfoList[0].remarks
+			} catch (error) {
+				console.log(
+					`Error occur while ${isAdd ? "created" : "updated"} Glossary`,
+					error
 				);
-				setImportErrorDetails(true);
+				serverError(error, toastId);
 			}
-			setImportData(importResp.data);
-		} catch (error) {
-			const message = getApiErrorToastMessage(error);
-			if (message === null) {
-				return;
-			}
-			toast.dismiss(toastId.current);
-			toastId.current = toast.error(message);
-		} finally {
-			setImportUploading(false);
-		}
-	};
+		};
 
-	const onSubmit = async (formValues: any) => {
-		let formData = { ...formValues };
-		const { guid, qualifiedName } = glossaryObj;
-		const {
-			name,
-			shortDescription,
-			longDescription
-		}: { name: string; shortDescription: string; longDescription: string } =
-			formData;
-		let data: Record<string, string> = {};
-		if (!isAdd) {
-			data["guid"] = guid;
-			data["qualifiedName"] = qualifiedName;
-		}
-		data["name"] = name;
-		data["shortDescription"] = !isEmpty(shortDescription)
-			? shortDescription
-			: "";
-		data["longDescription"] = !isEmpty(longDescription) ? longDescription : "";
+		const showImportError = isAdd && glossaryCreateTab === "import" && importErrorDetails;
 
-		try {
-			if (isAdd) {
-				await createGlossary(data);
-			} else {
-				await editGlossary(guid, data);
-			}
+		const modalTitle = showImportError
+			? "Error Details"
+			: isAdd
+				? "Create Glossary"
+				: "Edit Glossary";
 
-			await dispatch(fetchGlossaryData());
-			toast.dismiss(toastId.current);
-			toastId.current = toast.success(
-				`Glossary ${name} was ${isAdd ? "created" : "updated"} successfully`
-			);
-			handleModalClose();
-		} catch (error) {
-			serverError(error, toastId);
-		}
-	};
+		const titleIconNode =
+			showImportError ? (
+				<IconButton
+					aria-label="Back to import file"
+					onClick={(e) => {
+						e.stopPropagation();
+						setImportErrorDetails(false);
+					}}
+					size="small"
+					sx={{ color: (theme) => theme.palette.grey[500] }}
+				>
+					<LightTooltip title="Back to import file">
+						<ArrowBackIosNewIcon sx={{ fontSize: "1.25rem" }} />
+					</LightTooltip>
+				</IconButton>
+			) : undefined;
 
-	const showImportError = isAdd && glossaryCreateTab === "import" && importErrorDetails;
+		const isImportMode = isAdd && glossaryCreateTab === "import" && !importErrorDetails;
 
-	const modalTitle = showImportError
-		? "Error Details"
-		: isAdd
-			? "Create Glossary"
-			: "Edit Glossary";
+		const button2Label = (() => {
+			if (!isAdd) return "Update";
+			if (glossaryCreateTab === "create") return "Create";
+			if (importErrorDetails) return "";
+			return "Upload";
+		})();
 
-	const titleIconNode =
-		showImportError ? (
-			<IconButton
-				aria-label="Back to import file"
-				onClick={(e) => {
-					e.stopPropagation();
-					setImportErrorDetails(false);
-				}}
-				size="small"
-				sx={{ color: (theme) => theme.palette.grey[500] }}
-			>
-				<LightTooltip title="Back to import file">
-					<ArrowBackIosNewIcon sx={{ fontSize: "1.25rem" }} />
-				</LightTooltip>
-			</IconButton>
-		) : undefined;
+		const button2Handler = (() => {
+			if (!isAdd || glossaryCreateTab === "create") return handleSubmit(onSubmit);
+			if (importErrorDetails) return () => { };
+			return handleImportUpload;
+		})();
 
-	const isImportMode = isAdd && glossaryCreateTab === "import" && !importErrorDetails;
+		const disableButton2 = (() => {
+			if (!isAdd) return isSubmitting;
+			if (glossaryCreateTab === "create") return isSubmitting;
+			if (importErrorDetails) return true;
+			return !hasSelectedImportFile(importFileData);
+		})();
 
-	const button2Label = (() => {
-		if (!isAdd) return "Update";
-		if (glossaryCreateTab === "create") return "Create";
-		if (importErrorDetails) return "";
-		return "Upload";
-	})();
+		const button2Loading =
+			isAdd && glossaryCreateTab === "import" && !importErrorDetails
+				? importUploading
+				: isSubmitting;
 
-	const button2Handler = (() => {
-		if (!isAdd || glossaryCreateTab === "create") return handleSubmit(onSubmit);
-		if (importErrorDetails) return () => {};
-		return handleImportUpload;
-	})();
-
-	const disableButton2 = (() => {
-		if (!isAdd) return isSubmitting;
-		if (glossaryCreateTab === "create") return isSubmitting;
-		if (importErrorDetails) return true;
-		return !hasSelectedImportFile(importFileData);
-	})();
-
-	const button2Loading =
-		isAdd && glossaryCreateTab === "import" && !importErrorDetails
-			? importUploading
-			: isSubmitting;
-
-	const hideButton2 = Boolean(
-		isAdd && glossaryCreateTab === "import" && importErrorDetails
-	);
-
-	return (
-		<>
-			<CustomModal
-				open={open}
-				onClose={handleModalClose}
-				title={modalTitle}
-				titleIcon={titleIconNode}
-				button1Label="Cancel"
-				button1Handler={handleModalClose}
-				button2Label={button2Label}
-				maxWidth="sm"
-				button2Handler={button2Handler}
-				disableButton2={disableButton2}
-				button2Loading={button2Loading}
-				hideButton2={hideButton2}
-			>
-				<Stack>
-					{isAdd && (
-						<Stack marginBottom="1rem">
-							<ToggleButtonGroup
-								exclusive
-								value={glossaryCreateTab}
-								onChange={handleGlossaryCreateTabChange}
-								size="small"
-								color="primary"
-								aria-label="Choose create glossary or import glossary terms"
-							>
-								<ToggleButton
-									value="create"
-									className="entity-form-toggle-btn"
-									data-cy="create-glossary-tab"
-								>
-									Create glossary
-								</ToggleButton>
-								<ToggleButton
-									value="import"
-									className="entity-form-toggle-btn"
-									data-cy="import-glossary-terms-tab"
-								>
-									Import glossary terms
-								</ToggleButton>
-							</ToggleButtonGroup>
-						</Stack>
-					)}
-					{(!isAdd || glossaryCreateTab === "create") && (
-						<GlossaryForm
-							control={control}
-							handleSubmit={handleSubmit(onSubmit)}
-							setValue={setValue}
-						/>
-					)}
-					{isImportMode && (
-						<Stack gap={2}>
-							<Button
-								variant="outlined"
-								color="primary"
-								startIcon={<FileDownloadIcon />}
-								onClick={handleDownloadTemplate}
-								aria-label="Download import template"
-							>
-								Download import template
-							</Button>
-							<ImportLayout
-								setFileData={setImportFileData}
-								progressVal={importProgress}
-								setProgress={setImportProgress}
-								selectedFile={
-									importFileData !== undefined &&
-									hasSelectedImportFile(importFileData)
-										? [importFileData]
-										: []
-								}
-								errorDetails={importErrorDetails}
-							/>
-						</Stack>
-					)}
-					{showImportError && importData?.failedImportInfoList && (
-						<Stack
-							sx={{
-								width: "100%",
-								minHeight: 200,
-								maxHeight: 400,
-								bgcolor: "background.paper"
-							}}
+		const hideButton2 = Boolean(
+			isAdd && glossaryCreateTab === "import" && importErrorDetails
+		);
+		return (
+			<>
+		<CustomModal
+			open={open}
+			onClose={handleModalClose}
+			title={modalTitle}
+			titleIcon={titleIconNode}
+			button1Label="Cancel"
+			button1Handler={handleModalClose}
+			button2Label={button2Label}
+			maxWidth="sm"
+			button2Handler={button2Handler}
+			disableButton2={disableButton2}
+			button2Loading={button2Loading}
+			hideButton2={hideButton2}
+		>
+			<Stack>
+				{isAdd && (
+					<Stack marginBottom="1rem">
+						<ToggleButtonGroup
+							exclusive
+							value={glossaryCreateTab}
+							onChange={handleGlossaryCreateTabChange}
+							size="small"
+							color="primary"
+							aria-label="Choose create glossary or import glossary terms"
 						>
-							<List>
-								{importData.failedImportInfoList.map(
-									(
-										value: {
-											index: number;
-											remarks: string;
-										},
-										index: number
-									) => (
-										<ListItem key={value.index} disableGutters disablePadding>
-											<ListItemText
-												className="dropzone-listitem"
-												primary={`${index + 1}. ${value.remarks}`}
-											/>
-										</ListItem>
-									)
-								)}
-							</List>
-						</Stack>
-					)}
-				</Stack>
-			</CustomModal>
-		</>
-	);
+							<ToggleButton
+								value="create"
+								className="entity-form-toggle-btn"
+								data-cy="create-glossary-tab"
+							>
+								Create glossary
+							</ToggleButton>
+							<ToggleButton
+								value="import"
+								className="entity-form-toggle-btn"
+								data-cy="import-glossary-terms-tab"
+							>
+								Import glossary terms
+							</ToggleButton>
+						</ToggleButtonGroup>
+					</Stack>
+				)}
+				{(!isAdd || glossaryCreateTab === "create") && (
+					<GlossaryForm
+						control={control}
+						handleSubmit={handleSubmit(onSubmit)}
+						setValue={setValue}
+					/>
+				)}
+				{isImportMode && (
+					<Stack gap={2}>
+						<Button
+							variant="outlined"
+							color="primary"
+							startIcon={<FileDownloadIcon />}
+							onClick={handleDownloadTemplate}
+							aria-label="Download import template"
+						>
+							Download import template
+						</Button>
+						<ImportLayout
+							setFileData={setImportFileData}
+							progressVal={importProgress}
+							setProgress={setImportProgress}
+							selectedFile={
+								importFileData !== undefined &&
+									hasSelectedImportFile(importFileData)
+									? [importFileData]
+									: []
+							}
+							errorDetails={importErrorDetails}
+						/>
+					</Stack>
+				)}
+				{showImportError && importData?.failedImportInfoList && (
+					<Stack
+						sx={{
+							width: "100%",
+							minHeight: 200,
+							maxHeight: 400,
+							bgcolor: "background.paper"
+						}}
+					>
+						<List>
+							{importData.failedImportInfoList.map(
+								(
+									value: {
+										index: number;
+										remarks: string;
+									},
+									index: number
+								) => (
+									<ListItem key={value.index} disableGutters disablePadding>
+										<ListItemText
+											className="dropzone-listitem"
+											primary={`${index + 1}. ${value.remarks}`}
+										/>
+									</ListItem>
+								)
+							)}
+						</List>
+					</Stack>
+				)}
+			</Stack>
+		</CustomModal>
+	</>
+);
 };
 
 export default AddUpdateGlossaryForm;

--- a/dashboard/src/views/Glossary/AddUpdateTermForm.tsx
+++ b/dashboard/src/views/Glossary/AddUpdateTermForm.tsx
@@ -37,8 +37,9 @@ const AddUpdateTermForm = (props: {
   isAdd: any;
   node: Record<string, any> | undefined;
   dataObj: any;
+  updatedData?: any;
 }) => {
-  const { open, onClose, isAdd, node, dataObj } = props;
+  const { open, onClose, isAdd, node, dataObj, updatedData } = props;
   const { id, parent } = node || {};
   const dispatchApi = useAppDispatch();
   const location = useLocation();
@@ -114,12 +115,21 @@ const AddUpdateTermForm = (props: {
       }
       if (isAdd) {
         dispatchApi(fetchGlossaryData());
+        if (gType && entityGuid) {
+          let params: any = { gtype: gType, guid: entityGuid };
+          dispatchApi(fetchGlossaryDetails(params));
+          dispatchApi(fetchDetailPageData(entityGuid as string));
+        }
       } else {
         if (!isEmpty(dataObj)) {
           let params: any = { gtype: gType, guid: entityGuid };
           dispatchApi(fetchGlossaryData());
-          dispatchApi(fetchGlossaryDetails(params));
-          dispatchApi(fetchDetailPageData(dataObj.guid as string));
+          if (updatedData) {
+            updatedData();
+          } else {
+            dispatchApi(fetchGlossaryDetails(params));
+            dispatchApi(fetchDetailPageData(dataObj.guid as string));
+          }
         }
       }
       toast.dismiss(toastId.current);

--- a/dashboard/src/views/Glossary/DeleteGlossary.tsx
+++ b/dashboard/src/views/Glossary/DeleteGlossary.tsx
@@ -17,7 +17,8 @@
 
 import {
   deleteGlossaryorTerm,
-  deleteGlossaryorType
+  deleteGlossaryorType,
+  deleteCategory
 } from "@api/apiMethods/glossaryApiMethod";
 import CustomModal from "@components/Modal";
 import { useAppDispatch } from "@hooks/reducerHook";
@@ -27,7 +28,7 @@ import { fetchGlossaryData } from "@redux/slice/glossarySlice";
 import { isEmpty, serverError } from "@utils/Utils";
 import { useRef } from "react";
 import { useAsyncPending } from "@hooks/useAsyncPending";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 
 const DeleteGlossary = (props: {
@@ -40,10 +41,8 @@ const DeleteGlossary = (props: {
   const { open, onClose, setExpandNode, node, updatedData } = props;
   const { id, guid, cGuid, types } = node;
   const gtype: string | undefined | null =
-    types != "parent" ? "term" : "glossary";
-  const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
-  const glossaryType = searchParams.get("gtype");
+    types == "Category" ? "category" : types != "parent" ? "term" : "glossary";
+
   const { guid: glossaryGuid } = useParams();
 
   const navigate = useNavigate();
@@ -58,17 +57,27 @@ const DeleteGlossary = (props: {
   const handleRemove = () => {
     void runDelete(async () => {
       try {
-        gtype == "term"
+        gtype == "category"
+          ? await deleteCategory(cGuid)
+          : gtype == "term"
           ? await deleteGlossaryorType(cGuid)
           : await deleteGlossaryorTerm(guid);
-        updatedData();
+        onClose();
+        updatedData?.();
         await fetchCurrentData();
         toast.success(
           `${
-            gtype == "term" ? "Term" : "Glossary"
+            gtype == "category"
+              ? "Category"
+              : gtype == "term"
+              ? "Term"
+              : "Glossary"
           } ${id} was deleted successfully`
         );
-        if (!isEmpty(glossaryGuid) || !isEmpty(glossaryType)) {
+        if (
+          (!isEmpty(glossaryGuid) && glossaryGuid === guid) ||
+          (!isEmpty(glossaryGuid) && glossaryGuid === cGuid)
+        ) {
           navigate(
             {
               pathname: "/"
@@ -76,7 +85,6 @@ const DeleteGlossary = (props: {
             { replace: true }
           );
         }
-        onClose();
         setExpandNode(null);
       } catch (error) {
         serverError(error, toastId);
@@ -101,7 +109,11 @@ const DeleteGlossary = (props: {
       >
         <Typography fontSize={15}>
           Are you sure you want to delete{" "}
-          {gtype == "term" ? "Term" : "Glossary"}
+          {gtype == "category"
+            ? "Category"
+            : gtype == "term"
+            ? "Term"
+            : "Glossary"}
         </Typography>
       </CustomModal>
     </>

--- a/dashboard/src/views/Glossary/GlossaryForm.tsx
+++ b/dashboard/src/views/Glossary/GlossaryForm.tsx
@@ -29,9 +29,9 @@ import ReactQuill from "react-quill-new";
 const GlossaryForm = (props: {
   control: any;
   handleSubmit: any;
-  setValue: any;
+  setValue?: any;
 }) => {
-  const { control, handleSubmit, setValue } = props;
+  const { control, handleSubmit } = props;
   const [alignment, setAlignment] = useState<string>("formatted");
 
   const handleChange = (
@@ -146,7 +146,6 @@ const GlossaryForm = (props: {
                         placeholder={"Description required"}
                         onChange={(text) => {
                           field.onChange(text);
-                          setValue("description", text);
                         }}
                         className="classification-form-editor"
                         value={field.value || ""}
@@ -161,7 +160,6 @@ const GlossaryForm = (props: {
                         e.stopPropagation();
                         const value = e.target.value;
                         field.onChange(value);
-                        setValue("description", value);
                       }}
                       style={{ width: "100%" }}
                     />

--- a/dashboard/src/views/Glossary/__tests__/AddUpdateCategoryForm.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/AddUpdateCategoryForm.test.tsx
@@ -27,9 +27,9 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
 import AddUpdateCategoryForm from '../AddUpdateCategoryForm';
-import * as glossarySlice from '@redux/slice/glossarySlice';
-import * as glossaryDetailsSlice from '@redux/slice/glossaryDetailsSlice';
-import * as detailPageSlice from '@redux/slice/detailPageSlice';
+import * as glossarySlice from '../../../redux/slice/glossarySlice';
+import * as glossaryDetailsSlice from '../../../redux/slice/glossaryDetailsSlice';
+import * as detailPageSlice from '../../../redux/slice/detailPageSlice';
 
 // Mock functions
 const mockOnClose = jest.fn();
@@ -59,34 +59,34 @@ const mockToastSuccess = jest.fn();
 const mockToastDismiss = jest.fn();
 jest.mock('react-toastify', () => ({
 	toast: {
-		success: (...args: any[]) => mockToastSuccess(...args),
-		dismiss: (...args: any[]) => mockToastDismiss(...args),
+		success: function() { return mockToastSuccess.apply(null, arguments as any); },
+		dismiss: function() { return mockToastDismiss.apply(null, arguments as any); },
 		error: jest.fn()
 	}
 }));
 
 // Mock API methods
-jest.mock('@api/apiMethods/glossaryApiMethod', () => ({
-	createTermorCategory: (...args: any[]) => mockCreateTermorCategory(...args),
-	editTermorCatgeory: (...args: any[]) => mockEditTermorCatgeory(...args)
+jest.mock('../../../api/apiMethods/glossaryApiMethod', () => ({
+	createTermorCategory: function() { return mockCreateTermorCategory.apply(null, arguments as any); },
+	editTermorCatgeory: function() { return mockEditTermorCatgeory.apply(null, arguments as any); }
 }));
 
 // Mock Redux slices
-jest.mock('@redux/slice/glossarySlice', () => ({
+jest.mock('../../../redux/slice/glossarySlice', () => ({
 	fetchGlossaryData: jest.fn()
 }));
 
-jest.mock('@redux/slice/glossaryDetailsSlice', () => ({
+jest.mock('../../../redux/slice/glossaryDetailsSlice', () => ({
 	fetchGlossaryDetails: jest.fn()
 }));
 
-jest.mock('@redux/slice/detailPageSlice', () => ({
+jest.mock('../../../redux/slice/detailPageSlice', () => ({
 	fetchDetailPageData: jest.fn()
 }));
 
 // Mock Utils
-jest.mock('@utils/Utils', () => {
-	const actualUtils = jest.requireActual('@utils/Utils');
+jest.mock('../../../utils/Utils', () => {
+	const actualUtils = jest.requireActual('../../../utils/Utils');
 	return {
 		...actualUtils,
 		isEmpty: (value: any) => {
@@ -95,12 +95,12 @@ jest.mock('@utils/Utils', () => {
 			if (typeof value === 'string' && value.trim().length === 0) return true;
 			return false;
 		},
-		serverError: (...args: any[]) => mockServerError(...args)
+		serverError: function() { return mockServerError.apply(null, arguments as any); }
 	};
 });
 
 // Mock CustomModal
-jest.mock('@components/Modal', () => ({
+jest.mock('../../../components/Modal', () => ({
 	__esModule: true,
 	default: ({ open, onClose, children, title, button1Handler, button2Handler, button2Label, disableButton2 }: any) =>
 		open ? (
@@ -222,18 +222,18 @@ describe('AddUpdateCategoryForm', () => {
 		mockToastSuccess.mockReturnValue('toast-id-123');
 		
 		// Set up Redux action mocks
-		(glossarySlice.fetchGlossaryData as jest.Mock).mockImplementation((...args: any[]) => {
-			mockFetchGlossaryData(...args);
+		(glossarySlice.fetchGlossaryData as unknown as jest.Mock).mockImplementation(function() {
+			mockFetchGlossaryData.apply(null, arguments as any);
 			return { type: 'FETCH_GLOSSARY_DATA' };
 		});
 		
-		(glossaryDetailsSlice.fetchGlossaryDetails as jest.Mock).mockImplementation((...args: any[]) => {
-			mockFetchGlossaryDetails(...args);
+		(glossaryDetailsSlice.fetchGlossaryDetails as unknown as jest.Mock).mockImplementation(function() {
+			mockFetchGlossaryDetails.apply(null, arguments as any);
 			return { type: 'FETCH_GLOSSARY_DETAILS' };
 		});
 		
-		(detailPageSlice.fetchDetailPageData as jest.Mock).mockImplementation((...args: any[]) => {
-			mockFetchDetailPageData(...args);
+		(detailPageSlice.fetchDetailPageData as unknown as jest.Mock).mockImplementation(function() {
+			mockFetchDetailPageData.apply(null, arguments as any);
 			return { type: 'FETCH_DETAIL_PAGE_DATA' };
 		});
 	});
@@ -387,6 +387,44 @@ describe('AddUpdateCategoryForm', () => {
 			// Verify modal was closed
 			expect(mockOnClose).toHaveBeenCalled();
 		}, 30000);
+
+		it('should dispatch fetchGlossaryDetails and fetchDetailPageData when creating category successfully in add mode and URL has gtype and guid', async () => {
+			mockLocation = { search: '?gtype=glossary' };
+			mockParams = { guid: 'entity-guid-456' };
+
+			const store = createStore([
+				{
+					name: 'Parent Glossary',
+					guid: 'parent-guid',
+					shortDescription: 'Parent Short Desc',
+					longDescription: 'Parent Long Desc'
+				}
+			]);
+
+			render(
+				<Provider store={store}>
+					<MemoryRouter>
+						<AddUpdateCategoryForm
+							open={true}
+							onClose={mockOnClose}
+							isAdd={true}
+							node={{ id: 'test-id', parent: 'Parent Glossary' }}
+							dataObj={{ name: 'Test Category' }}
+						/>
+					</MemoryRouter>
+				</Provider>
+			);
+
+			await fillFormAndSubmit('Test Category');
+
+			await waitFor(() => {
+				expect(mockFetchGlossaryDetails).toHaveBeenCalledWith({ gtype: 'glossary', guid: 'entity-guid-456' });
+			}, { timeout: 10000 });
+
+			await waitFor(() => {
+				expect(mockFetchDetailPageData).toHaveBeenCalledWith('entity-guid-456');
+			}, { timeout: 10000 });
+		});
 
 		it('should create child category with parentCategory in add mode', async () => {
 			mockParams = { guid: 'glossary-type-guid' };

--- a/dashboard/src/views/Glossary/__tests__/AddUpdateGlossaryForm.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/AddUpdateGlossaryForm.test.tsx
@@ -56,19 +56,25 @@ const mockGlossaryData = [
 // Mock toast
 jest.mock('react-toastify', () => ({
 	toast: {
-		success: (...args: any[]) => mockToastSuccess(...args),
-		dismiss: (...args: any[]) => mockToastDismiss(...args)
+		success: function () { return mockToastSuccess.apply(null, arguments as any); },
+		dismiss: function () { return mockToastDismiss.apply(null, arguments as any); }
 	}
 }));
 
+// Mock react-router-dom
+jest.mock('react-router-dom', () => ({
+	useLocation: () => ({ search: '?gtype=glossary&guid=test-guid' }),
+	useParams: () => ({})
+}));
+
 // Mock API methods
-jest.mock('@api/apiMethods/glossaryApiMethod', () => ({
-	createGlossary: (...args: any[]) => mockCreateGlossary(...args),
-	editGlossary: (...args: any[]) => mockEditGlossary(...args)
+jest.mock('../../../api/apiMethods/glossaryApiMethod', () => ({
+	createGlossary: function () { return mockCreateGlossary.apply(null, arguments as any); },
+	editGlossary: function () { return mockEditGlossary.apply(null, arguments as any); }
 }));
 
 // Mock Redux hooks
-jest.mock('@hooks/reducerHook', () => {
+jest.mock('../../../hooks/reducerHook', () => {
 	// Define mock glossary data inside the factory to avoid hoisting issues
 	const mockGlossaryDataLocal = [
 		{
@@ -86,23 +92,23 @@ jest.mock('@hooks/reducerHook', () => {
 			longDescription: 'Another long description'
 		}
 	];
-	
+
 	// Define mock state inside the factory function to avoid hoisting issues
 	const mockState = {
 		glossary: {
 			glossaryData: mockGlossaryDataLocal
 		}
 	};
-	
+
 	const mockUseAppSelectorFn = jest.fn((sel: any) => {
 		// If selector is not a function, return default
 		if (typeof sel !== 'function') {
 			return { glossaryData: mockGlossaryDataLocal };
 		}
-		
+
 		// Execute selector
 		const result = sel(mockState);
-		
+
 		// CRITICAL: Never return undefined - return glossaryData if result is undefined
 		// Also ensure glossaryData is always an array, never null
 		if (result === undefined || result === null) {
@@ -112,20 +118,20 @@ jest.mock('@hooks/reducerHook', () => {
 		if (result.glossaryData === null || result.glossaryData === undefined) {
 			return { glossaryData: mockGlossaryDataLocal };
 		}
-		
+
 		return result;
 	});
-	
+
 	return {
 		useAppDispatch: () => mockDispatch,
-		useAppSelector: (...args: any[]) => mockUseAppSelectorFn(...args),
+		useAppSelector: mockUseAppSelectorFn,
 		// Export the mock function for use in tests
 		__mockUseAppSelector: mockUseAppSelectorFn
 	};
 });
 
 // Get the mock function for use in tests
-const { __mockUseAppSelector: mockUseAppSelector } = require('@hooks/reducerHook');
+const { __mockUseAppSelector: mockUseAppSelector } = require('../../../hooks/reducerHook');
 
 // Mock Redux slice - fetchGlossaryData is a thunk that returns a function
 const mockFetchGlossaryDataThunk = jest.fn(() => async (dispatch: any) => {
@@ -133,14 +139,15 @@ const mockFetchGlossaryDataThunk = jest.fn(() => async (dispatch: any) => {
 	return Promise.resolve({ type: 'glossary/fetchGlossaryData' });
 });
 
-jest.mock('@redux/slice/glossarySlice', () => ({
-	fetchGlossaryData: (...args: any[]) => mockFetchGlossaryDataThunk(...args)
+jest.mock('../../../redux/slice/glossarySlice', () => ({
+	fetchGlossaryData: function() { return mockFetchGlossaryDataThunk.apply(null, arguments as any); }
 }));
 
 // Mock Utils
-jest.mock('@utils/Utils', () => {
-	const actualLodash = jest.requireActual('lodash');
+jest.mock('../../../utils/Utils', () => {
+	const actualUtils = jest.requireActual('../../../utils/Utils') as any;
 	return {
+		...actualUtils,
 		isEmpty: (value: any) => {
 			return (
 				value === undefined ||
@@ -149,12 +156,12 @@ jest.mock('@utils/Utils', () => {
 				(typeof value === 'string' && value.trim().length === 0)
 			);
 		},
-		serverError: (...args: any[]) => mockServerError(...args)
+		serverError: function () { return mockServerError.apply(null, arguments as any); }
 	};
 });
 
 // Mock Modal component
-jest.mock('@components/Modal', () => ({
+jest.mock('../../../components/Modal', () => ({
 	__esModule: true,
 	default: ({ open, onClose, children, title, button1Label, button1Handler, button2Label, button2Handler, disableButton2 }: any) =>
 		open ? (
@@ -283,7 +290,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			return action;
 		});
 		// Reset useAppSelector to default behavior
-		const { __mockUseAppSelector } = require('@hooks/reducerHook');
+		const { __mockUseAppSelector } = require('../../../hooks/reducerHook');
 		__mockUseAppSelector.mockImplementation((selector: any) => {
 			const mockState = {
 				glossary: {
@@ -474,7 +481,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -498,7 +505,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -534,7 +541,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -574,7 +581,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -608,7 +615,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 				// Wait for async operations to complete
@@ -643,7 +650,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -676,7 +683,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -701,7 +708,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -726,7 +733,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -751,7 +758,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -776,7 +783,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -813,7 +820,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 				// Wait for async operations to complete
@@ -849,7 +856,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -877,7 +884,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 				}
 			];
 
-			const { __mockUseAppSelector } = require('@hooks/reducerHook');
+			const { __mockUseAppSelector } = require('../../../hooks/reducerHook');
 			__mockUseAppSelector.mockReturnValueOnce({
 				glossaryData: incompleteGlossaryData
 			});
@@ -895,7 +902,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 		});
 
 		test('handles empty glossaryData array', () => {
-			const { __mockUseAppSelector } = require('@hooks/reducerHook');
+			const { __mockUseAppSelector } = require('../../../hooks/reducerHook');
 			__mockUseAppSelector.mockReturnValueOnce({
 				glossaryData: []
 			});
@@ -914,7 +921,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 		});
 
 		test('handles null glossaryData', () => {
-			const { __mockUseAppSelector } = require('@hooks/reducerHook');
+			const { __mockUseAppSelector } = require('../../../hooks/reducerHook');
 			__mockUseAppSelector.mockReturnValueOnce({
 				glossaryData: null
 			});
@@ -957,7 +964,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -981,7 +988,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1005,7 +1012,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1029,7 +1036,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1053,7 +1060,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1077,7 +1084,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1101,7 +1108,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1122,7 +1129,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 				}
 			];
 
-			const { __mockUseAppSelector } = require('@hooks/reducerHook');
+			const { __mockUseAppSelector } = require('../../../hooks/reducerHook');
 			__mockUseAppSelector.mockReturnValueOnce({
 				glossaryData: glossaryDataWithoutGuid
 			});
@@ -1150,7 +1157,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 				}
 			];
 
-			const { __mockUseAppSelector } = require('@hooks/reducerHook');
+			const { __mockUseAppSelector } = require('../../../hooks/reducerHook');
 			__mockUseAppSelector.mockReturnValueOnce({
 				glossaryData: glossaryDataWithoutQualifiedName
 			});
@@ -1231,7 +1238,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1260,7 +1267,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1288,7 +1295,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 			});
@@ -1321,7 +1328,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 				// Wait for async operations to complete
@@ -1353,7 +1360,7 @@ describe('AddUpdateGlossaryForm - 100% Coverage', () => {
 			);
 
 			const submitBtn = screen.getByTestId('submit-btn');
-			
+
 			await act(async () => {
 				fireEvent.click(submitBtn);
 				// Wait for async operations to complete

--- a/dashboard/src/views/Glossary/__tests__/AddUpdateTermForm.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/AddUpdateTermForm.test.tsx
@@ -27,9 +27,9 @@ import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
 import AddUpdateTermForm from '../AddUpdateTermForm';
 import userEvent from '@testing-library/user-event';
-import * as glossarySlice from '@redux/slice/glossarySlice';
-import * as glossaryDetailsSlice from '@redux/slice/glossaryDetailsSlice';
-import * as detailPageSlice from '@redux/slice/detailPageSlice';
+import * as glossarySlice from '../../../redux/slice/glossarySlice';
+import * as glossaryDetailsSlice from '../../../redux/slice/glossaryDetailsSlice';
+import * as detailPageSlice from '../../../redux/slice/detailPageSlice';
 
 // Mock state variables
 let mockGuid: string | undefined = undefined;
@@ -58,9 +58,9 @@ const mockToastDismiss = jest.fn();
 
 jest.mock('react-toastify', () => ({
 	toast: {
-		success: (...args: any[]) => mockToastSuccess(...args),
+		success: function () { return mockToastSuccess.apply(null, arguments as any); },
 		error: jest.fn(),
-		dismiss: (...args: any[]) => mockToastDismiss(...args)
+		dismiss: function () { return mockToastDismiss.apply(null, arguments as any); }
 	}
 }));
 
@@ -68,9 +68,9 @@ jest.mock('react-toastify', () => ({
 const mockCreateTermorCategory = jest.fn();
 const mockEditTermorCategory = jest.fn();
 
-jest.mock('@api/apiMethods/glossaryApiMethod', () => ({
-	createTermorCategory: (...args: any[]) => mockCreateTermorCategory(...args),
-	editTermorCatgeory: (...args: any[]) => mockEditTermorCategory(...args)
+jest.mock('../../../api/apiMethods/glossaryApiMethod', () => ({
+	createTermorCategory: function () { return mockCreateTermorCategory.apply(null, arguments as any); },
+	editTermorCatgeory: function () { return mockEditTermorCategory.apply(null, arguments as any); }
 }));
 
 // Mock Redux actions
@@ -81,20 +81,20 @@ const mockFetchGlossaryData = jest.fn(() => (dispatch: any) => {
 const mockFetchGlossaryDetails = jest.fn();
 const mockFetchDetailPageData = jest.fn();
 
-jest.mock('@redux/slice/glossarySlice', () => ({
+jest.mock('../../../redux/slice/glossarySlice', () => ({
 	fetchGlossaryData: jest.fn()
 }));
 
-jest.mock('@redux/slice/glossaryDetailsSlice', () => ({
+jest.mock('../../../redux/slice/glossaryDetailsSlice', () => ({
 	fetchGlossaryDetails: jest.fn()
 }));
 
-jest.mock('@redux/slice/detailPageSlice', () => ({
+jest.mock('../../../redux/slice/detailPageSlice', () => ({
 	fetchDetailPageData: jest.fn()
 }));
 
 // Mock Utils
-jest.mock('@utils/Utils', () => {
+jest.mock('../../../utils/Utils', () => {
 	const actualLodash = jest.requireActual('lodash');
 	return {
 		isEmpty: actualLodash.isEmpty,
@@ -103,25 +103,25 @@ jest.mock('@utils/Utils', () => {
 });
 
 // Mock CustomModal
-jest.mock('@components/Modal', () => ({
+jest.mock('../../../components/Modal', () => ({
 	__esModule: true,
-	default: ({ 
-		open, 
-		onClose, 
-		children, 
-		title, 
-		button1Handler, 
-		button2Handler, 
+	default: ({
+		open,
+		onClose,
+		children,
+		title,
+		button1Handler,
+		button2Handler,
 		button2Label,
-		disableButton2 
+		disableButton2
 	}: any) =>
 		open ? (
 			<div data-testid="modal">
 				<div data-testid="modal-title">{title}</div>
 				{children}
 				<button data-testid="cancel-btn" onClick={button1Handler}>Cancel</button>
-				<button 
-					data-testid="submit-btn" 
+				<button
+					data-testid="submit-btn"
 					onClick={button2Handler}
 					disabled={disableButton2}
 				>
@@ -140,7 +140,7 @@ jest.mock('../GlossaryForm', () => ({
 				<input
 					data-testid="name-input"
 					onChange={(e: any) => {
-						const onChange = control._formValues?.name?.onChange || (() => {});
+						const onChange = control._formValues?.name?.onChange || (() => { });
 						onChange(e.target.value);
 					}}
 					placeholder="Name"
@@ -148,7 +148,7 @@ jest.mock('../GlossaryForm', () => ({
 				<input
 					data-testid="short-description-input"
 					onChange={(e: any) => {
-						const onChange = control._formValues?.shortDescription?.onChange || (() => {});
+						const onChange = control._formValues?.shortDescription?.onChange || (() => { });
 						onChange(e.target.value);
 					}}
 					placeholder="Short Description"
@@ -156,7 +156,7 @@ jest.mock('../GlossaryForm', () => ({
 				<textarea
 					data-testid="long-description-input"
 					onChange={(e: any) => {
-						const onChange = control._formValues?.longDescription?.onChange || (() => {});
+						const onChange = control._formValues?.longDescription?.onChange || (() => { });
 						onChange(e.target.value);
 					}}
 					placeholder="Long Description"
@@ -194,7 +194,7 @@ const mockUseForm = jest.fn(() => ({
 }));
 
 jest.mock('react-hook-form', () => ({
-	useForm: (...args: any[]) => mockUseForm(...args)
+	useForm: function () { return mockUseForm.apply(null, arguments as any); }
 }));
 
 const createStore = (glossaryData: any[] = []) => {
@@ -225,20 +225,20 @@ describe('AddUpdateTermForm', () => {
 		mockToastSuccess.mockReturnValue('toast-id-123');
 		mockCreateTermorCategory.mockResolvedValue({});
 		mockEditTermorCategory.mockResolvedValue({});
-		
+
 		// Set up Redux action mocks
-		(glossarySlice.fetchGlossaryData as jest.Mock).mockImplementation((...args: any[]) => {
-			mockFetchGlossaryData(...args);
+		(glossarySlice.fetchGlossaryData as unknown as jest.Mock).mockImplementation(function () {
+			mockFetchGlossaryData.apply(null, arguments as any);
 			return { type: 'FETCH_GLOSSARY_DATA' };
 		});
-		
-		(glossaryDetailsSlice.fetchGlossaryDetails as jest.Mock).mockImplementation((...args: any[]) => {
-			mockFetchGlossaryDetails(...args);
+
+		(glossaryDetailsSlice.fetchGlossaryDetails as unknown as jest.Mock).mockImplementation(function () {
+			mockFetchGlossaryDetails.apply(null, arguments as any);
 			return { type: 'FETCH_GLOSSARY_DETAILS' };
 		});
-		
-		(detailPageSlice.fetchDetailPageData as jest.Mock).mockImplementation((...args: any[]) => {
-			mockFetchDetailPageData(...args);
+
+		(detailPageSlice.fetchDetailPageData as unknown as jest.Mock).mockImplementation(function () {
+			mockFetchDetailPageData.apply(null, arguments as any);
 			return { type: 'FETCH_DETAIL_PAGE_DATA' };
 		});
 		mockHandleSubmit.mockImplementation((onSubmitFn: any) => {
@@ -391,7 +391,7 @@ describe('AddUpdateTermForm', () => {
 			});
 
 			// Check that Redux action was called
-			const { fetchGlossaryData } = require('@redux/slice/glossarySlice');
+			const { fetchGlossaryData } = require('../../../redux/slice/glossarySlice');
 			await waitFor(() => {
 				expect(fetchGlossaryData).toHaveBeenCalled();
 			});
@@ -406,6 +406,58 @@ describe('AddUpdateTermForm', () => {
 
 			await waitFor(() => {
 				expect(mockOnClose).toHaveBeenCalled();
+			});
+		});
+
+		it('should dispatch fetchGlossaryDetails and fetchDetailPageData when creating term successfully in add mode and URL has gtype and guid', async () => {
+			mockLocationSearch = '?gtype=glossary';
+			mockGuid = 'entity-guid-456';
+			mockUseLocation.mockReturnValue({
+				pathname: '/glossary',
+				search: '?gtype=glossary',
+				hash: '',
+				state: null,
+				key: 'default'
+			});
+
+			const glossaryData = [
+				{ name: 'Test Glossary', guid: 'glossary-guid-1' }
+			];
+			store = createStore(glossaryData);
+
+			render(
+				<Provider store={store}>
+					<MemoryRouter>
+						<AddUpdateTermForm
+							open={true}
+							onClose={mockOnClose}
+							isAdd={true}
+							node={{ id: 'term-id', parent: 'Test Glossary' }}
+							dataObj={undefined}
+						/>
+					</MemoryRouter>
+				</Provider>
+			);
+
+			const submitButton = screen.getByTestId('submit-btn');
+			await act(async () => {
+				fireEvent.click(submitButton);
+			});
+
+			const { fetchGlossaryData } = require('../../../redux/slice/glossarySlice');
+			const { fetchGlossaryDetails } = require('../../../redux/slice/glossaryDetailsSlice');
+			const { fetchDetailPageData } = require('../../../redux/slice/detailPageSlice');
+
+			await waitFor(() => {
+				expect(fetchGlossaryData).toHaveBeenCalled();
+			});
+
+			await waitFor(() => {
+				expect(fetchGlossaryDetails).toHaveBeenCalledWith({ gtype: 'glossary', guid: 'entity-guid-456' });
+			});
+
+			await waitFor(() => {
+				expect(fetchDetailPageData).toHaveBeenCalledWith('entity-guid-456');
 			});
 		});
 
@@ -497,8 +549,8 @@ describe('AddUpdateTermForm', () => {
 
 		it('should use glossaryObj values when dataObj is empty in add mode', () => {
 			const glossaryData = [
-				{ 
-					name: 'Test Glossary', 
+				{
+					name: 'Test Glossary',
 					guid: 'glossary-guid-1',
 					shortDescription: 'Glossary Short',
 					longDescription: 'Glossary Long'
@@ -577,9 +629,9 @@ describe('AddUpdateTermForm', () => {
 			});
 
 			// Check that Redux actions were called
-			const { fetchGlossaryData } = require('@redux/slice/glossarySlice');
-			const { fetchGlossaryDetails } = require('@redux/slice/glossaryDetailsSlice');
-			const { fetchDetailPageData } = require('@redux/slice/detailPageSlice');
+			const { fetchGlossaryData } = require('../../../redux/slice/glossarySlice');
+			const { fetchGlossaryDetails } = require('../../../redux/slice/glossaryDetailsSlice');
+			const { fetchDetailPageData } = require('../../../redux/slice/detailPageSlice');
 
 			await waitFor(() => {
 				expect(fetchGlossaryData).toHaveBeenCalled();
@@ -654,9 +706,9 @@ describe('AddUpdateTermForm', () => {
 			}, { timeout: 3000 });
 
 			// Check that Redux actions were called by checking the mocked modules
-			const { fetchGlossaryData } = require('@redux/slice/glossarySlice');
-			const { fetchGlossaryDetails } = require('@redux/slice/glossaryDetailsSlice');
-			const { fetchDetailPageData } = require('@redux/slice/detailPageSlice');
+			const { fetchGlossaryData } = require('../../../redux/slice/glossarySlice');
+			const { fetchGlossaryDetails } = require('../../../redux/slice/glossaryDetailsSlice');
+			const { fetchDetailPageData } = require('../../../redux/slice/detailPageSlice');
 
 			await waitFor(() => {
 				expect(fetchGlossaryData).toHaveBeenCalled();
@@ -799,7 +851,7 @@ describe('AddUpdateTermForm', () => {
 			const error = new Error('API Error');
 			mockCreateTermorCategory.mockRejectedValue(error);
 
-			const { serverError } = require('@utils/Utils');
+			const { serverError } = require('../../../utils/Utils');
 
 			const glossaryData = [
 				{ name: 'Test Glossary', guid: 'glossary-guid-1' }
@@ -840,7 +892,7 @@ describe('AddUpdateTermForm', () => {
 			const error = new Error('API Error');
 			mockEditTermorCategory.mockRejectedValue(error);
 
-			const { serverError } = require('@utils/Utils');
+			const { serverError } = require('../../../utils/Utils');
 
 			const dataObj = {
 				name: 'Existing Term',
@@ -985,7 +1037,7 @@ describe('AddUpdateTermForm', () => {
 
 			const submitButton = screen.getByTestId('submit-btn');
 			expect(submitButton).toBeDisabled();
-			
+
 			// Restore original mock
 			if (originalMock) {
 				mockUseForm.mockImplementation(originalMock);
@@ -1009,8 +1061,8 @@ describe('AddUpdateTermForm', () => {
 			};
 
 			const glossaryData = [
-				{ 
-					name: 'Test Glossary', 
+				{
+					name: 'Test Glossary',
 					guid: 'glossary-guid-1',
 					shortDescription: 'Glossary Short',
 					longDescription: 'Glossary Long'
@@ -1037,8 +1089,8 @@ describe('AddUpdateTermForm', () => {
 
 		it('should use glossaryObj values when dataObj is empty in add mode', () => {
 			const glossaryData = [
-				{ 
-					name: 'Test Glossary', 
+				{
+					name: 'Test Glossary',
 					guid: 'glossary-guid-1',
 					shortDescription: 'Glossary Short',
 					longDescription: 'Glossary Long'

--- a/dashboard/src/views/Glossary/__tests__/AssignCategory.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/AssignCategory.test.tsx
@@ -28,7 +28,7 @@ const theme = createTheme();
 const mockDispatch = jest.fn();
 const mockUseAppSelector = jest.fn();
 
-jest.mock('@hooks/reducerHook', () => ({
+jest.mock('../../../hooks/reducerHook', () => ({
 	useAppDispatch: () => mockDispatch,
 	useAppSelector: (selector: any) => mockUseAppSelector(selector)
 }));
@@ -43,7 +43,7 @@ const mockLocation = {
 	key: 'test-key'
 };
 
-const mockUseParams = jest.fn(() => ({ guid: 'test-guid-123' }));
+const mockUseParams = jest.fn<any, any>(() => ({ guid: 'test-guid-123' }));
 const mockUseLocation = jest.fn(() => ({
 	pathname: '/glossary/test-guid-123',
 	search: '?gtype=term',
@@ -63,29 +63,29 @@ jest.mock('react-router-dom', () => {
 
 // Mock API methods
 const mockAssignGlossaryType = jest.fn();
-jest.mock('@api/apiMethods/glossaryApiMethod', () => ({
-	assignGlossaryType: (...args: any[]) => mockAssignGlossaryType(...args)
+jest.mock('../../../api/apiMethods/glossaryApiMethod', () => ({
+	assignGlossaryType: function() { return mockAssignGlossaryType.apply(null, arguments as any); }
 }));
 
 // Mock Redux slices
-const mockFetchGlossaryData = jest.fn(() => ({ type: 'glossary/fetchData' }));
-const mockFetchGlossaryDetails = jest.fn(() => ({ type: 'glossary/fetchDetails' }));
-const mockFetchDetailPageData = jest.fn(() => ({ type: 'detailPage/fetchData' }));
+const mockFetchGlossaryData = jest.fn((...args: any[]) => ({ type: 'glossary/fetchData' }));
+const mockFetchGlossaryDetails = jest.fn((...args: any[]) => ({ type: 'glossary/fetchDetails' }));
+const mockFetchDetailPageData = jest.fn((...args: any[]) => ({ type: 'detailPage/fetchData' }));
 
-jest.mock('@redux/slice/glossarySlice', () => ({
-	fetchGlossaryData: (...args: any[]) => mockFetchGlossaryData(...args)
+jest.mock('../../../redux/slice/glossarySlice', () => ({
+	fetchGlossaryData: function() { return mockFetchGlossaryData.apply(null, arguments as any); }
 }));
 
-jest.mock('@redux/slice/glossaryDetailsSlice', () => ({
-	fetchGlossaryDetails: (...args: any[]) => mockFetchGlossaryDetails(...args)
+jest.mock('../../../redux/slice/glossaryDetailsSlice', () => ({
+	fetchGlossaryDetails: function() { return mockFetchGlossaryDetails.apply(null, arguments as any); }
 }));
 
-jest.mock('@redux/slice/detailPageSlice', () => ({
-	fetchDetailPageData: (...args: any[]) => mockFetchDetailPageData(...args)
+jest.mock('../../../redux/slice/detailPageSlice', () => ({
+	fetchDetailPageData: function() { return mockFetchDetailPageData.apply(null, arguments as any); }
 }));
 
 // Mock Utils - must be before importing the component
-jest.mock('@utils/Utils', () => {
+jest.mock('../../../utils/Utils', () => {
 	const mockCustomSortByObjectKeys = (arr: any[]) => {
 		// CRITICAL: Always return an array, never undefined
 		if (arr === undefined || arr === null) return [];
@@ -152,7 +152,7 @@ jest.mock('@utils/Utils', () => {
 });
 
 // Mock Helper
-jest.mock('@utils/Helper', () => ({
+jest.mock('../../../utils/Helper', () => ({
 	cloneDeep: jest.fn((obj: any) => {
 		if (obj === null || obj === undefined) {
 			return {};
@@ -202,7 +202,7 @@ jest.mock('moment-timezone', () => {
 });
 
 // Mock FormTreeView component
-jest.mock('@components/Forms/FormTreeView', () => {
+jest.mock('../../../components/Forms/FormTreeView', () => {
 	return function MockFormTreeView({
 		treeData,
 		searchTerm,
@@ -234,7 +234,7 @@ jest.mock('@components/Forms/FormTreeView', () => {
 });
 
 // Mock CustomModal component
-jest.mock('@components/Modal', () => {
+jest.mock('../../../components/Modal', () => {
 	return function MockCustomModal({
 		open,
 		onClose,
@@ -715,7 +715,7 @@ describe('AssignCategory', () => {
 			});
 
 			await waitFor(() => {
-				const { serverError } = require('@utils/Utils');
+				const { serverError } = require('../../../utils/Utils');
 				expect(serverError).toHaveBeenCalled();
 			});
 		});

--- a/dashboard/src/views/Glossary/__tests__/AssignTerm.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/AssignTerm.test.tsx
@@ -25,7 +25,7 @@ import { toast } from 'react-toastify';
 const mockDispatch = jest.fn();
 const mockUseAppSelector = jest.fn();
 
-jest.mock('@hooks/reducerHook', () => ({
+jest.mock('../../../hooks/reducerHook', () => ({
 	useAppDispatch: () => mockDispatch,
 	useAppSelector: (selector: any) => mockUseAppSelector(selector)
 }));
@@ -50,10 +50,10 @@ const mockAssignGlossaryType = jest.fn();
 const mockAssignTermstoCategory = jest.fn();
 const mockAssignTermstoEntites = jest.fn();
 
-jest.mock('@api/apiMethods/glossaryApiMethod', () => ({
-	assignGlossaryType: (...args: any[]) => mockAssignGlossaryType(...args),
-	assignTermstoCategory: (...args: any[]) => mockAssignTermstoCategory(...args),
-	assignTermstoEntites: (...args: any[]) => mockAssignTermstoEntites(...args)
+jest.mock('../../../api/apiMethods/glossaryApiMethod', () => ({
+	assignGlossaryType: function() { return mockAssignGlossaryType.apply(null, arguments as any); },
+	assignTermstoCategory: function() { return mockAssignTermstoCategory.apply(null, arguments as any); },
+	assignTermstoEntites: function() { return mockAssignTermstoEntites.apply(null, arguments as any); }
 }));
 
 // Mock Redux actions
@@ -61,16 +61,16 @@ const mockFetchDetailPageData = jest.fn(() => ({ type: 'detailPage/fetch' }));
 const mockFetchGlossaryDetails = jest.fn(() => ({ type: 'glossaryDetails/fetch' }));
 const mockFetchGlossaryData = jest.fn(() => ({ type: 'glossary/fetch' }));
 
-jest.mock('@redux/slice/detailPageSlice', () => ({
-	fetchDetailPageData: (...args: any[]) => mockFetchDetailPageData(...args)
+jest.mock('../../../redux/slice/detailPageSlice', () => ({
+	fetchDetailPageData: function() { return mockFetchDetailPageData.apply(null, arguments as any); }
 }));
 
-jest.mock('@redux/slice/glossaryDetailsSlice', () => ({
-	fetchGlossaryDetails: (...args: any[]) => mockFetchGlossaryDetails(...args)
+jest.mock('../../../redux/slice/glossaryDetailsSlice', () => ({
+	fetchGlossaryDetails: function() { return mockFetchGlossaryDetails.apply(null, arguments as any); }
 }));
 
-jest.mock('@redux/slice/glossarySlice', () => ({
-	fetchGlossaryData: (...args: any[]) => mockFetchGlossaryData(...args)
+jest.mock('../../../redux/slice/glossarySlice', () => ({
+	fetchGlossaryData: function() { return mockFetchGlossaryData.apply(null, arguments as any); }
 }));
 
 // Mock utils
@@ -80,18 +80,18 @@ const mockCustomSortByObjectKeys = jest.fn();
 const mockNoTreeData = jest.fn();
 const mockServerError = jest.fn();
 
-jest.mock('@utils/Utils', () => ({
-	isEmpty: (...args: any[]) => mockIsEmpty(...args),
-	customSortBy: (...args: any[]) => mockCustomSortBy(...args),
-	customSortByObjectKeys: (...args: any[]) => mockCustomSortByObjectKeys(...args),
-	noTreeData: (...args: any[]) => mockNoTreeData(...args),
-	serverError: (...args: any[]) => mockServerError(...args)
+jest.mock('../../../utils/Utils', () => ({
+	isEmpty: function() { return mockIsEmpty.apply(null, arguments as any); },
+	customSortBy: function() { return mockCustomSortBy.apply(null, arguments as any); },
+	customSortByObjectKeys: function() { return mockCustomSortByObjectKeys.apply(null, arguments as any); },
+	noTreeData: function() { return mockNoTreeData.apply(null, arguments as any); },
+	serverError: function() { return mockServerError.apply(null, arguments as any); }
 }));
 
 const mockCloneDeep = jest.fn();
 
-jest.mock('@utils/Helper', () => ({
-	cloneDeep: (...args: any[]) => mockCloneDeep(...args)
+jest.mock('../../../utils/Helper', () => ({
+	cloneDeep: function() { return mockCloneDeep.apply(null, arguments as any); }
 }));
 
 // Mock react-hook-form
@@ -109,7 +109,7 @@ const mockUseForm = jest.fn(() => ({
 }));
 
 jest.mock('react-hook-form', () => ({
-	useForm: (...args: any[]) => mockUseForm(...args),
+	useForm: function() { return mockUseForm.apply(null, arguments as any); },
 	Controller: ({ render, name }: any) => {
 		const field = {
 			onChange: mockOnChange,
@@ -144,7 +144,7 @@ jest.mock('moment-timezone', () => {
 });
 
 // Mock components
-jest.mock('@components/Modal', () => ({
+jest.mock('../../../components/Modal', () => ({
 	__esModule: true,
 	default: ({
 		open,
@@ -180,7 +180,7 @@ jest.mock('@components/Modal', () => ({
 }));
 
 let mockOnNodeSelect: any;
-jest.mock('@components/Forms/FormTreeView', () => ({
+jest.mock('../../../components/Forms/FormTreeView', () => ({
 	__esModule: true,
 	default: ({
 		treeData,

--- a/dashboard/src/views/Glossary/__tests__/DeleteGlossary.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/DeleteGlossary.test.tsx
@@ -37,6 +37,7 @@ const mockSetExpandNode = jest.fn();
 const mockUpdatedData = jest.fn();
 const mockDeleteGlossaryorTerm = jest.fn();
 const mockDeleteGlossaryorType = jest.fn();
+const mockDeleteCategory = jest.fn();
 const mockFetchGlossaryData = jest.fn();
 const mockIsEmpty = jest.fn();
 const mockServerError = jest.fn();
@@ -51,7 +52,7 @@ let mockLocation = {
 };
 
 // Mock params state
-let mockParams = { guid: undefined };
+let mockParams: { guid: string | undefined } = { guid: undefined };
 
 // Mock toast
 const mockToastSuccess = jest.fn();
@@ -67,23 +68,24 @@ jest.mock('react-router-dom', () => ({
 }));
 
 // Mock API methods
-jest.mock('@api/apiMethods/glossaryApiMethod', () => ({
+jest.mock('../../../api/apiMethods/glossaryApiMethod', () => ({
 	deleteGlossaryorTerm: (...args: any[]) => mockDeleteGlossaryorTerm(...args),
-	deleteGlossaryorType: (...args: any[]) => mockDeleteGlossaryorType(...args)
+	deleteGlossaryorType: (...args: any[]) => mockDeleteGlossaryorType(...args),
+	deleteCategory: (...args: any[]) => mockDeleteCategory(...args)
 }));
 
 // Mock Redux hooks
-jest.mock('@hooks/reducerHook', () => ({
+jest.mock('../../../hooks/reducerHook', () => ({
 	useAppDispatch: () => mockDispatch
 }));
 
 // Mock Redux slice
-jest.mock('@redux/slice/glossarySlice', () => ({
+jest.mock('../../../redux/slice/glossarySlice', () => ({
 	fetchGlossaryData: jest.fn(() => ({ type: 'glossary/fetchGlossaryData' }))
 }));
 
 // Mock utils
-jest.mock('@utils/Utils', () => ({
+jest.mock('../../../utils/Utils', () => ({
 	isEmpty: (...args: any[]) => mockIsEmpty(...args),
 	serverError: (...args: any[]) => mockServerError(...args)
 }));
@@ -98,18 +100,18 @@ jest.mock('react-toastify', () => ({
 }));
 
 // Mock CustomModal
-jest.mock('@components/Modal', () => ({
+jest.mock('../../../components/Modal', () => ({
 	__esModule: true,
-	default: ({ 
-		open, 
-		onClose, 
-		title, 
-		titleIcon, 
-		button1Label, 
-		button1Handler, 
-		button2Label, 
-		button2Handler, 
-		children 
+	default: ({
+		open,
+		onClose,
+		title,
+		titleIcon,
+		button1Label,
+		button1Handler,
+		button2Label,
+		button2Handler,
+		children
 	}: any) =>
 		open ? (
 			<div data-testid="custom-modal">
@@ -160,6 +162,13 @@ describe('DeleteGlossary', () => {
 		types: 'term'
 	};
 
+	const categoryNode = {
+		id: 'test-category-1',
+		guid: 'test-category-guid-123',
+		cGuid: 'test-category-cguid-456',
+		types: 'Category'
+	};
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockLocation = {
@@ -173,6 +182,7 @@ describe('DeleteGlossary', () => {
 		mockDispatch.mockResolvedValue(undefined);
 		mockDeleteGlossaryorTerm.mockResolvedValue({});
 		mockDeleteGlossaryorType.mockResolvedValue({});
+		mockDeleteCategory.mockResolvedValue({});
 		mockIsEmpty.mockReturnValue(true);
 		mockFetchGlossaryData.mockReturnValue({ type: 'glossary/fetchGlossaryData' });
 	});
@@ -206,6 +216,12 @@ describe('DeleteGlossary', () => {
 			render(<DeleteGlossary {...defaultProps} node={termNode} />);
 
 			expect(screen.getByText(/Are you sure you want to delete Term/i)).toBeInTheDocument();
+		});
+
+		it('should display correct text for category deletion', () => {
+			render(<DeleteGlossary {...defaultProps} node={categoryNode} />);
+
+			expect(screen.getByText(/Are you sure you want to delete Category/i)).toBeInTheDocument();
 		});
 
 		it('should render Cancel and Ok buttons', () => {
@@ -250,7 +266,7 @@ describe('DeleteGlossary', () => {
 			render(<DeleteGlossary {...defaultProps} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
+
 			await act(async () => {
 				fireEvent.click(okButton);
 			});
@@ -281,40 +297,14 @@ describe('DeleteGlossary', () => {
 			});
 		});
 
-		it('should navigate to home when glossaryGuid is not empty after successful deletion', async () => {
-			mockParams = { guid: 'existing-guid' };
+		it('should navigate to home when the currently viewed glossary is deleted', async () => {
+			mockParams = { guid: 'test-guid-123' };
 			mockIsEmpty.mockReturnValue(false);
 
 			render(<DeleteGlossary {...defaultProps} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
-			await act(async () => {
-				fireEvent.click(okButton);
-			});
 
-			await waitFor(() => {
-				expect(mockNavigate).toHaveBeenCalledWith(
-					{ pathname: '/' },
-					{ replace: true }
-				);
-			});
-		});
-
-		it('should navigate to home when glossaryType is not empty after successful deletion', async () => {
-			mockLocation = {
-				pathname: '/glossary',
-				search: '?gtype=term',
-				hash: '',
-				state: null,
-				key: 'test-key'
-			};
-			mockIsEmpty.mockReturnValue(false);
-
-			render(<DeleteGlossary {...defaultProps} />);
-
-			const okButton = screen.getByTestId('modal-button-2');
-			
 			await act(async () => {
 				fireEvent.click(okButton);
 			});
@@ -341,7 +331,7 @@ describe('DeleteGlossary', () => {
 			render(<DeleteGlossary {...defaultProps} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
+
 			await act(async () => {
 				fireEvent.click(okButton);
 			});
@@ -361,7 +351,7 @@ describe('DeleteGlossary', () => {
 			render(<DeleteGlossary {...defaultProps} node={termNode} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
+
 			await act(async () => {
 				fireEvent.click(okButton);
 			});
@@ -392,14 +382,74 @@ describe('DeleteGlossary', () => {
 			});
 		});
 
-		it('should navigate to home when glossaryGuid is not empty after term deletion', async () => {
-			mockParams = { guid: 'existing-guid' };
+		it('should navigate to home when the currently viewed term is deleted', async () => {
+			mockParams = { guid: 'test-term-cguid-456' };
 			mockIsEmpty.mockReturnValue(false);
 
 			render(<DeleteGlossary {...defaultProps} node={termNode} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
+
+			await act(async () => {
+				fireEvent.click(okButton);
+			});
+
+			await waitFor(() => {
+				expect(mockNavigate).toHaveBeenCalledWith(
+					{ pathname: '/' },
+					{ replace: true }
+				);
+			});
+		});
+	});
+
+	describe('Delete Category Functionality', () => {
+		it('should delete category successfully when Ok button is clicked', async () => {
+			mockDispatch.mockResolvedValue(undefined);
+
+			render(<DeleteGlossary {...defaultProps} node={categoryNode} />);
+
+			const okButton = screen.getByTestId('modal-button-2');
+
+			await act(async () => {
+				fireEvent.click(okButton);
+			});
+
+			await waitFor(() => {
+				expect(mockDeleteCategory).toHaveBeenCalledWith('test-category-cguid-456');
+				expect(mockDeleteGlossaryorType).not.toHaveBeenCalled();
+				expect(mockDeleteGlossaryorTerm).not.toHaveBeenCalled();
+			});
+
+			await waitFor(() => {
+				expect(mockUpdatedData).toHaveBeenCalledTimes(1);
+			});
+
+			await waitFor(() => {
+				expect(mockDispatch).toHaveBeenCalled();
+			});
+
+			await waitFor(() => {
+				expect(mockToastSuccess).toHaveBeenCalledWith('Category test-category-1 was deleted successfully');
+			});
+
+			await waitFor(() => {
+				expect(mockOnClose).toHaveBeenCalledTimes(1);
+			});
+
+			await waitFor(() => {
+				expect(mockSetExpandNode).toHaveBeenCalledWith(null);
+			});
+		});
+
+		it('should navigate to home when the currently viewed category is deleted', async () => {
+			mockParams = { guid: 'test-category-cguid-456' };
+			mockIsEmpty.mockReturnValue(false);
+
+			render(<DeleteGlossary {...defaultProps} node={categoryNode} />);
+
+			const okButton = screen.getByTestId('modal-button-2');
+
 			await act(async () => {
 				fireEvent.click(okButton);
 			});
@@ -421,7 +471,7 @@ describe('DeleteGlossary', () => {
 			render(<DeleteGlossary {...defaultProps} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
+
 			await act(async () => {
 				fireEvent.click(okButton);
 			});
@@ -441,7 +491,27 @@ describe('DeleteGlossary', () => {
 			render(<DeleteGlossary {...defaultProps} node={termNode} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
+
+			await act(async () => {
+				fireEvent.click(okButton);
+			});
+
+			await waitFor(() => {
+				expect(mockServerError).toHaveBeenCalledWith(mockError, expect.any(Object));
+			});
+
+			expect(mockOnClose).not.toHaveBeenCalled();
+			expect(mockSetExpandNode).not.toHaveBeenCalled();
+		});
+
+		it('should handle error when deleting category fails', async () => {
+			const mockError = new Error('Delete failed');
+			mockDeleteCategory.mockRejectedValue(mockError);
+
+			render(<DeleteGlossary {...defaultProps} node={categoryNode} />);
+
+			const okButton = screen.getByTestId('modal-button-2');
+
 			await act(async () => {
 				fireEvent.click(okButton);
 			});
@@ -489,7 +559,7 @@ describe('DeleteGlossary', () => {
 			render(<DeleteGlossary {...defaultProps} node={nodeWithEmptyId} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
+
 			await act(async () => {
 				fireEvent.click(okButton);
 			});
@@ -500,13 +570,13 @@ describe('DeleteGlossary', () => {
 		});
 
 		it('should handle fetchCurrentData being called', async () => {
-			const { fetchGlossaryData } = require('@redux/slice/glossarySlice');
+			const { fetchGlossaryData } = require('../../../redux/slice/glossarySlice');
 			mockDispatch.mockResolvedValue(undefined);
 
 			render(<DeleteGlossary {...defaultProps} />);
 
 			const okButton = screen.getByTestId('modal-button-2');
-			
+
 			await act(async () => {
 				fireEvent.click(okButton);
 			});

--- a/dashboard/src/views/SideBar/SideBarTree/GlossaryTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/GlossaryTree.tsx
@@ -81,8 +81,19 @@ const GlossaryTree = ({ sideBarOpen, searchTerm }: Props) => {
               children: EnumCategoryRelation[];
               parent: string;
             }) => {
-              return !isEmpty(glossaries.children)
-                ? glossaries.children
+              if (isEmpty(glossaries.children)) return [];
+              
+              // Deduplicate children by guid to prevent MUI TreeView identical id errors
+              const uniqueChildren = Array.from(
+                new Map(
+                  glossaries.children.map(item => [
+                    glossaryType ? item.termGuid : item.categoryGuid, 
+                    item
+                  ])
+                ).values()
+              );
+
+              return uniqueChildren
                   .map((glossariesType: any) => {
                     const getChild = (parentGuid: string | undefined): any => {
                       if (!parentGuid) return [];
@@ -121,8 +132,7 @@ const GlossaryTree = ({ sideBarOpen, searchTerm }: Props) => {
                       };
                     }
                   })
-                  .filter(Boolean)
-                : [];
+                  .filter(Boolean);
             };
 
             let name: string = glossary.name,

--- a/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
@@ -87,13 +87,21 @@ type CustomContentRootProps = HTMLAttributes<HTMLDivElement> & {
   selectedNode?: any;
 };
 
-const CustomContentRoot = styled("div")<CustomContentRootProps>(
+const CustomContentRoot = styled("div", {
+  shouldForwardProp: (prop) =>
+    prop !== "selectedNodeType" &&
+    prop !== "selectedNodeTag" &&
+    prop !== "selectedNodeRelationship" &&
+    prop !== "selectedNodeBM" &&
+    prop !== "node" &&
+    prop !== "selectedNode",
+})<CustomContentRootProps>(
   ({ theme, ...props }) => ({
     WebkitTapHighlightColor: "#0E8173",
     "&&:hover, &&.Mui-disabled, &&.Mui-focused, &&.Mui-selected, &&.Mui-selected.Mui-focused, &&.Mui-selected:hover":
-      {
-        backgroundColor: "transparent",
-      },
+    {
+      backgroundColor: "transparent",
+    },
     ".MuiTreeItem-contentBar": {
       position: "absolute",
       width: "100%",
@@ -196,8 +204,8 @@ const CustomContent = forwardRef(function CustomContent(
   };
 
   const labelProps = isValidElement(props.label)
-  ? (props.label.props as CustomContentRootProps)
-  : undefined;
+    ? (props.label.props as CustomContentRootProps)
+    : undefined;
 
   return (
     <CustomContentRoot
@@ -208,7 +216,7 @@ const CustomContent = forwardRef(function CustomContent(
             (labelProps?.selectedNodeType === labelProps?.node ||
               labelProps?.selectedNodeTag === labelProps?.node ||
               labelProps?.selectedNodeRelationship ===
-                labelProps?.node ||
+              labelProps?.node ||
               labelProps?.selectedNodeBM === labelProps?.node)) ||
           selected,
         "Mui-focused": focused,
@@ -287,1007 +295,1012 @@ const BarTreeView: FC<{
   searchTerm,
   loader,
 }) => {
-  const { savedSearchData }: any = useAppSelector(
-    (state: any) => state.savedSearch
-  );
-  const { bmguid } = useParams();
-  const location = useLocation();
-  const navigate = useNavigate();
-  const searchParams = new URLSearchParams(location.search);
-  const [expand, setExpand] = useState<null | HTMLElement>(null);
-  const [selectedNode, setSelectedNode] = useState<{
-    type: string | null;
-    tag: string | null;
-    relationship: string | null;
-    businessMetadata: string | null;
-  }>({
-    type: null,
-    tag: null,
-    relationship: null,
-    businessMetadata: null,
-  });
-
-  const [openModal, setOpenModal] = useState<boolean>(false);
-  const toastId: any = useRef(null);
-  const open = Boolean(expand);
-  const [expandedItems, setExpandedItems] = useState<string[]>([]);
-  const [tagModal, setTagModal] = useState<boolean>(false);
-  const [glossaryModal, setGlossaryModal] = useState<boolean>(false);
-  const { businessMetaData }: any = useAppSelector(
-    (state: any) => state.businessMetaData
-  );
-
-  const filteredData = useMemo(() => {
-    return treeData.filter((node) => {
-      return (
-        node.label?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (node.children &&
-          node.children.some((child) =>
-            child.label?.toLowerCase().includes(searchTerm.toLowerCase())
-          ))
-      );
-    });
-  }, [treeData, searchTerm]);
-
-  const displayTreeName = useMemo(() => {
-    return treeName === "CustomFilters" ? "Custom Filters" : treeName
-  }, [treeName]);
-
-  const highlightText = useMemo(() => {
-    return (text: string) => {
-      if (!searchTerm) return text;
-
-      const parts = text.split(new RegExp(`(${searchTerm})`, "gi"));
-      return parts.map((part, index) =>
-        part.toLowerCase() === searchTerm.toLowerCase() ? (
-          <span key={index} style={{ color: "#D3D3D3", fontWeight: "600" }}>
-            {part}
-          </span>
-        ) : (
-          part
-        )
-      );
-    };
-  }, [searchTerm]);
-
-  const expandedItemsMemo = useMemo(() => {
-    const allNodeIds = filteredData.flatMap((node) => {
-      return [
-        node.id,
-        ...(node.children ? node.children.map((child) => child.id) : []),
-      ];
-    });
-    return [...allNodeIds, ...[treeName]];
-  }, [filteredData, treeName]);
-
-  useEffect(() => {
-    setExpandedItems(expandedItemsMemo);
-  }, [expandedItemsMemo]);
-
-  useEffect(() => {
+    const { savedSearchData }: any = useAppSelector(
+      (state: any) => state.savedSearch
+    );
+    const { bmguid } = useParams();
+    const location = useLocation();
+    const navigate = useNavigate();
     const searchParams = new URLSearchParams(location.search);
-    const nodeIdFromParamsType = searchParams.get("type");
-    const nodeIdFromParamsTag = searchParams.get("tag");
-    const nodeIdFromParamsRelationshipName =
-      searchParams.get("relationshipName");
-    const nodeIdFromBMName = location.pathname.includes(
-      "/administrator/businessMetadata"
+    const [expand, setExpand] = useState<null | HTMLElement>(null);
+    const [selectedNode, setSelectedNode] = useState<{
+      type: string | null;
+      tag: string | null;
+      relationship: string | null;
+      businessMetadata: string | null;
+    }>({
+      type: null,
+      tag: null,
+      relationship: null,
+      businessMetadata: null,
+    });
+
+    const [openModal, setOpenModal] = useState<boolean>(false);
+    const toastId: any = useRef(null);
+    const open = Boolean(expand);
+    const [expandedItems, setExpandedItems] = useState<string[]>([]);
+    const [tagModal, setTagModal] = useState<boolean>(false);
+    const [glossaryModal, setGlossaryModal] = useState<boolean>(false);
+    const { businessMetaData }: any = useAppSelector(
+      (state: any) => state.businessMetaData
     );
 
-    const bmObj = !isEmpty(businessMetaData?.businessMetadataDefs)
-      ? businessMetaData?.businessMetadataDefs?.find((obj: EnumTypeDefData) => {
+    const filteredData = useMemo(() => {
+      return treeData.filter((node) => {
+        return (
+          node.label?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          (node.children &&
+            node.children.some((child) =>
+              child.label?.toLowerCase().includes(searchTerm.toLowerCase())
+            ))
+        );
+      });
+    }, [treeData, searchTerm]);
+
+    const displayTreeName = useMemo(() => {
+      return treeName === "CustomFilters" ? "Custom Filters" : treeName
+    }, [treeName]);
+
+    const highlightText = useMemo(() => {
+      return (text: string) => {
+        if (!searchTerm) return text;
+
+        const parts = text.split(new RegExp(`(${searchTerm})`, "gi"));
+        return parts.map((part, index) =>
+          part.toLowerCase() === searchTerm.toLowerCase() ? (
+            <span key={index} style={{ color: "#D3D3D3", fontWeight: "600" }}>
+              {part}
+            </span>
+          ) : (
+            part
+          )
+        );
+      };
+    }, [searchTerm]);
+
+    const expandedItemsMemo = useMemo(() => {
+      const allNodeIds = filteredData.flatMap((node) => {
+        return [
+          node.id,
+          ...(node.children ? node.children.map((child) => child.id) : []),
+        ];
+      });
+      return [...allNodeIds, ...[treeName]];
+    }, [filteredData, treeName]);
+
+    useEffect(() => {
+      setExpandedItems(expandedItemsMemo);
+    }, [expandedItemsMemo]);
+
+    useEffect(() => {
+      const searchParams = new URLSearchParams(location.search);
+      const nodeIdFromParamsType = searchParams.get("type");
+      const nodeIdFromParamsTag = searchParams.get("tag");
+      const nodeIdFromParamsRelationshipName =
+        searchParams.get("relationshipName");
+      const nodeIdFromBMName = location.pathname.includes(
+        "/administrator/businessMetadata"
+      );
+
+      const bmObj = !isEmpty(businessMetaData?.businessMetadataDefs)
+        ? businessMetaData?.businessMetadataDefs?.find((obj: EnumTypeDefData) => {
           if (bmguid == obj.guid) {
             return obj;
           }
         })
-      : {};
-    const { name = "" } = bmObj || {};
+        : {};
+      const { name = "" } = bmObj || {};
 
-    setSelectedNode({
-      type: nodeIdFromParamsType,
-      tag: nodeIdFromParamsTag,
-      relationship: nodeIdFromParamsRelationshipName,
-      businessMetadata: nodeIdFromBMName ? name : null,
-    });
-
-    if (
-      !nodeIdFromParamsType &&
-      !nodeIdFromParamsTag &&
-      !nodeIdFromParamsRelationshipName &&
-      !nodeIdFromBMName
-    ) {
       setSelectedNode({
-        type: null,
-        tag: null,
-        relationship: null,
-        businessMetadata: null,
+        type: nodeIdFromParamsType,
+        tag: nodeIdFromParamsTag,
+        relationship: nodeIdFromParamsRelationshipName,
+        businessMetadata: nodeIdFromBMName ? name : null,
       });
-    }
-  }, [location.search]);
 
-  const getEmptyTypesTitle = () => {
-    switch (treeName) {
-      case "Entities":
-        return `${isEmptyServicetype ? "Hide" : "Show"} empty service types`;
-
-      case "Classifications":
-        return `${isEmptyServicetype ? "Show" : "Hide"} unused classifications`;
-
-      case "Glossary":
-        return `Show ${isEmptyServicetype ? "Category" : "Term"}`;
-
-      case "CustomFilters":
-        return `Show ${isEmptyServicetype ? "all" : "Type"}`;
-
-      default:
-        return "";
-    }
-  };
-
-  const handleExpandedItemsChange = (
-    _event: SyntheticEvent,
-    newExpandedItems: string[]
-  ) => {
-    setExpandedItems(newExpandedItems);
-  };
-
-  const handleOpenModal = () => {
-    setOpenModal(true);
-  };
-  const handleCloseModal = () => {
-    setOpenModal(false);
-  };
-
-  const handleClickMenu = (event: MouseEvent<HTMLElement>) => {
-    event.stopPropagation();
-    setExpand(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setExpand(null);
-  };
-
-  const handleCloseTagModal = () => {
-    setTagModal(false);
-  };
-  const handleCloseGlossaryModal = () => {
-    setGlossaryModal(false);
-  };
-
-  const handleClickNode = (nodeId: string) => {
-    const searchParams = new URLSearchParams(location.search);
-    const isTypeMatch = searchParams.get("type") === nodeId;
-    const isTagMatch = searchParams.get("tag") === nodeId;
-    const isRelationshipMatch = searchParams.get("relationshipName") === nodeId;
-    const isBusinessMetadataMatch = location.pathname.includes(
-      "/administrator/businessMetadata"
-    );
-
-    if (isTypeMatch) {
-      setSelectedNode({
-        type: nodeId,
-        tag: null,
-        relationship: null,
-        businessMetadata: null,
-      });
-    }
-    if (isTagMatch) {
-      setSelectedNode({
-        type: null,
-        tag: nodeId,
-        relationship: null,
-        businessMetadata: null,
-      });
-    }
-    if (isRelationshipMatch) {
-      setSelectedNode({
-        type: null,
-        tag: null,
-        relationship: nodeId,
-        businessMetadata: null,
-      });
-    }
-    if (isBusinessMetadataMatch) {
-      setSelectedNode({
-        type: null,
-        tag: null,
-        relationship: null,
-        businessMetadata: nodeId,
-      });
-    }
-  };
-
-  const getNodeId = (node: TreeNode) => {
-    if (treeName == "Classifications" && node.types == "parent") {
-      return node.label;
-    } else if (treeName == "Classifications" && node.types == "child") {
-      return `${node.id}@${node.label}`;
-    }
-    return !isEmpty(node?.parent) ? `${node.id}@${node?.parent}` : node.id;
-  };
-
-  const handleNodeClick = (
-    node: TreeNode,
-    treeName: string,
-    searchParams: URLSearchParams,
-    navigate: NavigateFunction,
-    isEmptyServicetype: boolean | undefined,
-    savedSearchData: any,
-    toastId: any
-  ) => {
-    globalSearchFilterInitialQuery.setQuery({});
-    searchParams.delete("tabActive");
-
-    if (treeName === "Classifications") {
-      handleClickNode(node.id);
-    } else {
-      handleClickNode(node.id);
-    }
-
-    if (node.id === "No Records Found") {
-      if (typeof event !== "undefined" && event.stopPropagation) {
-        event.stopPropagation();
+      if (
+        !nodeIdFromParamsType &&
+        !nodeIdFromParamsTag &&
+        !nodeIdFromParamsRelationshipName &&
+        !nodeIdFromBMName
+      ) {
+        setSelectedNode({
+          type: null,
+          tag: null,
+          relationship: null,
+          businessMetadata: null,
+        });
       }
-      return;
-    }
+    }, [location.search]);
 
-    if (shouldSetSearchParams(node, treeName)) {
-      setSearchParams(
-        node,
-        treeName,
-        searchParams,
-        isEmptyServicetype,
-        savedSearchData
+    const getEmptyTypesTitle = () => {
+      switch (treeName) {
+        case "Entities":
+          return `${isEmptyServicetype ? "Hide" : "Show"} empty service types`;
+
+        case "Classifications":
+          return `${isEmptyServicetype ? "Show" : "Hide"} unused classifications`;
+
+        case "Glossary":
+          return `Show ${isEmptyServicetype ? "Category" : "Term"}`;
+
+        case "CustomFilters":
+          return `Show ${isEmptyServicetype ? "all" : "Type"}`;
+
+        default:
+          return "";
+      }
+    };
+
+    const handleExpandedItemsChange = (
+      _event: SyntheticEvent,
+      newExpandedItems: string[]
+    ) => {
+      setExpandedItems(newExpandedItems);
+    };
+
+    const handleOpenModal = () => {
+      setOpenModal(true);
+    };
+    const handleCloseModal = () => {
+      setOpenModal(false);
+    };
+
+    const handleClickMenu = (event: MouseEvent<HTMLElement>) => {
+      event.stopPropagation();
+      setExpand(event.currentTarget);
+    };
+
+    const handleClose = () => {
+      setExpand(null);
+    };
+
+    const handleCloseTagModal = () => {
+      setTagModal(false);
+    };
+    const handleCloseGlossaryModal = () => {
+      setGlossaryModal(false);
+    };
+
+    const handleClickNode = (nodeId: string) => {
+      const searchParams = new URLSearchParams(location.search);
+      const isTypeMatch = searchParams.get("type") === nodeId;
+      const isTagMatch = searchParams.get("tag") === nodeId;
+      const isRelationshipMatch = searchParams.get("relationshipName") === nodeId;
+      const isBusinessMetadataMatch = location.pathname.includes(
+        "/administrator/businessMetadata"
       );
-      navigateToPath(
-        node,
-        treeName,
-        searchParams,
-        navigate,
-        isEmptyServicetype,
-        toastId
-      );
-    }
-  };
 
-  const shouldSetSearchParams = (node: TreeNode, treeName: string) => {
-    if (treeName === "CustomFilters" && node.types === "parent") {
-      return false;
-    }
-    return (
-      node.children === undefined ||
-      isEmpty(node.children) ||
-      treeName === "Classifications" ||
-      (treeName === "Glossary" && node.types === "child")
-    );
-  };
-
-  const setSearchParams = (
-    node: TreeNode,
-    treeName: string,
-    searchParams: URLSearchParams,
-    isEmptyServicetype: boolean | undefined,
-    savedSearchData: any
-  ) => {
-    searchParams.set(
-      "searchType",
-      node.parent === "ADVANCED" ? "dsl" : "basic"
-    );
-
-    switch (treeName) {
-      case "Entities":
-        searchParams.delete("relationshipName");
-        searchParams.set("type", node.id);
-        break;
-      case "Classifications": {
-        searchParams.delete("relationshipName");
-        const id = node.label.split(" (")[0];
-        searchParams.set("tag", id);
-        break;
+      if (isTypeMatch) {
+        setSelectedNode({
+          type: nodeId,
+          tag: null,
+          relationship: null,
+          businessMetadata: null,
+        });
       }
-      case "Glossary":
-        setGlossarySearchParams(node, searchParams, isEmptyServicetype);
-        break;
-      case "Relationships":
-      case "CustomFilters":
-        setCustomFiltersSearchParams(node, searchParams, savedSearchData);
-        break;
-      default:
-        break;
-    }
-
-    if (treeName !== "CustomFilters") {
-    searchParams.delete("attributes");
-    searchParams.delete("entityFilters");
-    searchParams.delete("tagFilters");
-    searchParams.delete("relationshipFilters");
-    searchParams.set("pageLimit", "25");
-    searchParams.set("pageOffset", "0");
-    }
-  };
-
-  const setGlossarySearchParams = (
-    node: TreeNode,
-    searchParams: URLSearchParams,
-    isEmptyServicetype: boolean | undefined
-  ) => {
-    const guid =
-      !isEmptyServicetype && node.cGuid !== undefined
-        ? node.cGuid
-        : node.guid || "";
-    searchParams.delete("relationshipName");
-
-    if (isEmptyServicetype) {
-      searchParams.set("term", `${node.id}@${node.parent}`);
-    } else {
-      searchParams.delete("type");
-      searchParams.delete("tag");
-      searchParams.set("gid", node.guid as string);
-    }
-
-    searchParams.set("gtype", `${isEmptyServicetype ? "term" : "category"}`);
-    searchParams.set("viewType", `${isEmptyServicetype ? "term" : "category"}`);
-    searchParams.set("guid", guid);
-  };
-
-  const setCustomFiltersSearchParams = (
-    node: TreeNode,
-    searchParams: URLSearchParams,
-    savedSearchData: any[]
-  ) => {
-    // Clear all existing params except searchType
-    const keys = Array.from(searchParams.keys());
-    for (let i = 0; i < keys.length; i++) {
-      if (keys[i] !== "searchType") {
-        searchParams.delete(keys[i]);
+      if (isTagMatch) {
+        setSelectedNode({
+          type: null,
+          tag: nodeId,
+          relationship: null,
+          businessMetadata: null,
+        });
       }
-    }
-
-    // Clear globalSearchFilterInitialQuery when applying new saved search
-    globalSearchFilterInitialQuery.setQuery({});
-
-    if (treeName === "CustomFilters") {
-      const params = savedSearchData.find((obj) => obj.name === node.id);
-      if (params) {
-        const searchParamsObj = params?.searchParameters || {};
-        
-        // Step 1: Set searchType based on saved search type
-        if (params.searchType) {
-          const searchTypeValue = params.searchType === "ADVANCED" ? "dsl" : "basic";
-          searchParams.set("searchType", searchTypeValue);
-        }
-        
-        // Step 2: Apply basic search parameters (excluding filters which are handled separately)
-        for (const key in searchParamsObj) {
-          if (shouldSetCustomFilterParam(node, key) && 
-              !["entityFilters", "tagFilters", "relationshipFilters"].includes(key)) {
-            setCustomFilterParam(searchParams, key, searchParamsObj[key]);
-          }
-        }
-        
-        // Step 3: Convert and apply entityFilters from API format to URL string format
-        if (searchParamsObj.entityFilters && !isEmpty(searchParamsObj.entityFilters)) {
-          const clonedFilter = cloneDeep(searchParamsObj.entityFilters);
-          const ruleUrl = attributeFilter.generateUrl({
-            value: clonedFilter,
-            formatedDateToLong: true
-          });
-          
-          if (ruleUrl && !isEmpty(ruleUrl) && typeof ruleUrl === "string") {
-            searchParams.set("entityFilters", ruleUrl);
-            
-            // Convert API format to query builder format for Filters component UI
-            const qbFilter = convertApiToQueryBuilder(searchParamsObj.entityFilters);
-            if (qbFilter && (qbFilter.rules || qbFilter.combinator)) {
-              globalSearchFilterInitialQuery.setQuery({ 
-                entityFilters: qbFilter 
-              });
-            }
-          }
-        }
-        
-        // Step 4: Convert and apply tagFilters from API format to URL string format
-        if (searchParamsObj.tagFilters && !isEmpty(searchParamsObj.tagFilters)) {
-          const clonedFilter = cloneDeep(searchParamsObj.tagFilters);
-          const ruleUrl = attributeFilter.generateUrl({
-            value: clonedFilter,
-            formatedDateToLong: true
-          });
-          
-          if (ruleUrl && !isEmpty(ruleUrl) && typeof ruleUrl === "string") {
-            searchParams.set("tagFilters", ruleUrl);
-            
-            // Convert API format to query builder format for Filters component UI
-            const qbFilter = convertApiToQueryBuilder(searchParamsObj.tagFilters);
-            if (qbFilter && (qbFilter.rules || qbFilter.combinator)) {
-              globalSearchFilterInitialQuery.setQuery({ 
-                tagFilters: qbFilter 
-              });
-            }
-          }
-        }
-        
-        // Step 5: Convert and apply relationshipFilters from API format to URL string format
-        if (searchParamsObj.relationshipFilters && !isEmpty(searchParamsObj.relationshipFilters)) {
-          const clonedFilter = cloneDeep(searchParamsObj.relationshipFilters);
-          const ruleUrl = attributeFilter.generateUrl({
-            value: clonedFilter,
-            formatedDateToLong: true
-          });
-          
-          if (ruleUrl && !isEmpty(ruleUrl) && typeof ruleUrl === "string") {
-            searchParams.set("relationshipFilters", ruleUrl);
-            
-            // Convert API format to query builder format for Filters component UI
-            const qbFilter = convertApiToQueryBuilder(searchParamsObj.relationshipFilters);
-            if (qbFilter && (qbFilter.rules || qbFilter.combinator)) {
-              globalSearchFilterInitialQuery.setQuery({ 
-                relationshipFilters: qbFilter 
-              });
-            }
-          }
-        }
-        
-      searchParams.set("isCF", "true");
+      if (isRelationshipMatch) {
+        setSelectedNode({
+          type: null,
+          tag: null,
+          relationship: nodeId,
+          businessMetadata: null,
+        });
       }
-    } else {
-      searchParams.set("relationshipName", node.id);
-    }
-  };
-  
-  // Helper function to convert API format filter (criterion/condition) to query builder format (rules/combinator)
-  const convertApiToQueryBuilder = (apiFilter: any): any => {
-    if (!apiFilter || typeof apiFilter !== "object") {
-      return null;
-    }
-    
-    const result: any = {};
-    
-    // Convert condition to combinator
-    if (apiFilter.condition) {
-      result.combinator = apiFilter.condition.toLowerCase();
-    } else {
-      result.combinator = "and"; // default
-    }
-    
-    // Convert criterion to rules
-    if (apiFilter.criterion && Array.isArray(apiFilter.criterion)) {
-      result.rules = apiFilter.criterion.map((rule: any) => {
-        // If nested condition, recurse
-        if (rule.condition || rule.criterion) {
-          return convertApiToQueryBuilder(rule);
-        }
-        // Convert API rule format to query builder format
-        return {
-          field: rule.attributeName || rule.id,
-          operator: rule.operator,
-          value: rule.attributeValue || rule.value,
-          type: rule.type || rule.attributeType
-        };
-      });
-    } else if (apiFilter.rules && Array.isArray(apiFilter.rules)) {
-      // Already in query builder format
-      result.rules = apiFilter.rules.map((rule: any) => 
-        rule.condition || rule.criterion ? convertApiToQueryBuilder(rule) : rule
-      );
-    }
-    
-    return Object.keys(result).length > 0 ? result : null;
-  };
-
-  const shouldSetCustomFilterParam = (node: TreeNode, key: string) => {
-    return (
-      node.parent === "BASIC" ||
-      node.parent === "ADVANCED" ||
-      (node.parent === "BASIC_RELATIONSHIP" &&
-        (key === "relationshipName" || key === "limit" || key === "offset"))
-    );
-  };
-
-  const setCustomFilterParam = (
-    searchParams: URLSearchParams,
-    key: string,
-    value: any
-  ) => {
-    if (key === "limit") {
-      searchParams.set("pageLimit", value || 25);
-    } else if (key === "offset") {
-      searchParams.set("pageOffset", value);
-    } else if (key === "typeName") {
-      searchParams.set("type", value);
-    } else if (key === "classification") {
-      // Map classification to tag parameter for URL (matching classic UI)
-      searchParams.set("tag", value);
-    } else if (key === "termName") {
-      // Map termName (API format) to term parameter for URL (matching classic UI)
-      searchParams.set("term", value);
-    } else if (value !== null && value !== undefined && value !== "") {
-      // Only set parameter if value is not null, undefined, or empty string
-      searchParams.set(key, value);
-    }
-  };
-
-  const navigateToPath = (
-    node: TreeNode,
-    treeName: string,
-    searchParams: URLSearchParams,
-    navigate: NavigateFunction,
-    isEmptyServicetype: boolean | undefined,
-    toastId: any
-  ) => {
-    switch (treeName) {
-      case "Business MetaData":
-        searchParams.delete("relationshipName");
-        navigate(
-          { pathname: `administrator/businessMetadata/${node.guid}` },
-          { replace: true }
-        );
-        break;
-      case "Glossary":
-        if (!isEmptyServicetype) {
-          searchParams.delete("relationshipName");
-          navigate(
-            {
-              pathname: `glossary/${
-                node.cGuid !== undefined ? node.cGuid : node.guid
-              }`,
-              search: searchParams.toString(),
-            },
-            { replace: true }
-          );
-        } else if (node.types === "parent") {
-          toast.dismiss(toastId.current);
-          toastId.current = toast.warning("Create a Term or Category");
-        } else {
-          searchParams.delete("relationshipName");
-          navigate(
-            {
-              pathname: "/search/searchResult",
-              search: searchParams.toString(),
-            },
-            { replace: true }
-          );
-        }
-        break;
-      case "Relationships":
-      case "CustomFilters":
-        if (
-          treeName == "Relationships" ||
-          (treeName == "CustomFilters" && node.parent == "BASIC_RELATIONSHIP")
-        ) {
-          navigate(
-            {
-              pathname: `relationship/relationshipSearchresult`,
-              search: searchParams.toString(),
-            },
-            { replace: true }
-          );
-        } else {
-          searchParams.delete("relationshipName");
-          navigate(
-            {
-              pathname: "/search/searchResult",
-              search: searchParams.toString(),
-            },
-            { replace: true }
-          );
-        }
-        break;
-      default:
-        searchParams.delete("relationshipName");
-        navigate(
-          { pathname: "/search/searchResult", search: searchParams.toString() },
-          { replace: true }
-        );
-        break;
-    }
-  };
-
-  const TreeLabelWithTooltip: React.FC<{ label: string }> = ({ label }) => {
-    const labelRef = useRef<HTMLSpanElement>(null);
-    const [isOverflown, setIsOverflown] = useState(false);
-
-    useEffect(() => {
-      const el = labelRef.current;
-      if (el) {
-        setIsOverflown(el.scrollWidth > el.clientWidth);
+      if (isBusinessMetadataMatch) {
+        setSelectedNode({
+          type: null,
+          tag: null,
+          relationship: null,
+          businessMetadata: nodeId,
+        });
       }
-    }, [label, searchTerm]);
+    };
 
-    return (
-      <LightTooltip title={label} disableHoverListener={!isOverflown}>
-        <span
-          ref={labelRef}
-          className="tree-item-label"
-          style={{
-            display: "inline-block",
-            maxWidth: "100%",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {highlightText(label)}
-        </span>
-      </LightTooltip>
-    );
-  };
-
-  const renderTreeItem = (node: TreeNode) =>
-    node?.id && (
-      <CustomTreeItem
-        key={node.id}
-        itemId={getNodeId(node)}
-        label={
-          <div
-            {...({
-              selectedNodeType: selectedNode.type,
-              selectedNodeTag: selectedNode.tag,
-              selectedNodeRelationship: selectedNode.relationship,
-              selectedNodeBM: selectedNode.businessMetadata,
-              node: node.id,
-              onClick: (_event: MouseEvent<HTMLElement>) => {
-                handleNodeClick(
-                  node,
-                  treeName,
-                  searchParams,
-                  navigate,
-                  isEmptyServicetype,
-                  savedSearchData,
-                  toastId
-                );
-              },
-              className: "custom-treeitem-label",
-            } as any)}
-          >
-            {node.id != "No Records Found" && (
-              <TreeIcons
-                node={node}
-                treeName={treeName}
-                isEmptyServicetype={isEmptyServicetype ?? false}
-              />
-            )}
-            <TreeLabelWithTooltip label={node.label} />
-            {(treeName == "Entities" ||
-              treeName == "Classifications" ||
-              treeName == "CustomFilters" ||
-              treeName == "Glossary") &&
-              node.id != "No Records Found" && (
-                <TreeNodeIcons
-                  node={node}
-                  treeName={treeName}
-                  updatedData={refreshData}
-                  isEmptyServicetype={isEmptyServicetype}
-                />
-              )}
-          </div>
+    const getNodeId = (node: TreeNode) => {
+      if (treeName == "Classifications" && node.types == "parent") {
+        return node.label;
+      } else if (treeName == "Classifications" && node.types == "child") {
+        return `${node.id}@${node.label}`;
+      } else if (treeName == "Glossary") {
+        if (node.types === "child") {
+          return node.cGuid ? node.cGuid : `${node.id}@${node?.parent}`;
         }
-      >
-        {node.children && node.children.map((child) => renderTreeItem(child))}
-      </CustomTreeItem>
-    );
+        return node.guid ? node.guid : node.id;
+      }
+      return !isEmpty(node?.parent) ? `${node.id}@${node?.parent}` : node.id;
+    };
 
-  const downloadFile = async () => {
-    try {
-      if (treeName == "Glossary") {
-        await downloadGlossaryImportTemplate();
+    const handleNodeClick = (
+      node: TreeNode,
+      treeName: string,
+      searchParams: URLSearchParams,
+      navigate: NavigateFunction,
+      isEmptyServicetype: boolean | undefined,
+      savedSearchData: any,
+      toastId: any
+    ) => {
+      globalSearchFilterInitialQuery.setQuery({});
+      searchParams.delete("tabActive");
+
+      if (treeName === "Classifications") {
+        handleClickNode(node.id);
+      } else {
+        handleClickNode(node.id);
+      }
+
+      if (node.id === "No Records Found") {
+        if (typeof event !== "undefined" && event.stopPropagation) {
+          event.stopPropagation();
+        }
         return;
       }
-      const apiResp: any = await getBusinessMetadataImportTmpl({});
-      const text: string = apiResp ? apiResp.data : "";
-      const blob = new Blob([text], { type: "text/plain" });
 
-      const url = window.URL.createObjectURL(blob);
+      if (shouldSetSearchParams(node, treeName)) {
+        setSearchParams(
+          node,
+          treeName,
+          searchParams,
+          isEmptyServicetype,
+          savedSearchData
+        );
+        navigateToPath(
+          node,
+          treeName,
+          searchParams,
+          navigate,
+          isEmptyServicetype,
+          toastId
+        );
+      }
+    };
 
-      const link = document.createElement("a");
-      link.href = url;
-      link.setAttribute("download", "template_business_metadata");
+    const shouldSetSearchParams = (node: TreeNode, treeName: string) => {
+      if (treeName === "CustomFilters" && node.types === "parent") {
+        return false;
+      }
+      return (
+        node.children === undefined ||
+        isEmpty(node.children) ||
+        treeName === "Classifications" ||
+        (treeName === "Glossary" && node.types === "child")
+      );
+    };
 
-      document.body.appendChild(link);
+    const setSearchParams = (
+      node: TreeNode,
+      treeName: string,
+      searchParams: URLSearchParams,
+      isEmptyServicetype: boolean | undefined,
+      savedSearchData: any
+    ) => {
+      searchParams.set(
+        "searchType",
+        node.parent === "ADVANCED" ? "dsl" : "basic"
+      );
 
-      link.click();
+      switch (treeName) {
+        case "Entities":
+          searchParams.delete("relationshipName");
+          searchParams.set("type", node.id);
+          break;
+        case "Classifications": {
+          searchParams.delete("relationshipName");
+          const id = node.label.split(" (")[0];
+          searchParams.set("tag", id);
+          break;
+        }
+        case "Glossary":
+          setGlossarySearchParams(node, searchParams, isEmptyServicetype);
+          break;
+        case "Relationships":
+        case "CustomFilters":
+          setCustomFiltersSearchParams(node, searchParams, savedSearchData);
+          break;
+        default:
+          break;
+      }
 
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
-    } catch {
-      /* ignore download error */
-    }
-  };
+      if (treeName !== "CustomFilters") {
+        searchParams.delete("attributes");
+        searchParams.delete("entityFilters");
+        searchParams.delete("tagFilters");
+        searchParams.delete("relationshipFilters");
+        searchParams.set("pageLimit", "25");
+        searchParams.set("pageOffset", "0");
+      }
+    };
 
-  const label = { inputProps: { "aria-label": "Switch demo" } };
-  return (
-    <>
-      <Stack
-        className="sidebar-tree-box"
-        sx={{
-          ...(sideBarOpen == false && {
-            visibility: "hidden !important",
-            top: "62px !important",
-          }),
-          minWidth: "30px",
-          width: `100% !important`,
-          overflowX: "auto",
-        }}
-      >
-        <SimpleTreeView
-          expandedItems={expandedItems}
-          onExpandedItemsChange={handleExpandedItemsChange}
-          aria-label="customized"
-          className="sidebar-treeview"
-        >
-          <TreeItem
-            itemId={treeName}
-            label={
-              <Stack
-                display="flex"
-                alignItems="center"
-                flexDirection="row"
-                className="tree-item-parent-label"
-              >
-                <Stack flexGrow={1}>
-                  <span>{displayTreeName}</span>
-                </Stack>
-                <Stack direction="row" alignItems="center" gap="0.375rem">
-                  <LightTooltip title="Refresh">
-                    <IconButton
-                      size="small"
-                      data-cy="refreshTree"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        refreshData();
-                      }}
-                      disabled={loader}
-                    >
-                      <RefreshIcon />
-                    </IconButton>
-                  </LightTooltip>
+    const setGlossarySearchParams = (
+      node: TreeNode,
+      searchParams: URLSearchParams,
+      isEmptyServicetype: boolean | undefined
+    ) => {
+      const guid =
+        !isEmptyServicetype && node.cGuid !== undefined
+          ? node.cGuid
+          : node.guid || "";
+      searchParams.delete("relationshipName");
 
+      if (isEmptyServicetype) {
+        const termName = node.id.endsWith(`@${node.parent}`) ? node.id : `${node.id}@${node.parent}`;
+        searchParams.set("term", termName);
+      } else {
+        searchParams.delete("type");
+        searchParams.delete("tag");
+        searchParams.set("gid", node.guid as string);
+      }
 
-                  {(treeName == "Entities" ||
-                    treeName == "Classifications" ||
-                    treeName == "Glossary") && (
-                    <>
-                      {
-                        <LightTooltip title={getEmptyTypesTitle()}>
-                          <AntSwitch
-                            {...label}
-                            size="small"
-                            onClick={(e: { stopPropagation: () => void }) => {
-                              e.stopPropagation();
-                              if (setisEmptyServicetype) {
-                                setisEmptyServicetype(!isEmptyServicetype);
-                              }
-                            }}
-                            data-cy="showEmptyServiceType"
-                            inputProps={{ "aria-label": "ant design" }}
-                          />
-                        </LightTooltip>
-                      }
-                    </>
-                  )}
+      searchParams.set("gtype", `${isEmptyServicetype ? "term" : "category"}`);
+      searchParams.set("viewType", `${isEmptyServicetype ? "term" : "category"}`);
+      searchParams.set("guid", guid);
+    };
 
-                  {(treeName == "Entities" ||
-                    treeName == "Classifications" ||
-                    treeName == "Glossary") && (
-                    <MoreVertIcon
-                      onClick={(e: any) => {
-                        e.stopPropagation();
-                        handleClickMenu(e);
-                      }}
-                      data-cy="dropdownMenuButton"
-                      fontSize="small"
-                    />
-                  )}
+    const setCustomFiltersSearchParams = (
+      node: TreeNode,
+      searchParams: URLSearchParams,
+      savedSearchData: any[]
+    ) => {
+      // Clear all existing params except searchType
+      const keys = Array.from(searchParams.keys());
+      for (let i = 0; i < keys.length; i++) {
+        if (keys[i] !== "searchType") {
+          searchParams.delete(keys[i]);
+        }
+      }
 
-                  {treeName == "Business MetaData" && (
-                    <LightTooltip title="Open Businesss Metadata">
-                      <LaunchOutlinedIcon
-                        fontSize="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          const newSearchParams = new URLSearchParams();
+      // Clear globalSearchFilterInitialQuery when applying new saved search
+      globalSearchFilterInitialQuery.setQuery({});
 
-                          newSearchParams.set("tabActive", "businessMetadata");
-                          navigate(
-                            {
-                              pathname: `administrator`,
-                              search: newSearchParams.toString(),
-                            },
-                            { replace: true }
-                          );
-                        }}
-                        data-cy="createBusinessMetadata"
-                      />
-                    </LightTooltip>
-                  )}
-                </Stack>
-                <Menu
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                  anchorEl={expand}
-                  id="account-menu"
-                  open={open}
-                  onClose={handleClose}
-                  transformOrigin={{ horizontal: "right", vertical: "top" }}
-                  anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
-                  sx={{
-                    "& .MuiPaper-root": {
-                      transition: "none !important",
-                    },
-                  }}
-                  disableScrollLock={true}
-                >
-                  {(treeName == "Entities" ||
-                    treeName == "Classifications") && (
-                    <MenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (setisGroupView) {
-                          setisGroupView(!isGroupView);
-                        }
-                        handleClose();
-                      }}
-                      data-cy="groupOrFlatTreeView"
-                      className="sidebar-menu-item"
-                    >
-                      <ListItemIcon
-                        sx={{ minWidth: "28px !important" }}
-                        data-cy="groupOrFlatTreeView"
-                      >
-                        {isGroupView ? (
-                          <FormatListBulletedIcon
-                            fontSize="small"
-                            className="menuitem-icon"
-                          />
-                        ) : (
-                          <AccountTreeIcon
-                            fontSize="small"
-                            className="menuitem-icon"
-                          />
-                        )}
-                      </ListItemIcon>
-                      <Typography className="menuitem-label">
-                        Show {isGroupView ? "flat" : "group"} tree
-                      </Typography>
-                    </MenuItem>
-                  )}
-                  {(treeName == "Classifications" ||
-                    treeName == "Glossary") && (
-                    <MenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (treeName == "Classifications") {
-                          setTagModal(true);
-                        } else if (treeName == "Glossary") {
-                          setGlossaryModal(true);
-                        }
-                        handleClose();
-                      }}
-                      data-cy="createClassification"
-                      className="sidebar-menu-item"
-                    >
-                      <ListItemIcon
-                        sx={{ minWidth: "28px !important" }}
-                        data-cy="createTag"
-                      >
-                        <AddIcon fontSize="small" className="menuitem-icon" />
-                      </ListItemIcon>
-                      <Typography className="menuitem-label">
-                        Create{" "}
-                        {treeName == "Classifications"
-                          ? "Classifications"
-                          : "Glossary"}
-                      </Typography>
-                    </MenuItem>
-                  )}
-                  {(treeName == "Entities" || treeName == "Glossary") && (
-                    <MenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        downloadFile();
-                        handleClose();
-                      }}
-                      data-cy="downloadBusinessMetadata"
-                      disabled={
-                        treeName == "Glossary" && !isEmptyServicetype
-                          ? true
-                          : false
-                      }
-                      className="sidebar-menu-item"
-                    >
-                      <ListItemIcon sx={{ minWidth: "28px !important" }}>
-                        <FileDownloadIcon
-                          fontSize="small"
-                          className="menuitem-icon"
-                        />
-                      </ListItemIcon>
-                      <Typography className="menuitem-label">
-                        Download Import template
-                      </Typography>
-                    </MenuItem>
-                  )}
-                  {(treeName == "Entities" || treeName == "Glossary") && (
-                    <MenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleOpenModal();
-                        handleClose();
-                      }}
-                      data-cy="importBusinessMetadata"
-                      disabled={
-                        treeName == "Glossary" && !isEmptyServicetype
-                          ? true
-                          : false
-                      }
-                      className="sidebar-menu-item"
-                    >
-                      <ListItemIcon sx={{ minWidth: "28px !important" }}>
-                        <FileUploadIcon
-                          fontSize="small"
-                          className="menuitem-icon"
-                        />
-                      </ListItemIcon>
+      if (treeName === "CustomFilters") {
+        const params = savedSearchData.find((obj) => obj.name === node.id);
+        if (params) {
+          const searchParamsObj = params?.searchParameters || {};
 
-                      <Typography className="menuitem-label">
-                        {treeName == "Entities"
-                          ? "Import Business Metadata"
-                          : "Import Glossary Term"}
-                      </Typography>
-                    </MenuItem>
-                  )}
-                </Menu>
-              </Stack>
+          // Step 1: Set searchType based on saved search type
+          if (params.searchType) {
+            const searchTypeValue = params.searchType === "ADVANCED" ? "dsl" : "basic";
+            searchParams.set("searchType", searchTypeValue);
+          }
+
+          // Step 2: Apply basic search parameters (excluding filters which are handled separately)
+          for (const key in searchParamsObj) {
+            if (shouldSetCustomFilterParam(node, key) &&
+              !["entityFilters", "tagFilters", "relationshipFilters"].includes(key)) {
+              setCustomFilterParam(searchParams, key, searchParamsObj[key]);
             }
-            sx={{
-              "& .MuiTreeItem-label": {
-                fontWeight: "600  !important",
-                fontSize: "14px  !important",
-                lineHeight: "26px !important",
-                color: "white",
+          }
+
+          // Step 3: Convert and apply entityFilters from API format to URL string format
+          if (searchParamsObj.entityFilters && !isEmpty(searchParamsObj.entityFilters)) {
+            const clonedFilter = cloneDeep(searchParamsObj.entityFilters);
+            const ruleUrl = attributeFilter.generateUrl({
+              value: clonedFilter,
+              formatedDateToLong: true
+            });
+
+            if (ruleUrl && !isEmpty(ruleUrl) && typeof ruleUrl === "string") {
+              searchParams.set("entityFilters", ruleUrl);
+
+              // Convert API format to query builder format for Filters component UI
+              const qbFilter = convertApiToQueryBuilder(searchParamsObj.entityFilters);
+              if (qbFilter && (qbFilter.rules || qbFilter.combinator)) {
+                globalSearchFilterInitialQuery.setQuery({
+                  entityFilters: qbFilter
+                });
+              }
+            }
+          }
+
+          // Step 4: Convert and apply tagFilters from API format to URL string format
+          if (searchParamsObj.tagFilters && !isEmpty(searchParamsObj.tagFilters)) {
+            const clonedFilter = cloneDeep(searchParamsObj.tagFilters);
+            const ruleUrl = attributeFilter.generateUrl({
+              value: clonedFilter,
+              formatedDateToLong: true
+            });
+
+            if (ruleUrl && !isEmpty(ruleUrl) && typeof ruleUrl === "string") {
+              searchParams.set("tagFilters", ruleUrl);
+
+              // Convert API format to query builder format for Filters component UI
+              const qbFilter = convertApiToQueryBuilder(searchParamsObj.tagFilters);
+              if (qbFilter && (qbFilter.rules || qbFilter.combinator)) {
+                globalSearchFilterInitialQuery.setQuery({
+                  tagFilters: qbFilter
+                });
+              }
+            }
+          }
+
+          // Step 5: Convert and apply relationshipFilters from API format to URL string format
+          if (searchParamsObj.relationshipFilters && !isEmpty(searchParamsObj.relationshipFilters)) {
+            const clonedFilter = cloneDeep(searchParamsObj.relationshipFilters);
+            const ruleUrl = attributeFilter.generateUrl({
+              value: clonedFilter,
+              formatedDateToLong: true
+            });
+
+            if (ruleUrl && !isEmpty(ruleUrl) && typeof ruleUrl === "string") {
+              searchParams.set("relationshipFilters", ruleUrl);
+
+              // Convert API format to query builder format for Filters component UI
+              const qbFilter = convertApiToQueryBuilder(searchParamsObj.relationshipFilters);
+              if (qbFilter && (qbFilter.rules || qbFilter.combinator)) {
+                globalSearchFilterInitialQuery.setQuery({
+                  relationshipFilters: qbFilter
+                });
+              }
+            }
+          }
+
+          searchParams.set("isCF", "true");
+        }
+      } else {
+        searchParams.set("relationshipName", node.id);
+      }
+    };
+
+    // Helper function to convert API format filter (criterion/condition) to query builder format (rules/combinator)
+    const convertApiToQueryBuilder = (apiFilter: any): any => {
+      if (!apiFilter || typeof apiFilter !== "object") {
+        return null;
+      }
+
+      const result: any = {};
+
+      // Convert condition to combinator
+      if (apiFilter.condition) {
+        result.combinator = apiFilter.condition.toLowerCase();
+      } else {
+        result.combinator = "and"; // default
+      }
+
+      // Convert criterion to rules
+      if (apiFilter.criterion && Array.isArray(apiFilter.criterion)) {
+        result.rules = apiFilter.criterion.map((rule: any) => {
+          // If nested condition, recurse
+          if (rule.condition || rule.criterion) {
+            return convertApiToQueryBuilder(rule);
+          }
+          // Convert API rule format to query builder format
+          return {
+            field: rule.attributeName || rule.id,
+            operator: rule.operator,
+            value: rule.attributeValue || rule.value,
+            type: rule.type || rule.attributeType
+          };
+        });
+      } else if (apiFilter.rules && Array.isArray(apiFilter.rules)) {
+        // Already in query builder format
+        result.rules = apiFilter.rules.map((rule: any) =>
+          rule.condition || rule.criterion ? convertApiToQueryBuilder(rule) : rule
+        );
+      }
+
+      return Object.keys(result).length > 0 ? result : null;
+    };
+
+    const shouldSetCustomFilterParam = (node: TreeNode, key: string) => {
+      return (
+        node.parent === "BASIC" ||
+        node.parent === "ADVANCED" ||
+        (node.parent === "BASIC_RELATIONSHIP" &&
+          (key === "relationshipName" || key === "limit" || key === "offset"))
+      );
+    };
+
+    const setCustomFilterParam = (
+      searchParams: URLSearchParams,
+      key: string,
+      value: any
+    ) => {
+      if (key === "limit") {
+        searchParams.set("pageLimit", value || 25);
+      } else if (key === "offset") {
+        searchParams.set("pageOffset", value);
+      } else if (key === "typeName") {
+        searchParams.set("type", value);
+      } else if (key === "classification") {
+        // Map classification to tag parameter for URL (matching classic UI)
+        searchParams.set("tag", value);
+      } else if (key === "termName") {
+        // Map termName (API format) to term parameter for URL (matching classic UI)
+        searchParams.set("term", value);
+      } else if (value !== null && value !== undefined && value !== "") {
+        // Only set parameter if value is not null, undefined, or empty string
+        searchParams.set(key, value);
+      }
+    };
+
+    const navigateToPath = (
+      node: TreeNode,
+      treeName: string,
+      searchParams: URLSearchParams,
+      navigate: NavigateFunction,
+      isEmptyServicetype: boolean | undefined,
+      toastId: any
+    ) => {
+      switch (treeName) {
+        case "Business MetaData":
+          searchParams.delete("relationshipName");
+          navigate(
+            { pathname: `administrator/businessMetadata/${node.guid}` },
+            { replace: true }
+          );
+          break;
+        case "Glossary":
+          if (!isEmptyServicetype) {
+            searchParams.delete("relationshipName");
+            navigate(
+              {
+                pathname: `glossary/${node.cGuid !== undefined ? node.cGuid : node.guid
+                  }`,
+                search: searchParams.toString(),
               },
-              "& .MuiTreeItem-content svg": {
-                color: "white",
-                fontSize: "20px !important",
+              { replace: true }
+            );
+          } else if (node.types === "parent") {
+            toast.dismiss(toastId.current);
+            toastId.current = toast.warning("Create a Term or Category");
+          } else {
+            searchParams.delete("relationshipName");
+            navigate(
+              {
+                pathname: "/search/searchResult",
+                search: searchParams.toString(),
               },
+              { replace: true }
+            );
+          }
+          break;
+        case "Relationships":
+        case "CustomFilters":
+          if (
+            treeName == "Relationships" ||
+            (treeName == "CustomFilters" && node.parent == "BASIC_RELATIONSHIP")
+          ) {
+            navigate(
+              {
+                pathname: `relationship/relationshipSearchresult`,
+                search: searchParams.toString(),
+              },
+              { replace: true }
+            );
+          } else {
+            searchParams.delete("relationshipName");
+            navigate(
+              {
+                pathname: "/search/searchResult",
+                search: searchParams.toString(),
+              },
+              { replace: true }
+            );
+          }
+          break;
+        default:
+          searchParams.delete("relationshipName");
+          navigate(
+            { pathname: "/search/searchResult", search: searchParams.toString() },
+            { replace: true }
+          );
+          break;
+      }
+    };
+
+    const TreeLabelWithTooltip: React.FC<{ label: string }> = ({ label }) => {
+      const labelRef = useRef<HTMLSpanElement>(null);
+      const [isOverflown, setIsOverflown] = useState(false);
+
+      useEffect(() => {
+        const el = labelRef.current;
+        if (el) {
+          setIsOverflown(el.scrollWidth > el.clientWidth);
+        }
+      }, [label, searchTerm]);
+
+      return (
+        <LightTooltip title={label} disableHoverListener={!isOverflown}>
+          <span
+            ref={labelRef}
+            className="tree-item-label"
+            style={{
+              display: "inline-block",
+              maxWidth: "100%",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
             }}
           >
-            {loader ? (
-              <SkeletonLoader animation="pulse" variant="text" width={300} count={5}/>
-            ) : (
-              filteredData.map((node: TreeNode) => renderTreeItem(node))
-            )}
-          </TreeItem>
+            {highlightText(label)}
+          </span>
+        </LightTooltip>
+      );
+    };
 
-          <ImportDialog
-            open={openModal}
-            onClose={handleCloseModal}
-            title={
-              treeName == "Entities"
-                ? "Import Business Metadata"
-                : "Import Glossary Term"
-            }
+    const renderTreeItem = (node: TreeNode) =>
+      node?.id && (
+        <CustomTreeItem
+          key={node.id}
+          itemId={getNodeId(node)}
+          label={
+            <div
+              {...({
+                selectedNodeType: selectedNode.type,
+                selectedNodeTag: selectedNode.tag,
+                selectedNodeRelationship: selectedNode.relationship,
+                selectedNodeBM: selectedNode.businessMetadata,
+                node: node.id,
+                onClick: (_event: MouseEvent<HTMLElement>) => {
+                  handleNodeClick(
+                    node,
+                    treeName,
+                    searchParams,
+                    navigate,
+                    isEmptyServicetype,
+                    savedSearchData,
+                    toastId
+                  );
+                },
+                className: "custom-treeitem-label",
+              } as any)}
+            >
+              {node.id != "No Records Found" && (
+                <TreeIcons
+                  node={node}
+                  treeName={treeName}
+                  isEmptyServicetype={isEmptyServicetype ?? false}
+                />
+              )}
+              <TreeLabelWithTooltip label={node.label} />
+              {(treeName == "Entities" ||
+                treeName == "Classifications" ||
+                treeName == "CustomFilters" ||
+                treeName == "Glossary") &&
+                node.id != "No Records Found" && (
+                  <TreeNodeIcons
+                    node={node}
+                    treeName={treeName}
+                    updatedData={refreshData}
+                    isEmptyServicetype={isEmptyServicetype}
+                  />
+                )}
+            </div>
+          }
+        >
+          {node.children && node.children.map((child) => renderTreeItem(child))}
+        </CustomTreeItem>
+      );
+
+    const downloadFile = async () => {
+      try {
+        if (treeName == "Glossary") {
+          await downloadGlossaryImportTemplate();
+          return;
+        }
+        const apiResp: any = await getBusinessMetadataImportTmpl({});
+        const text: string = apiResp ? apiResp.data : "";
+        const blob = new Blob([text], { type: "text/plain" });
+
+        const url = window.URL.createObjectURL(blob);
+
+        const link = document.createElement("a");
+        link.href = url;
+        link.setAttribute("download", "template_business_metadata");
+
+        document.body.appendChild(link);
+
+        link.click();
+
+        document.body.removeChild(link);
+        window.URL.revokeObjectURL(url);
+      } catch {
+        /* ignore download error */
+      }
+    };
+
+    const label = { inputProps: { "aria-label": "Switch demo" } };
+    return (
+      <>
+        <Stack
+          className="sidebar-tree-box"
+          sx={{
+            ...(sideBarOpen == false && {
+              visibility: "hidden !important",
+              top: "62px !important",
+            }),
+            minWidth: "30px",
+            width: `100% !important`,
+            overflowX: "auto",
+          }}
+        >
+          <SimpleTreeView
+            expandedItems={expandedItems}
+            onExpandedItemsChange={handleExpandedItemsChange}
+            aria-label="customized"
+            className="sidebar-treeview"
+          >
+            <TreeItem
+              itemId={treeName}
+              label={
+                <Stack
+                  display="flex"
+                  alignItems="center"
+                  flexDirection="row"
+                  className="tree-item-parent-label"
+                >
+                  <Stack flexGrow={1}>
+                    <span>{displayTreeName}</span>
+                  </Stack>
+                  <Stack direction="row" alignItems="center" gap="0.375rem">
+                    <LightTooltip title="Refresh">
+                      <IconButton
+                        size="small"
+                        data-cy="refreshTree"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          refreshData();
+                        }}
+                        disabled={loader}
+                      >
+                        <RefreshIcon />
+                      </IconButton>
+                    </LightTooltip>
+
+
+                    {(treeName == "Entities" ||
+                      treeName == "Classifications" ||
+                      treeName == "Glossary") && (
+                        <>
+                          {
+                            <LightTooltip title={getEmptyTypesTitle()}>
+                              <AntSwitch
+                                {...label}
+                                size="small"
+                                onClick={(e: { stopPropagation: () => void }) => {
+                                  e.stopPropagation();
+                                  if (setisEmptyServicetype) {
+                                    setisEmptyServicetype(!isEmptyServicetype);
+                                  }
+                                }}
+                                data-cy="showEmptyServiceType"
+                                inputProps={{ "aria-label": "ant design" }}
+                              />
+                            </LightTooltip>
+                          }
+                        </>
+                      )}
+
+                    {(treeName == "Entities" ||
+                      treeName == "Classifications" ||
+                      treeName == "Glossary") && (
+                        <MoreVertIcon
+                          onClick={(e: any) => {
+                            e.stopPropagation();
+                            handleClickMenu(e);
+                          }}
+                          data-cy="dropdownMenuButton"
+                          fontSize="small"
+                        />
+                      )}
+
+                    {treeName == "Business MetaData" && (
+                      <LightTooltip title="Open Businesss Metadata">
+                        <LaunchOutlinedIcon
+                          fontSize="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            const newSearchParams = new URLSearchParams();
+
+                            newSearchParams.set("tabActive", "businessMetadata");
+                            navigate(
+                              {
+                                pathname: `administrator`,
+                                search: newSearchParams.toString(),
+                              },
+                              { replace: true }
+                            );
+                          }}
+                          data-cy="createBusinessMetadata"
+                        />
+                      </LightTooltip>
+                    )}
+                  </Stack>
+                  <Menu
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                    anchorEl={expand}
+                    id="account-menu"
+                    open={open}
+                    onClose={handleClose}
+                    transformOrigin={{ horizontal: "right", vertical: "top" }}
+                    anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+                    sx={{
+                      "& .MuiPaper-root": {
+                        transition: "none !important",
+                      },
+                    }}
+                    disableScrollLock={true}
+                  >
+                    {(treeName == "Entities" ||
+                      treeName == "Classifications") && (
+                        <MenuItem
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (setisGroupView) {
+                              setisGroupView(!isGroupView);
+                            }
+                            handleClose();
+                          }}
+                          data-cy="groupOrFlatTreeView"
+                          className="sidebar-menu-item"
+                        >
+                          <ListItemIcon
+                            sx={{ minWidth: "28px !important" }}
+                            data-cy="groupOrFlatTreeView"
+                          >
+                            {isGroupView ? (
+                              <FormatListBulletedIcon
+                                fontSize="small"
+                                className="menuitem-icon"
+                              />
+                            ) : (
+                              <AccountTreeIcon
+                                fontSize="small"
+                                className="menuitem-icon"
+                              />
+                            )}
+                          </ListItemIcon>
+                          <Typography className="menuitem-label">
+                            Show {isGroupView ? "flat" : "group"} tree
+                          </Typography>
+                        </MenuItem>
+                      )}
+                    {(treeName == "Classifications" ||
+                      treeName == "Glossary") && (
+                        <MenuItem
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (treeName == "Classifications") {
+                              setTagModal(true);
+                            } else if (treeName == "Glossary") {
+                              setGlossaryModal(true);
+                            }
+                            handleClose();
+                          }}
+                          data-cy="createClassification"
+                          className="sidebar-menu-item"
+                        >
+                          <ListItemIcon
+                            sx={{ minWidth: "28px !important" }}
+                            data-cy="createTag"
+                          >
+                            <AddIcon fontSize="small" className="menuitem-icon" />
+                          </ListItemIcon>
+                          <Typography className="menuitem-label">
+                            Create{" "}
+                            {treeName == "Classifications"
+                              ? "Classifications"
+                              : "Glossary"}
+                          </Typography>
+                        </MenuItem>
+                      )}
+                    {(treeName == "Entities" || treeName == "Glossary") && (
+                      <MenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          downloadFile();
+                          handleClose();
+                        }}
+                        data-cy="downloadBusinessMetadata"
+                        disabled={
+                          treeName == "Glossary" && !isEmptyServicetype
+                            ? true
+                            : false
+                        }
+                        className="sidebar-menu-item"
+                      >
+                        <ListItemIcon sx={{ minWidth: "28px !important" }}>
+                          <FileDownloadIcon
+                            fontSize="small"
+                            className="menuitem-icon"
+                          />
+                        </ListItemIcon>
+                        <Typography className="menuitem-label">
+                          Download Import template
+                        </Typography>
+                      </MenuItem>
+                    )}
+                    {(treeName == "Entities" || treeName == "Glossary") && (
+                      <MenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleOpenModal();
+                          handleClose();
+                        }}
+                        data-cy="importBusinessMetadata"
+                        disabled={
+                          treeName == "Glossary" && !isEmptyServicetype
+                            ? true
+                            : false
+                        }
+                        className="sidebar-menu-item"
+                      >
+                        <ListItemIcon sx={{ minWidth: "28px !important" }}>
+                          <FileUploadIcon
+                            fontSize="small"
+                            className="menuitem-icon"
+                          />
+                        </ListItemIcon>
+
+                        <Typography className="menuitem-label">
+                          {treeName == "Entities"
+                            ? "Import Business Metadata"
+                            : "Import Glossary Term"}
+                        </Typography>
+                      </MenuItem>
+                    )}
+                  </Menu>
+                </Stack>
+              }
+              sx={{
+                "& .MuiTreeItem-label": {
+                  fontWeight: "600  !important",
+                  fontSize: "14px  !important",
+                  lineHeight: "26px !important",
+                  color: "white",
+                },
+                "& .MuiTreeItem-content svg": {
+                  color: "white",
+                  fontSize: "20px !important",
+                },
+              }}
+            >
+              {loader ? (
+                <SkeletonLoader animation="pulse" variant="text" width={300} count={5} />
+              ) : (
+                filteredData.map((node: TreeNode) => renderTreeItem(node))
+              )}
+            </TreeItem>
+
+            <ImportDialog
+              open={openModal}
+              onClose={handleCloseModal}
+              title={
+                treeName == "Entities"
+                  ? "Import Business Metadata"
+                  : "Import Glossary Term"
+              }
+            />
+          </SimpleTreeView>
+        </Stack>
+
+        {tagModal && (
+          <ClassificationForm
+            open={tagModal}
+            isAdd={true}
+            onClose={handleCloseTagModal}
           />
-        </SimpleTreeView>
-      </Stack>
-
-      {tagModal && (
-        <ClassificationForm
-          open={tagModal}
-          isAdd={true}
-          onClose={handleCloseTagModal}
-        />
-      )}
-      {glossaryModal && (
-        <AddUpdateGlossaryForm
-          open={glossaryModal}
-          isAdd={true}
-          onClose={handleCloseGlossaryModal}
-          node={undefined}
-        />
-      )}
-    </>
-  );
-};
+        )}
+        {glossaryModal && (
+          <AddUpdateGlossaryForm
+            open={glossaryModal}
+            isAdd={true}
+            onClose={handleCloseGlossaryModal}
+            node={undefined}
+          />
+        )}
+      </>
+    );
+  };
 
 export default BarTreeView;

--- a/dashboard/src/views/SideBar/SideBarTree/__tests__/GlossaryTree.test.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/__tests__/GlossaryTree.test.tsx
@@ -31,10 +31,10 @@ import { render, screen, waitFor, act } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import GlossaryTree from '../GlossaryTree'
-import { fetchGlossaryData } from '@redux/slice/glossarySlice'
+import { fetchGlossaryData } from '../../../../redux/slice/glossarySlice'
 
 // Mock dependencies
-jest.mock('@redux/slice/glossarySlice', () => ({
+jest.mock('../../../../redux/slice/glossarySlice', () => ({
 	fetchGlossaryData: jest.fn()
 }))
 
@@ -62,8 +62,8 @@ jest.mock('../SideBarTree.tsx', () => {
 	}
 })
 
-jest.mock('@utils/Utils', () => {
-	const actualUtils = jest.requireActual('@utils/Utils')
+jest.mock('../../../../utils/Utils', () => {
+	const actualUtils = jest.requireActual('../../../../utils/Utils')
 	return {
 		...actualUtils,
 		customSortBy: jest.fn((arr, ...args) => {
@@ -140,9 +140,9 @@ describe('GlossaryTree', () => {
 	beforeEach(() => {
 		jest.clearAllMocks()
 		mockFetchGlossaryData.mockReturnValue({ type: 'fetchGlossaryData' } as any)
-		
+
 		// Ensure mocks always return arrays
-		const utils = require('@utils/Utils')
+		const utils = require('../../../../utils/Utils')
 		if (utils.customSortByObjectKeys) {
 			jest.spyOn(utils, 'customSortByObjectKeys').mockImplementation((arr: any) => {
 				if (arr === undefined || arr === null) return []
@@ -228,7 +228,7 @@ describe('GlossaryTree', () => {
 			renderComponent()
 
 			const refreshButton = screen.getByTestId('refresh-button')
-			
+
 			await act(async () => {
 				refreshButton.click()
 			})
@@ -514,6 +514,45 @@ describe('GlossaryTree', () => {
 
 			const treeData = screen.getByTestId('tree-data')
 			expect(treeData).toBeInTheDocument()
+		})
+
+		it('should deduplicate nodes with the same guid in the tree structure', async () => {
+			const mockGlossaryData = [
+				{
+					name: 'Glossary1',
+					guid: 'guid1',
+					categories: [],
+					terms: [
+						{
+							displayText: 'Term1',
+							termGuid: 'duplicate-term',
+							categoryGuid: 'cat1',
+							parentCategoryGuid: undefined
+						},
+						{
+							displayText: 'Term2',
+							termGuid: 'duplicate-term', // Same guid
+							categoryGuid: 'cat2',
+							parentCategoryGuid: undefined
+						}
+					]
+				}
+			]
+
+			renderComponent({}, {
+				glossary: {
+					glossaryData: mockGlossaryData,
+					loading: false
+				}
+			})
+
+			await waitFor(() => {
+				const treeDataStr = screen.getByTestId('tree-data').textContent
+				// Since deduplication keeps the last one in the Map by guid, 
+				// we verify the overall array has only one term processed.
+				expect(treeDataStr).toContain('Term2')
+				expect(treeDataStr).not.toContain('Term1')
+			})
 		})
 	})
 

--- a/dashboard/src/views/SideBar/SideBarTree/__tests__/SideBarTree.test.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/__tests__/SideBarTree.test.tsx
@@ -28,19 +28,20 @@
 
 import React from 'react'
 import { render, screen, waitFor, fireEvent, act, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { BrowserRouter, MemoryRouter } from 'react-router-dom'
 import SideBarTree from '../SideBarTree'
-import { getBusinessMetadataImportTmpl } from '@api/apiMethods/entitiesApiMethods'
-import { getGlossaryImportTmpl } from '@api/apiMethods/glossaryApiMethod'
+import { getBusinessMetadataImportTmpl } from '../../../../api/apiMethods/entitiesApiMethods'
+import { getGlossaryImportTmpl } from '../../../../api/apiMethods/glossaryApiMethod'
 
 // Mock dependencies
-jest.mock('@api/apiMethods/entitiesApiMethods', () => ({
+jest.mock('../../../../api/apiMethods/entitiesApiMethods', () => ({
 	getBusinessMetadataImportTmpl: jest.fn()
 }))
 
-jest.mock('@api/apiMethods/glossaryApiMethod', () => ({
+jest.mock('../../../../api/apiMethods/glossaryApiMethod', () => ({
 	getGlossaryImportTmpl: jest.fn()
 }))
 
@@ -51,54 +52,54 @@ jest.mock('react-toastify', () => ({
 	}
 }))
 
-jest.mock('@utils/Utils', () => ({
+jest.mock('../../../../utils/Utils', () => ({
 	globalSearchFilterInitialQuery: {
 		setQuery: jest.fn()
 	},
 	isEmpty: jest.fn((val) => !val || (Array.isArray(val) && val.length === 0))
 }))
 
-jest.mock('@utils/CommonViewFunction', () => ({
+jest.mock('../../../../utils/CommonViewFunction', () => ({
 	attributeFilter: {
 		generateUrl: jest.fn((params) => 'mock-url-string')
 	}
 }))
 
-jest.mock('@utils/Helper', () => ({
+jest.mock('../../../../utils/Helper', () => ({
 	cloneDeep: jest.fn((obj) => JSON.parse(JSON.stringify(obj)))
 }))
 
-jest.mock('@components/ImportDialog', () => {
+jest.mock('../../../../components/ImportDialog', () => {
 	return function MockImportDialog(props: any) {
 		return props.open ? <div data-testid="import-dialog">Import Dialog</div> : null
 	}
 })
 
-jest.mock('@views/Classification/ClassificationForm', () => {
+jest.mock('../../../../views/Classification/ClassificationForm', () => {
 	return function MockClassificationForm(props: any) {
 		return props.open ? <div data-testid="classification-form">Classification Form</div> : null
 	}
 })
 
-jest.mock('@views/Glossary/AddUpdateGlossaryForm', () => {
+jest.mock('../../../../views/Glossary/AddUpdateGlossaryForm', () => {
 	return function MockAddUpdateGlossaryForm(props: any) {
 		return props.open ? <div data-testid="glossary-form">Glossary Form</div> : null
 	}
 })
 
-jest.mock('@components/Treeicons', () => {
+jest.mock('../../../../components/Treeicons', () => {
 	return function MockTreeIcons(props: any) {
 		return <div data-testid="tree-icons">Tree Icons</div>
 	}
 })
 
-jest.mock('@components/TreeNodeIcons', () => {
+jest.mock('../../../../components/TreeNodeIcons', () => {
 	return function MockTreeNodeIcons(props: any) {
 		return <div data-testid="tree-node-icons">TreeNode Icons</div>
 	}
 })
 
-jest.mock('@components/SkeletonLoader', () => {
+jest.mock('../../../../components/SkeletonLoader', () => {
 	return function MockSkeletonLoader(props: any) {
 		return <div data-testid="skeleton-loader">Loading...</div>
 	}
@@ -139,15 +140,15 @@ jest.mock('@mui/x-tree-view/TreeItem', () => {
 			</div>
 		)
 	}
-	return { 
-		TreeItem, 
+	return {
+		TreeItem,
 		useTreeItemState,
 		TreeItemProps: {},
 		TreeItemContentProps: {}
 	}
 })
 
-jest.mock('@components/muiComponents', () => ({
+jest.mock('../../../../components/muiComponents', () => ({
 	MoreVertIcon: ({ onClick, ...props }: any) => (
 		<div data-testid="more-vert-icon" onClick={onClick} {...props}>More</div>
 	),
@@ -175,7 +176,7 @@ jest.mock('@components/muiComponents', () => ({
 	)
 }))
 
-jest.mock('@utils/Muiutils', () => ({
+jest.mock('../../../../utils/Muiutils', () => ({
 	AntSwitch: ({ onClick, inputProps, ...props }: any) => (
 		<div data-testid="ant-switch" onClick={onClick} {...props}>Switch</div>
 	)
@@ -260,7 +261,7 @@ describe('SideBarTree', () => {
 		jest.clearAllMocks()
 		global.URL.createObjectURL = jest.fn(() => 'blob:url')
 		global.URL.revokeObjectURL = jest.fn()
-		
+
 		// Restore original createElement for React Testing Library
 		document.createElement = originalCreateElement
 		document.body.appendChild = originalAppendChild
@@ -570,7 +571,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const downloadItem = menuItems.find(item => item.textContent?.includes('Download'))
-			
+
 			if (downloadItem) {
 				fireEvent.click(downloadItem)
 			}
@@ -620,7 +621,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const downloadItem = menuItems.find(item => item.textContent?.includes('Download'))
-			
+
 			if (downloadItem) {
 				fireEvent.click(downloadItem)
 			}
@@ -649,7 +650,7 @@ describe('SideBarTree', () => {
 			await waitFor(() => {
 				const menuItems = screen.getAllByTestId('menu-item')
 				const downloadItem = menuItems.find(item => item.textContent?.includes('Download'))
-				
+
 				if (downloadItem) {
 					expect(downloadItem).toHaveAttribute('data-disabled', 'true')
 				}
@@ -677,15 +678,15 @@ describe('SideBarTree', () => {
 			// Find menu item by text content
 			const importText = screen.getByText('Import Business Metadata')
 			expect(importText).toBeInTheDocument()
-			
+
 			const importMenuItem = importText.closest('[data-testid="menu-item"]')
 			expect(importMenuItem).toBeInTheDocument()
-			
+
 			if (importMenuItem) {
 				await act(async () => {
 					fireEvent.click(importMenuItem)
 				})
-				
+
 				// Wait for state update and dialog to appear
 				await waitFor(() => {
 					expect(screen.getByTestId('import-dialog')).toBeInTheDocument()
@@ -712,7 +713,7 @@ describe('SideBarTree', () => {
 			// Find menu item by text content
 			const importText = screen.getByText('Import Business Metadata')
 			const importMenuItem = importText.closest('[data-testid="menu-item"]')
-			
+
 			if (importMenuItem) {
 				await act(async () => {
 					fireEvent.click(importMenuItem)
@@ -745,7 +746,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const createItem = menuItems.find(item => item.textContent?.includes('Create'))
-			
+
 			if (createItem) {
 				fireEvent.click(createItem)
 			}
@@ -773,7 +774,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const createItem = menuItems.find(item => item.textContent?.includes('Create'))
-			
+
 			if (createItem) {
 				fireEvent.click(createItem)
 			}
@@ -1293,6 +1294,22 @@ describe('SideBarTree', () => {
 			})
 		})
 
+		it('should set search params for Glossary term without duplicating glossary suffix', async () => {
+			const treeData = [
+				{ id: 'term1@glossary1', label: 'Term 1', guid: 'guid1', parent: 'glossary1', types: 'child', children: [] }
+			]
+
+			renderComponent({
+				treeName: 'Glossary',
+				treeData,
+				isEmptyServicetype: true
+			}, {}, ['/search/searchResult'])
+
+			await waitFor(() => {
+				expect(screen.getByTestId('simple-tree-view')).toBeInTheDocument()
+			})
+		})
+
 		it('should set search params for Glossary category', async () => {
 			const treeData = [
 				{ id: 'cat1', label: 'Category 1', guid: 'guid1', cGuid: 'cguid1', types: 'child', children: [] }
@@ -1319,10 +1336,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'ADVANCED', 
-						searchParameters: { query: 'test' } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'ADVANCED',
+						searchParameters: { query: 'test' }
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1349,10 +1366,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC', 
-						searchParameters: { entityFilters: mockEntityFilters } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC',
+						searchParameters: { entityFilters: mockEntityFilters }
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1379,10 +1396,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC', 
-						searchParameters: { tagFilters: mockTagFilters } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC',
+						searchParameters: { tagFilters: mockTagFilters }
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1409,10 +1426,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC_RELATIONSHIP', 
-						searchParameters: { relationshipFilters: mockRelationshipFilters } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC_RELATIONSHIP',
+						searchParameters: { relationshipFilters: mockRelationshipFilters }
 					}]
 				}
 			}, ['/relationship/relationshipSearchresult'])
@@ -1432,10 +1449,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC_RELATIONSHIP', 
-						searchParameters: { limit: 50, offset: 10 } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC_RELATIONSHIP',
+						searchParameters: { limit: 50, offset: 10 }
 					}]
 				}
 			}, ['/relationship/relationshipSearchresult'])
@@ -1455,10 +1472,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC', 
-						searchParameters: { typeName: 'EntityType' } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC',
+						searchParameters: { typeName: 'EntityType' }
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1478,10 +1495,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC', 
-						searchParameters: { classification: 'Tag1' } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC',
+						searchParameters: { classification: 'Tag1' }
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1501,14 +1518,14 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC', 
-						searchParameters: { 
-							nullValue: null, 
-							undefinedValue: undefined, 
-							emptyValue: '' 
-						} 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC',
+						searchParameters: {
+							nullValue: null,
+							undefinedValue: undefined,
+							emptyValue: ''
+						}
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1613,7 +1630,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const downloadItem = menuItems.find(item => item.textContent?.includes('Download'))
-			
+
 			if (downloadItem) {
 				await act(async () => {
 					fireEvent.click(downloadItem)
@@ -1659,7 +1676,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const downloadItem = menuItems.find(item => item.textContent?.includes('Download'))
-			
+
 			if (downloadItem) {
 				await act(async () => {
 					fireEvent.click(downloadItem)
@@ -1697,10 +1714,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC', 
-						searchParameters: { entityFilters: nestedFilters } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC',
+						searchParameters: { entityFilters: nestedFilters }
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1727,10 +1744,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC', 
-						searchParameters: { entityFilters: qbFilters } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC',
+						searchParameters: { entityFilters: qbFilters }
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1750,10 +1767,10 @@ describe('SideBarTree', () => {
 				treeData
 			}, {
 				savedSearch: {
-					savedSearchData: [{ 
-						name: 'filter1', 
-						searchType: 'BASIC', 
-						searchParameters: { entityFilters: 'invalid' } 
+					savedSearchData: [{
+						name: 'filter1',
+						searchType: 'BASIC',
+						searchParameters: { entityFilters: 'invalid' }
 					}]
 				}
 			}, ['/search/searchResult'])
@@ -1917,7 +1934,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const downloadItem = menuItems.find(item => item.textContent?.includes('Download'))
-			
+
 			if (downloadItem) {
 				expect(downloadItem).not.toHaveAttribute('data-disabled', 'true')
 			}
@@ -1942,7 +1959,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const importItem = menuItems.find(item => item.textContent?.includes('Import'))
-			
+
 			if (importItem) {
 				expect(importItem).not.toHaveAttribute('data-disabled', 'true')
 			}
@@ -1967,7 +1984,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const importItem = menuItems.find(item => item.textContent?.includes('Import'))
-			
+
 			if (importItem) {
 				expect(importItem).toHaveAttribute('data-disabled', 'true')
 			}
@@ -2016,7 +2033,7 @@ describe('SideBarTree', () => {
 
 			const menuItems = screen.getAllByTestId('menu-item')
 			const toggleItem = menuItems.find(item => item.textContent?.includes('flat'))
-			
+
 			if (toggleItem) {
 				await act(async () => {
 					fireEvent.click(toggleItem)


### PR DESCRIPTION
## What changes were proposed in this pull request?

(ATLAS-5045 - [React UI] Adding detail page view for Glossary)

Currently, there is no detail view for the root Glossary entity like we have for Terms and Categories. This PR introduces a dedicated Glossary detail view, complete with integrated tables for Terms and Categories that support full CRUD operations directly from the glossary page. Additionally, this PR addresses several functional UI bugs within the Glossary module—specifically stabilizing the rich text editor and standardizing table loading states—and resolves underlying test environment errors to improve the developer experience.

**Glossary Detail View Enhancements**
* **Integrated Terms & Categories Tables:** Upgraded the root Glossary view to feature fully functional, paginated tables for its nested Terms and Categories.
* **In-Place CRUD Operations:** Added the ability to seamlessly create, read, update, and delete (as well as assign/unassign) terms and categories directly from the new tables within the glossary page.
* **Standardized Table Loaders:** Refactored the loading skeletons across the application's tables to use a clean, single-row horizontal loader in both the headers and body. This prevents awkward UI shifts and layout breakages that were previously caused by dynamic column calculations.

**Glossary Editor & Form Fixes**
* **ReactQuill "Zombie" Toolbar Bug:** Fixed an issue where the rich text editor's formatting buttons (bold, italics, links, etc.) were completely unresponsive. This was resolved by updating the CSS to properly hide duplicate toolbars generated by React's StrictMode, ensuring only the active toolbar is visible and interactive.
* **Modal Focus Trap Bug:** Resolved an issue where users were blocked from interacting with the text editor's tooltips and dropdowns (such as the "Insert Link" input). Disabled the Material-UI Modal's strict focus trap to allow seamless interaction with the editor's popups.
* **Form Data Hydration:** Fixed a bug where the existing `longDescription` of a Glossary Term was failing to pre-fill into the text editor when opening the form to edit the entity.
* **State Mutations & Infinite Re-renders:** Stabilized the React Hook Form state management to eliminate redundant value mutations and unnecessary re-renders when typing in the text editor.

**General UI & Navigation Fixes**
* **Missing Update Button:** Restored the missing "Edit/Update" pencil icon on the main Glossary Detail Page so users can modify root glossaries just like they can with terms and categories.
* **Instant State Syncing:** Fixed an issue where the interface did not update after creating, editing, or deleting a Glossary, Category, or Term. The application now instantly fetches and displays the latest data upon a successful form submission without requiring a manual page refresh.
* **Navigation URL Bug:** Resolved a routing issue that caused the `@glossary` suffix to be appended multiple times to the URL search parameters during navigation.
* **Sidebar Tree Crashes:** Prevented the Glossary sidebar tree view from crashing by implementing deduplication logic, ensuring stable rendering even if duplicate node IDs are returned.

**Test & Environment Fixes**
* **IDE Module Resolution:** Resolved widespread "module not found" errors in the test suite so developers no longer see false-positive path alias errors in their editors.
* **TypeScript Strictness:** Fixed multiple strict-mode compilation errors across the testing environment (including spread parameter tuples, implicit scoping, unused variables, and mocked argument definitions) to ensure the test suite is 100% compliant with the project's strict TypeScript constraints.
* **Redux Context Test Pollution:** Fixed missing Redux mock hooks (like `useAppDispatch`) that were causing `TypeError`s and test suite pollution failures when rendering complex components in isolation.

## How was this patch tested?

* Manual tests
* Maven build
* Full NPM Test Suite passing (`npm run test`)
* Production NPM Build passing (`npm run build`)