### PR TITLE
ATLAS-5054: Introduce JaCoCo plugin and generate Code Coverage results with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jacoco
-          path: dev-support/atlas-docker/jacoco/coverage/*
+          path: dev-support/atlas-docker/dist/coverage/*
 
       - name: Cache downloaded archives
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Upload Code Coverage Results
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco
+          name: coverage
           path: dev-support/atlas-docker/dist/coverage/*
 
       - name: Cache downloaded archives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
             exit 1
           fi
 
+      - name: Upload Code Coverage Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco
+          path: /home/atlas/dist/coverage/*
+
       - name: Cache downloaded archives
         if: success()
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           cd dev-support/atlas-docker
           export DOCKER_BUILDKIT=1
           export COMPOSE_DOCKER_CLI_BUILD=1
+          mkdir -p ${{ github.workspace }}/jacoco
           SKIPTESTS=false docker compose -f docker-compose.atlas-base.yml -f docker-compose.atlas-build.yml up
           ATLAS_BUILD_CONTAINER=$(docker ps -a -q --filter "name=atlas-build")
           EXIT_CODE=$(docker inspect --format '{{.State.ExitCode}}' "$ATLAS_BUILD_CONTAINER")
@@ -79,14 +80,11 @@ jobs:
             exit 1
           fi
 
-      - name: List coverage files
-        run: ls -alh dist/coverage/
-
       - name: Upload Code Coverage Results
         uses: actions/upload-artifact@v4
         with:
           name: jacoco
-          path: dist/coverage/*
+          path: ${{ github.workspace }}/jacoco/coverage/*
 
       - name: Cache downloaded archives
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
             exit 1
           fi
 
+      - name: List coverage files
+        run: ls -alh dist/coverage/
+
       - name: Upload Code Coverage Results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jacoco
-          path: /home/atlas/dist/coverage/*
+          path: dist/coverage/*
 
       - name: Cache downloaded archives
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
           cd dev-support/atlas-docker
           export DOCKER_BUILDKIT=1
           export COMPOSE_DOCKER_CLI_BUILD=1
-          mkdir -p ${{ github.workspace }}/jacoco
           SKIPTESTS=false docker compose -f docker-compose.atlas-base.yml -f docker-compose.atlas-build.yml up
           ATLAS_BUILD_CONTAINER=$(docker ps -a -q --filter "name=atlas-build")
           EXIT_CODE=$(docker inspect --format '{{.State.ExitCode}}' "$ATLAS_BUILD_CONTAINER")
@@ -84,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jacoco
-          path: ${{ github.workspace }}/jacoco/coverage/*
+          path: dev-support/atlas-docker/jacoco/coverage/*
 
       - name: Cache downloaded archives
         if: success()

--- a/dev-support/atlas-docker/Dockerfile.atlas-build
+++ b/dev-support/atlas-docker/Dockerfile.atlas-build
@@ -20,7 +20,7 @@ ARG ATLAS_BUILD_JAVA_VERSION
 ARG TARGETARCH
 
 # Install necessary packages to build Atlas
-RUN apt-get update && apt-get -y install git maven
+RUN apt-get update && apt-get -y install git maven unzip
 
 # Set environment variables
 ENV JAVA_HOME=/usr/lib/jvm/java-${ATLAS_BUILD_JAVA_VERSION}-openjdk-${TARGETARCH}

--- a/dev-support/atlas-docker/Dockerfile.atlas-build
+++ b/dev-support/atlas-docker/Dockerfile.atlas-build
@@ -32,6 +32,7 @@ RUN update-java-alternatives --set /usr/lib/jvm/java-1.${ATLAS_BUILD_JAVA_VERSIO
 # setup atlas group, and users
 RUN mkdir -p /home/atlas/git && \
     mkdir -p /home/atlas/.m2 && \
+    mkdir -p /home/atlas/jacoco && \
     chown -R atlas:atlas /home/atlas
 
 COPY ./scripts/atlas-build.sh /home/atlas/scripts/

--- a/dev-support/atlas-docker/Dockerfile.atlas-build
+++ b/dev-support/atlas-docker/Dockerfile.atlas-build
@@ -32,7 +32,6 @@ RUN update-java-alternatives --set /usr/lib/jvm/java-1.${ATLAS_BUILD_JAVA_VERSIO
 # setup atlas group, and users
 RUN mkdir -p /home/atlas/git && \
     mkdir -p /home/atlas/.m2 && \
-    mkdir -p /home/atlas/jacoco && \
     chown -R atlas:atlas /home/atlas
 
 COPY ./scripts/atlas-build.sh /home/atlas/scripts/

--- a/dev-support/atlas-docker/docker-compose.atlas-build.yml
+++ b/dev-support/atlas-docker/docker-compose.atlas-build.yml
@@ -18,7 +18,6 @@ services:
       - ./patches:/home/atlas/patches
       - ./dist:/home/atlas/dist
       - ./../..:/home/atlas/src:delegated
-      - ./jacoco:/home/atlas/jacoco
     depends_on:
       - atlas-base
     environment:

--- a/dev-support/atlas-docker/docker-compose.atlas-build.yml
+++ b/dev-support/atlas-docker/docker-compose.atlas-build.yml
@@ -18,6 +18,7 @@ services:
       - ./patches:/home/atlas/patches
       - ./dist:/home/atlas/dist
       - ./../..:/home/atlas/src:delegated
+      - ./jacoco:/home/atlas/jacoco
     depends_on:
       - atlas-base
     environment:

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -86,7 +86,7 @@ else
   done
 fi
 
-mvn ${ARG_PROFILES} ${ARG_SKIPTESTS} -DskipDocs clean package
+mvn ${ARG_PROFILES} ${ARG_SKIPTESTS} -DskipDocs clean package -pl 'server-api'
 
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-server.tar.gz     /home/atlas/dist/
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-hive-hook.tar.gz  /home/atlas/dist/
@@ -97,7 +97,6 @@ mv -f distro/target/apache-atlas-${ATLAS_VERSION}-kafka-hook.tar.gz /home/atlas/
 ./dev-support/checks/coverage.sh
 status=$?
 
-ls -lrt target/coverage
 # save coverage reports to the dist directory before container shutdown
-mv -f target/coverage /home/atlas/dist/ || true
+mv -f target/coverage ${{ github.workspace }}/jacoco
 exit $status

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -96,6 +96,8 @@ mv -f distro/target/apache-atlas-${ATLAS_VERSION}-kafka-hook.tar.gz /home/atlas/
 # Run code coverage and generate reports
 ./dev-support/checks/coverage.sh
 status=$?
+
+ls -lrt target/coverage
 # save coverage reports to the dist directory before container shutdown
 mv -f target/coverage /home/atlas/dist/ || true
 exit $status

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -98,5 +98,5 @@ mv -f distro/target/apache-atlas-${ATLAS_VERSION}-kafka-hook.tar.gz /home/atlas/
 status=$?
 
 # save coverage reports to the dist directory before container shutdown
-mv -f target/coverage /home/atlas/jacoco/
+mv -f target/coverage /home/atlas/dist/
 exit $status

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -92,3 +92,10 @@ mv -f distro/target/apache-atlas-${ATLAS_VERSION}-server.tar.gz     /home/atlas/
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-hive-hook.tar.gz  /home/atlas/dist/
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-hbase-hook.tar.gz /home/atlas/dist/
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-kafka-hook.tar.gz /home/atlas/dist/
+
+# Run code coverage and generate reports
+cd dev-support/checks || exit
+chmod +x coverage.sh && ./coverage.sh
+
+# save coverage reports to the dist directory before container shutdown
+mv -f target/coverage /home/atlas/dist

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -86,7 +86,7 @@ else
   done
 fi
 
-mvn ${ARG_PROFILES} ${ARG_SKIPTESTS} -DskipDocs clean package -pl 'server-api'
+mvn ${ARG_PROFILES} ${ARG_SKIPTESTS} -DskipDocs clean package
 
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-server.tar.gz     /home/atlas/dist/
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-hive-hook.tar.gz  /home/atlas/dist/

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -97,4 +97,4 @@ mv -f distro/target/apache-atlas-${ATLAS_VERSION}-kafka-hook.tar.gz /home/atlas/
 ./dev-support/checks/coverage.sh
 
 # save coverage reports to the dist directory before container shutdown
-mv -f target/coverage /home/atlas/dist
+mv -f target/coverage /home/atlas/dist/

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -95,6 +95,7 @@ mv -f distro/target/apache-atlas-${ATLAS_VERSION}-kafka-hook.tar.gz /home/atlas/
 
 # Run code coverage and generate reports
 ./dev-support/checks/coverage.sh
-
+status=$?
 # save coverage reports to the dist directory before container shutdown
-mv -f target/coverage /home/atlas/dist/
+mv -f target/coverage /home/atlas/dist/ || true
+exit $status

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -98,5 +98,5 @@ mv -f distro/target/apache-atlas-${ATLAS_VERSION}-kafka-hook.tar.gz /home/atlas/
 status=$?
 
 # save coverage reports to the dist directory before container shutdown
-mv -f target/coverage ${{ github.workspace }}/jacoco
+mv -f target/coverage /home/atlas/jacoco/
 exit $status

--- a/dev-support/atlas-docker/scripts/atlas-build.sh
+++ b/dev-support/atlas-docker/scripts/atlas-build.sh
@@ -94,8 +94,7 @@ mv -f distro/target/apache-atlas-${ATLAS_VERSION}-hbase-hook.tar.gz /home/atlas/
 mv -f distro/target/apache-atlas-${ATLAS_VERSION}-kafka-hook.tar.gz /home/atlas/dist/
 
 # Run code coverage and generate reports
-cd dev-support/checks || exit
-chmod +x coverage.sh && ./coverage.sh
+./dev-support/checks/coverage.sh
 
 # save coverage reports to the dist directory before container shutdown
 mv -f target/coverage /home/atlas/dist

--- a/dev-support/checks/coverage.sh
+++ b/dev-support/checks/coverage.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script merges the jacoco exec files and generates a report in HTML and XML formats
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$DIR/../.." || exit 1
+
+set -ex
+
+REPORT_DIR="$DIR/../../target/coverage"
+
+mkdir -p "$REPORT_DIR"
+
+JACOCO_VERSION=$(mvn help:evaluate -Dexpression=jacoco.version -q -DforceStdout -Dscan=false)
+
+# Install jacoco cli
+mvn --non-recursive --no-transfer-progress -Dscan=false \
+  org.apache.maven.plugins:maven-dependency-plugin:copy \
+  -Dartifact=org.jacoco:org.jacoco.cli:${JACOCO_VERSION}:jar:nodeps
+
+jacoco() {
+  java -jar target/dependency/org.jacoco.cli-${JACOCO_VERSION}-nodeps.jar "$@"
+}
+
+# Merge all the jacoco.exec files
+jacoco merge $(find **/target -name jacoco.exec) --destfile "$REPORT_DIR/jacoco-all.exec"
+
+rm -rf target/coverage-classes || true
+mkdir -p target/coverage-classes
+
+# Unzip all the classes from the last build
+{ find */target/ -name 'atlas-*.jar'; find addons/**/target/*.jar -name '*-bridge-*.jar'; } | grep -v 'tests' | xargs -n1 unzip -o -q -d target/coverage-classes
+
+# get all source file paths
+src=$(find . -path '*/src/main/java' -o -path './target' -prune | sed 's/^/--sourcefiles /g' | xargs echo)
+
+# generate the reports
+jacoco report "$REPORT_DIR/jacoco-all.exec" $src --classfiles target/coverage-classes --html "$REPORT_DIR/all" --xml "$REPORT_DIR/all.xml"

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
         <ivy.version>2.5.2</ivy.version>
         <jackson.databind.version>2.12.7</jackson.databind.version>
         <jackson.version>2.12.7</jackson.version>
+        <jacoco.version>0.8.13</jacoco.version>
         <janusgraph.cassandra.version>0.5.3</janusgraph.cassandra.version>
         <janusgraph.version>1.0.0</janusgraph.version>
         <java.version.required>1.8</java.version.required>
@@ -906,6 +907,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>
                 <version>${slf4j.version}</version>
@@ -1339,7 +1346,7 @@
                     <forkCount>${surefire.forkCount}</forkCount>
                     <reuseForks>false</reuseForks>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <argLine>-Djava.awt.headless=true -Dproject.version=${project.version}
+                    <argLine>${argLine} -Djava.awt.headless=true -Dproject.version=${project.version}
                         -Dhadoop.tmp.dir="${project.build.directory}/tmp-hadoop-${user.name}"
                         -Xmx1024m -Djava.net.preferIPv4Stack=true ${atlas.surefire.options}</argLine>
                     <skip>${skipUTs}</skip>
@@ -1570,6 +1577,27 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>javancss-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-site</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Integrate code coverage with JaCoCo in CI

- Introduce Maven JaCoCo plugin
- Merge all `jacoco.exec` files generated as part of JDK8 build into a single `.exec` file.
- Run report generation and upload artifacts for consumption

## How was this patch tested?
Tested the changes in local docker build