### PR TITLE
ATLAS-5060: Remove slf4j-reload4j as it conflicts with Logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1046,11 +1046,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`slf4j-reload4j` dependency needs to removed from `webapp` module (pulled in from parent `pom.xml`)as it can't be used simultaneously with `logback` implementation.

## How was this patch tested?
- Manually removed `/opt/atlas/server/webapp/atlas/WEB-INF/lib/slf4j-reload4j-2.0.16.jar` from the `atlas` container and restarted atlas, no errors were seen during startup and `.err` file in `/var/log/atlas/` is empty.

Container startup logs
```
+ '[' '!' -e /opt/atlas/.setupDone ']'
+ SETUP_ATLAS=true
+ '[' true == true ']'
++ /opt/atlas/bin/cputil.py -g -u admin -p 'atlasR0cks!' -s
++ tail -1
+ encryptedPwd='$2a$10$HnxfHcnTeEbjjg3Hmz9jpu4wtTraV7.QbuuiM6tNH/80s1NsgTzWS'
+ echo 'admin=ADMIN::$2a$10$HnxfHcnTeEbjjg3Hmz9jpu4wtTraV7.QbuuiM6tNH/80s1NsgTzWS'
+ sed -i 's/atlas.graph.storage.hostname=.*$/atlas.graph.storage.hostname=atlas-zk.example.com:2181/' /opt/atlas/conf/atlas-application.properties
+ sed -i 's/atlas.audit.hbase.zookeeper.quorum=.*$/atlas.audit.hbase.zookeeper.quorum=atlas-zk.example.com:2181/' /opt/atlas/conf/atlas-application.properties
+ sed -i 's/^atlas.graph.index.search.solr.mode=cloud/# atlas.graph.index.search.solr.mode=cloud/' /opt/atlas/conf/atlas-application.properties
+ sed -i 's/^# *atlas.graph.index.search.solr.mode=http/atlas.graph.index.search.solr.mode=http/' /opt/atlas/conf/atlas-application.properties
+ sed -i 's/^.*atlas.graph.index.search.solr.http-urls=.*$/atlas.graph.index.search.solr.http-urls=http:\/\/atlas-solr.example.com:8983\/solr/' /opt/atlas/conf/atlas-application.properties
+ sed -i 's/atlas.notification.embedded=.*$/atlas.notification.embedded=false/' /opt/atlas/conf/atlas-application.properties
+ sed -i 's/atlas.kafka.zookeeper.connect=.*$/atlas.kafka.zookeeper.connect=atlas-zk.example.com:2181/' /opt/atlas/conf/atlas-application.properties
+ sed -i 's/atlas.kafka.bootstrap.servers=.*$/atlas.kafka.bootstrap.servers=atlas-kafka.example.com:9092/' /opt/atlas/conf/atlas-application.properties
+ echo ''
+ echo atlas.graph.storage.hbase.compression-algorithm=NONE
+ chown -R atlas:atlas /opt/atlas/
+ touch /opt/atlas/.setupDone
+ su -c 'cd /opt/atlas/bin && ./atlas_start.py' atlas

Starting Atlas server on host: localhost
Starting Atlas server on port: 21000
```

Contents of `/var/log/atlas`

```
root@atlas:/var/log/atlas# ls -lrt
total 104
-rw-rw-r-- 1 atlas atlas     0 Jun 20 00:57 atlas.20250620-005708.err
-rw-rw-r-- 1 atlas atlas     2 Jun 20 00:57 atlas.pid
-rw-rw-r-- 1 atlas atlas     0 Jun 20 00:57 large_messages.log
-rw-rw-r-- 1 atlas atlas     0 Jun 20 00:57 audit.log
-rw-rw-r-- 1 atlas atlas     0 Jun 20 00:57 tasks.log
-rw-rw-r-- 1 atlas atlas     0 Jun 20 00:57 metrics.log
-rw-rw-r-- 1 atlas atlas     0 Jun 20 00:57 failed.log
-rw-rw-r-- 1 atlas atlas 17638 Jun 20 00:57 atlas.20250620-005708.out
-rw-rw-r-- 1 atlas atlas 80804 Jun 20 00:57 application.log
```

- Verified with fresh install atlas build and startup in docker containers.