### PR TITLE
ATLAS-5055: Incremental Export : When entity exported has a tag propa…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -18,7 +18,9 @@
 package org.apache.atlas.repository.store.graph.v2;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.TimeBoundary;
 import org.apache.atlas.model.glossary.AtlasGlossaryCategory;
@@ -162,6 +164,7 @@ public class EntityGraphRetriever {
     private static final String GLOSSARY_CATEGORY_HIERARCHY_EDGE_LABEL = "r:AtlasGlossaryCategoryHierarchyLink";
     private static final String GLOSSARY_CATEGORY_TYPE_NAME            = AtlasGlossaryCategory.class.getSimpleName();
     private static final String PARENT_GLOSSARY_CATEGORY_GUID          = "parentCategoryGuid";
+    private boolean             deferredActionEnabled                  = AtlasConfiguration.TASKS_USE_ENABLED.getBoolean();
 
     private static final TypeReference<List<TimeBoundary>> TIME_BOUNDARIES_LIST_TYPE = new TypeReference<List<TimeBoundary>>() {};
 
@@ -698,7 +701,7 @@ public class EntityGraphRetriever {
             Iterable<AtlasEdge> propagationEdges = entityVertex.getEdges(AtlasEdgeDirection.BOTH, tagPropagationEdges);
 
             for (AtlasEdge propagationEdge : propagationEdges) {
-                if (getEdgeStatus(propagationEdge) != ACTIVE) {
+                if (getEdgeStatus(propagationEdge) != ACTIVE && !deferredActionEnabled && !RequestContext.get().isImportInProgress()) {
                     continue;
                 }
 


### PR DESCRIPTION
…gated from entity which is deleted , tag is not propagated to it at target

## What changes were proposed in this pull request?

Create lineage table1 --> table2 ---> table3 ---> table4

Add tag tag1 to table1

tag1 is propogated till table4

Drop table1

Export and Import entire lineage along with parent using incremental fetch type

CURRENT BEHAVIOUR:

table1 , table2 , table3 are exported

But since table1 is deleted , on the destination after import tag appears to be applied on table1 but tag is not propagated to any of the child entities.

Root cause:
 when deferred action is enabled and such a case if this is imported from source to target on target side the  propagation doesn't happen 
Flow with deferred actions enabled:

classification is created

entities are created

Add propagation task is created 

classification is mapped to parent

Because parent entity is expected to be in deleted state it goes and deletes entities

After this the Add propagation task attempts to propogate the classification but fails as it finds the edge deleted between parent and classification

Patch fix : Add a check for  ignore if import in progress and deferred actions is enabled
for a code block in getimpactedvertices where we check for status of edge if not active it doesn’t propagate the tag

## How was this patch tested?

Sanity testing and by importing multiple entities with ctas and parent is deleted it works successfully