### PR TITLE
ATLAS-5057: Atlas - Upgrade spring-ldap-core to 2.4.4/3.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
         <solr-test-framework.version>8.11.3</solr-test-framework.version>
         <solr.version>8.11.3</solr.version>
         <spray.version>1.3.1</spray.version>
+        <spring-ldap-core.version>2.4.4</spring-ldap-core.version>
         <spring.security.version>5.8.15</spring.security.version>
         <spring.version>5.3.39</spring.version>
         <sqoop.classifier>hadoop260</sqoop.classifier>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -415,6 +415,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ldap</groupId>
+            <artifactId>spring-ldap-core</artifactId>
+            <version>${spring-ldap-core.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
         </dependency>
@@ -427,6 +433,12 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-ldap</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.ldap</groupId>
+                    <artifactId>spring-ldap-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgraded Spring ldap core version to 2.4.4

## How was this patch tested?
Tested by creating tables through all Hooks
Did sanity testing for Classification ,labels,BMs and CURL calls
Atlas server running successfully
PC is successful
