### PR TITLE
ATLAS-5034: Entities not created in Atlas when hive table created on top a OFS/O3FS bucket/volume

### DIFF
--- a/common/src/main/java/org/apache/atlas/utils/AtlasPathExtractorUtil.java
+++ b/common/src/main/java/org/apache/atlas/utils/AtlasPathExtractorUtil.java
@@ -90,7 +90,7 @@ public class AtlasPathExtractorUtil {
     }
 
     public static AtlasEntityWithExtInfo getPathEntity(Path path, PathExtractorContext context) {
-        if (StringUtils.isEmpty(path.toString())) {
+        if (path == null || StringUtils.isEmpty(path.toString())) {
             throw new IllegalArgumentException("Invalid Input: Path is Null");
         }
 
@@ -500,7 +500,7 @@ public class AtlasPathExtractorUtil {
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("<== addOzonePathEntity(strPath={})", path.toString());
+            LOG.debug("<== addOzonePathEntity(strPath={})", path);
         }
 
         return currentOfsKeyEntity;
@@ -555,7 +555,7 @@ public class AtlasPathExtractorUtil {
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("<== addOzonePathEntity(strPath={})", path.toString());
+            LOG.debug("<== addOzonePathEntity(strPath={})", path);
         }
 
         return currentO3fsKeyEntity;

--- a/common/src/test/java/org/apache/atlas/utils/AtlasPathExtractorUtilTest.java
+++ b/common/src/test/java/org/apache/atlas/utils/AtlasPathExtractorUtilTest.java
@@ -20,6 +20,7 @@ package org.apache.atlas.utils;
 
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +29,6 @@ import org.testng.annotations.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -101,11 +101,11 @@ public class AtlasPathExtractorUtilTest {
         assertNotNull(entity);
         verifyOzoneKeyEntity(entity, validator);
 
-        if (entity.getTypeName() == OZONE_KEY) {
+        if (StringUtils.equals(entity.getTypeName(), OZONE_KEY)) {
             verifyReferredAndKnownEntities(entityWithExtInfo, extractorContext, validator, validator.knownEntitiesCountTillKey, 2);
-        } else if (entity.getTypeName() == OZONE_BUCKET) {
+        } else if (StringUtils.equals(entity.getTypeName(), OZONE_BUCKET)) {
             verifyReferredAndKnownEntities(entityWithExtInfo, extractorContext, validator, validator.knownEntitiesCountTillBucket, 2);
-        } else if (entity.getTypeName() == OZONE_VOLUME) {
+        } else if (StringUtils.equals(entity.getTypeName(), OZONE_VOLUME)) {
             verifyReferredAndKnownEntities(entityWithExtInfo, extractorContext, validator, validator.knownEntitiesCountTillVolume, 1);
         }
     }
@@ -340,14 +340,11 @@ public class AtlasPathExtractorUtilTest {
     }
 
     private void verifyOzoneKeyEntity(AtlasEntity entity, OzoneKeyValidator validator) {
-        if (Objects.equals(entity.getTypeName(), OZONE_KEY)) {
-            assertEquals(entity.getTypeName(), OZONE_KEY);
+        if (StringUtils.equals(entity.getTypeName(), OZONE_KEY)) {
             assertTrue(validator.validateNameQName(entity));
-        } else if (Objects.equals(entity.getTypeName(), OZONE_BUCKET)) {
-            assertEquals(entity.getTypeName(), OZONE_BUCKET);
+        } else if (StringUtils.equals(entity.getTypeName(), OZONE_BUCKET)) {
             assertTrue(validator.validateNameQName(entity));
-        } else if (Objects.equals(entity.getTypeName(), OZONE_VOLUME)) {
-            assertEquals(entity.getTypeName(), OZONE_VOLUME);
+        } else if (StringUtils.equals(entity.getTypeName(), OZONE_VOLUME)) {
             assertTrue(validator.validateNameQName(entity));
         }
     }


### PR DESCRIPTION
Some cases were pending to handle:
1. Null check
2. Use of StringUtils.equals() instead of Objects.equals()

Jira reference - https://issues.apache.org/jira/browse/ATLAS-5034
PR refernece - https://github.com/apache/atlas/pull/372
PC build: https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1917/