### PR TITLE
ATLAS-5061: Fix slow startup by making the import startup asynchronous

### DIFF
--- a/intg/src/main/java/org/apache/atlas/security/SecurityProperties.java
+++ b/intg/src/main/java/org/apache/atlas/security/SecurityProperties.java
@@ -45,7 +45,7 @@ public final class SecurityProperties {
     public static final String       ATLAS_SSL_EXCLUDE_PROTOCOLS              = "atlas.ssl.exclude.protocols";
     public static final String       ATLAS_SSL_ENABLED_PROTOCOLS              = "atlas.ssl.enabled.protocols";
     public static final String[]     DEFAULT_EXCLUDE_PROTOCOLS                = new String[] {"TLSv1", "TLSv1.1"};
-    public static final String[]     ATLAS_SSL_DEFAULT_PROTOCOL               = new String[] { "TLSv1.2" };
+    public static final String[]     ATLAS_SSL_DEFAULT_PROTOCOL               = new String[] {"TLSv1.2"};
 
     private SecurityProperties() {
     }

--- a/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
@@ -194,12 +194,14 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
     void startInternal() {
         populateRequestQueue();
 
-        CompletableFuture.runAsync(this::startNextImportInQueue)
-                .exceptionally(ex -> {
-                    LOG.error("Failed to start next import in queue", ex);
+        if (!requestQueue.isEmpty()) {
+            CompletableFuture.runAsync(this::startNextImportInQueue)
+                    .exceptionally(ex -> {
+                        LOG.error("Failed to start next import in queue", ex);
 
-                    return null;
-                });
+                        return null;
+                    });
+        }
     }
 
     @VisibleForTesting

--- a/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
@@ -270,20 +270,18 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
     void populateRequestQueue() {
         LOG.info("==> populateRequestQueue()");
 
-        List<String> queuedImports = asyncImportService.fetchQueuedImportRequests();
+        List<String> queuedImports     = asyncImportService.fetchQueuedImportRequests();
         List<String> inProgressImports = asyncImportService.fetchInProgressImportIds();
 
-        try {
-            if (queuedImports.isEmpty() && inProgressImports.isEmpty()) {
-                LOG.warn("populateRequestQueue(): No queued requests found.");
-                return;
-            }
+        if (queuedImports.isEmpty() && inProgressImports.isEmpty()) {
+            LOG.warn("populateRequestQueue(): no queued asynchronous import requests found.");
+        } else {
+            LOG.info("populateRequestQueue(): loaded {} asynchronous import requests (in-progress={}, queued={})", (inProgressImports.size() + queuedImports.size()), inProgressImports.size(), queuedImports.size());
 
-            Stream.concat(inProgressImports.stream(), queuedImports.stream())
-                    .forEach(this::enqueueImportId);
-        } finally {
-            LOG.info("<== populateRequestQueue()");
+            Stream.concat(inProgressImports.stream(), queuedImports.stream()).forEach(this::enqueueImportId);
         }
+
+        LOG.info("<== populateRequestQueue()");
     }
 
     private void enqueueImportId(String importId) {

--- a/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
@@ -60,7 +60,7 @@ import static org.apache.atlas.AtlasErrorCode.IMPORT_QUEUEING_FAILED;
 public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler, ImportTaskListener {
     private static final Logger LOG = LoggerFactory.getLogger(ImportTaskListenerImpl.class);
 
-    private static final String THREADNAME_PREFIX = ImportTaskListener.class.getSimpleName();
+    private static final String THREADNAME_PREFIX    = ImportTaskListener.class.getSimpleName();
     private static final int    ASYNC_IMPORT_PERMITS = 1; // Only one asynchronous import task is permitted
 
     private final BlockingQueue<String>    requestQueue;    // Blocking queue for requests
@@ -76,12 +76,12 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
     }
 
     public ImportTaskListenerImpl(AsyncImportService asyncImportService, NotificationHookConsumer notificationHookConsumer, BlockingQueue<String> requestQueue) throws AtlasException {
-        this.asyncImportService = asyncImportService;
+        this.asyncImportService       = asyncImportService;
         this.notificationHookConsumer = notificationHookConsumer;
-        this.requestQueue = requestQueue;
-        this.asyncImportSemaphore = new Semaphore(ASYNC_IMPORT_PERMITS);
-        this.applicationProperties = ApplicationProperties.get();
-        this.executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(THREADNAME_PREFIX + " thread-%d")
+        this.requestQueue             = requestQueue;
+        this.asyncImportSemaphore     = new Semaphore(ASYNC_IMPORT_PERMITS);
+        this.applicationProperties    = ApplicationProperties.get();
+        this.executorService          = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(THREADNAME_PREFIX + " thread-%d")
                 .setUncaughtExceptionHandler((thread, throwable) -> LOG.error("Uncaught exception in thread {}: {}", thread.getName(), throwable.getMessage(), throwable)).build());
     }
 
@@ -206,8 +206,8 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
     AtlasAsyncImportRequest getNextImportFromQueue() {
         LOG.info("==> getNextImportFromQueue()");
 
-        final int maxRetries = 5;
-        int retryCount = 0;
+        final int               maxRetries = 5;
+        int                     retryCount = 0;
         AtlasAsyncImportRequest nextImport = null;
 
         while (retryCount < maxRetries) {

--- a/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
@@ -96,14 +96,34 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
         startInternal();
     }
 
-    @VisibleForTesting
-    void startInternal() {
-        populateRequestQueue();
-        CompletableFuture.runAsync(this::startNextImportInQueue)
-                .exceptionally(ex -> {
-                    LOG.error("Failed to start next import in queue", ex);
-                    return null;
-                });
+    @Override
+    public void stop() throws AtlasException {
+        try {
+            stopImport();
+        } finally {
+            releaseAsyncImportSemaphore();
+        }
+    }
+
+    @Override
+    public void instanceIsActive() {
+        LOG.info("Reacting to active state: initializing Kafka consumers");
+
+        startInternal();
+    }
+
+    @Override
+    public void instanceIsPassive() {
+        try {
+            stopImport();
+        } finally {
+            releaseAsyncImportSemaphore();
+        }
+    }
+
+    @Override
+    public int getHandlerOrder() {
+        return ActiveStateChangeHandler.HandlerOrder.IMPORT_TASK_LISTENER.getOrder();
     }
 
     @Override
@@ -142,6 +162,46 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
         }
     }
 
+    @PreDestroy
+    public void stopImport() {
+        LOG.info("Shutting down import processor...");
+
+        executorService.shutdown(); // Initiate an orderly shutdown
+
+        try {
+            if (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
+                LOG.warn("Executor service did not terminate gracefully within the timeout. Waiting longer...");
+
+                // Retry shutdown before forcing it
+                if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                    LOG.warn("Forcing shutdown...");
+
+                    executorService.shutdownNow();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            LOG.error("Shutdown interrupted. Forcing shutdown...");
+
+            executorService.shutdownNow();
+        }
+
+        LOG.info("Import processor stopped.");
+    }
+
+    @VisibleForTesting
+    void startInternal() {
+        populateRequestQueue();
+
+        CompletableFuture.runAsync(this::startNextImportInQueue)
+                .exceptionally(ex -> {
+                    LOG.error("Failed to start next import in queue", ex);
+
+                    return null;
+                });
+    }
+
     @VisibleForTesting
     void startNextImportInQueue() {
         LOG.info("==> startNextImportInQueue()");
@@ -166,6 +226,7 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
 
             if (isNotValidImportRequest(nextImport)) {
                 releaseAsyncImportSemaphore();
+
                 return;
             }
 
@@ -179,36 +240,12 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
         }
     }
 
-    private void startImportConsumer(AtlasAsyncImportRequest importRequest) {
-        try {
-            LOG.info("==> startImportConsumer(atlasAsyncImportRequest={})", importRequest);
-
-            notificationHookConsumer.startAsyncImportConsumer(NotificationInterface.NotificationType.ASYNC_IMPORT, importRequest.getImportId(), importRequest.getTopicName());
-
-            importRequest.setStatus(ImportStatus.PROCESSING);
-            importRequest.setProcessingStartTime(System.currentTimeMillis());
-        } catch (Exception e) {
-            LOG.error("Failed to start consumer for import: {}, marking import as failed", importRequest, e);
-
-            importRequest.setStatus(ImportStatus.FAILED);
-        } finally {
-            asyncImportService.updateImportRequest(importRequest);
-
-            if (ObjectUtils.equals(importRequest.getStatus(), ImportStatus.FAILED)) {
-                onCompleteImportRequest(importRequest.getImportId());
-            }
-
-            LOG.info("<== startImportConsumer(atlasAsyncImportRequest={})", importRequest);
-        }
-    }
-
     @VisibleForTesting
     AtlasAsyncImportRequest getNextImportFromQueue() {
         LOG.info("==> getNextImportFromQueue()");
 
-        final int               maxRetries = 5;
-        int                     retryCount = 0;
-        AtlasAsyncImportRequest nextImport = null;
+        final int maxRetries = 5;
+        int       retryCount = 0;
 
         while (retryCount < maxRetries) {
             try {
@@ -238,8 +275,10 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
                 return importRequest;
             } catch (InterruptedException e) {
                 LOG.error("Thread interrupted while waiting for importId from the queue", e);
+
                 // Restore the interrupt flag
                 Thread.currentThread().interrupt();
+
                 return null;
             }
         }
@@ -255,6 +294,46 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
                 (!ImportStatus.WAITING.equals(importRequest.getStatus()) && !ImportStatus.PROCESSING.equals(importRequest.getStatus()));
     }
 
+    void populateRequestQueue() {
+        LOG.info("==> populateRequestQueue()");
+
+        List<String> queuedImports     = asyncImportService.fetchQueuedImportRequests();
+        List<String> inProgressImports = asyncImportService.fetchInProgressImportIds();
+
+        if (queuedImports.isEmpty() && inProgressImports.isEmpty()) {
+            LOG.info("populateRequestQueue(): no queued asynchronous import requests found.");
+        } else {
+            LOG.info("populateRequestQueue(): loaded {} asynchronous import requests (in-progress={}, queued={})", (inProgressImports.size() + queuedImports.size()), inProgressImports.size(), queuedImports.size());
+
+            Stream.concat(inProgressImports.stream(), queuedImports.stream()).forEach(this::enqueueImportId);
+        }
+
+        LOG.info("<== populateRequestQueue()");
+    }
+
+    private void startImportConsumer(AtlasAsyncImportRequest importRequest) {
+        try {
+            LOG.info("==> startImportConsumer(atlasAsyncImportRequest={})", importRequest);
+
+            notificationHookConsumer.startAsyncImportConsumer(NotificationInterface.NotificationType.ASYNC_IMPORT, importRequest.getImportId(), importRequest.getTopicName());
+
+            importRequest.setStatus(ImportStatus.PROCESSING);
+            importRequest.setProcessingStartTime(System.currentTimeMillis());
+        } catch (Exception e) {
+            LOG.error("Failed to start consumer for import: {}, marking import as failed", importRequest, e);
+
+            importRequest.setStatus(ImportStatus.FAILED);
+        } finally {
+            asyncImportService.updateImportRequest(importRequest);
+
+            if (ObjectUtils.equals(importRequest.getStatus(), ImportStatus.FAILED)) {
+                onCompleteImportRequest(importRequest.getImportId());
+            }
+
+            LOG.info("<== startImportConsumer(atlasAsyncImportRequest={})", importRequest);
+        }
+    }
+
     private void releaseAsyncImportSemaphore() {
         LOG.info("==> releaseAsyncImportSemaphore()");
 
@@ -267,89 +346,15 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
         }
     }
 
-    void populateRequestQueue() {
-        LOG.info("==> populateRequestQueue()");
-
-        List<String> queuedImports     = asyncImportService.fetchQueuedImportRequests();
-        List<String> inProgressImports = asyncImportService.fetchInProgressImportIds();
-
-        if (queuedImports.isEmpty() && inProgressImports.isEmpty()) {
-            LOG.warn("populateRequestQueue(): no queued asynchronous import requests found.");
-        } else {
-            LOG.info("populateRequestQueue(): loaded {} asynchronous import requests (in-progress={}, queued={})", (inProgressImports.size() + queuedImports.size()), inProgressImports.size(), queuedImports.size());
-
-            Stream.concat(inProgressImports.stream(), queuedImports.stream()).forEach(this::enqueueImportId);
-        }
-
-        LOG.info("<== populateRequestQueue()");
-    }
-
     private void enqueueImportId(String importId) {
         try {
             if (!requestQueue.offer(importId, 5, TimeUnit.SECONDS)) {
-                LOG.warn("populateRequestQueue(): Import {} enqueue timed out", importId);
+                LOG.warn("populateRequestQueue(): failed to add import {} to the queue - enqueue timed out", importId);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+
             LOG.error("populateRequestQueue(): Failed to add import {} to the queue", importId, e);
         }
-    }
-
-    @PreDestroy
-    public void stopImport() {
-        LOG.info("Shutting down import processor...");
-
-        executorService.shutdown(); // Initiate an orderly shutdown
-
-        try {
-            if (!executorService.awaitTermination(30, TimeUnit.SECONDS)) {
-                LOG.warn("Executor service did not terminate gracefully within the timeout. Waiting longer...");
-
-                // Retry shutdown before forcing it
-                if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-                    LOG.warn("Forcing shutdown...");
-
-                    executorService.shutdownNow();
-                }
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-
-            LOG.error("Shutdown interrupted. Forcing shutdown...");
-
-            executorService.shutdownNow();
-        }
-
-        LOG.info("Import processor stopped.");
-    }
-
-    @Override
-    public void stop() throws AtlasException {
-        try {
-            stopImport();
-        } finally {
-            releaseAsyncImportSemaphore();
-        }
-    }
-
-    @Override
-    public void instanceIsActive() {
-        LOG.info("Reacting to active state: initializing Kafka consumers");
-
-        startInternal();
-    }
-
-    @Override
-    public void instanceIsPassive() {
-        try {
-            stopImport();
-        } finally {
-            releaseAsyncImportSemaphore();
-        }
-    }
-
-    @Override
-    public int getHandlerOrder() {
-        return ActiveStateChangeHandler.HandlerOrder.IMPORT_TASK_LISTENER.getOrder();
     }
 }

--- a/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
@@ -61,14 +61,14 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
     private static final Logger LOG = LoggerFactory.getLogger(ImportTaskListenerImpl.class);
 
     private static final String THREADNAME_PREFIX = ImportTaskListener.class.getSimpleName();
-    private static final int ASYNC_IMPORT_PERMITS = 1; // Only one asynchronous import task is permitted
+    private static final int    ASYNC_IMPORT_PERMITS = 1; // Only one asynchronous import task is permitted
 
-    private final BlockingQueue<String> requestQueue;    // Blocking queue for requests
-    private final ExecutorService executorService; // Single-thread executor for sequential processing
-    private final AsyncImportService asyncImportService;
+    private final BlockingQueue<String>    requestQueue;    // Blocking queue for requests
+    private final ExecutorService          executorService; // Single-thread executor for sequential processing
+    private final AsyncImportService       asyncImportService;
     private final NotificationHookConsumer notificationHookConsumer;
-    private final Semaphore asyncImportSemaphore;
-    private final Configuration applicationProperties;
+    private final Semaphore                asyncImportSemaphore;
+    private final Configuration            applicationProperties;
 
     @Inject
     public ImportTaskListenerImpl(AsyncImportService asyncImportService, NotificationHookConsumer notificationHookConsumer) throws AtlasException {

--- a/webapp/src/main/java/org/apache/atlas/web/service/SecureEmbeddedServer.java
+++ b/webapp/src/main/java/org/apache/atlas/web/service/SecureEmbeddedServer.java
@@ -53,11 +53,11 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.List;
 
-import static org.apache.atlas.security.SecurityProperties.ATLAS_SSL_EXCLUDE_CIPHER_SUITES;
-import static org.apache.atlas.security.SecurityProperties.ATLAS_SSL_EXCLUDE_PROTOCOLS;
+import static org.apache.atlas.security.SecurityProperties.ATLAS_SSL_DEFAULT_PROTOCOL;
 import static org.apache.atlas.security.SecurityProperties.ATLAS_SSL_ENABLED_ALGORITHMS;
 import static org.apache.atlas.security.SecurityProperties.ATLAS_SSL_ENABLED_PROTOCOLS;
-import static org.apache.atlas.security.SecurityProperties.ATLAS_SSL_DEFAULT_PROTOCOL;
+import static org.apache.atlas.security.SecurityProperties.ATLAS_SSL_EXCLUDE_CIPHER_SUITES;
+import static org.apache.atlas.security.SecurityProperties.ATLAS_SSL_EXCLUDE_PROTOCOLS;
 import static org.apache.atlas.security.SecurityProperties.CLIENT_AUTH_KEY;
 import static org.apache.atlas.security.SecurityProperties.DEFATULT_TRUSTORE_FILE_LOCATION;
 import static org.apache.atlas.security.SecurityProperties.DEFAULT_CIPHER_SUITES;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The new asynchronous import feature had to start all of the import in backend which made the app startup longer, this PR fixes the same by making the import start up asynchronous thus not blocking the class initialization and app start up to wait. 




## How was this patch tested?

Manual testing by patching to cluster and Unit test