### PR TITLE
ATLAS-5058: Update ci.yml to rely on healthchecks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
           cd dev-support/atlas-docker
           export DOCKER_BUILDKIT=1
           export COMPOSE_DOCKER_CLI_BUILD=1
+          docker compose -f docker-compose.atlas-base.yml build 
           docker compose \
-          -f docker-compose.atlas-base.yml \
           -f docker-compose.atlas.yml \
           -f docker-compose.atlas-hadoop.yml \
           -f docker-compose.atlas-hbase.yml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,10 @@ jobs:
           -f docker-compose.atlas-hadoop.yml \
           -f docker-compose.atlas-hbase.yml \
           -f docker-compose.atlas-kafka.yml \
-          -f docker-compose.atlas-hive.yml up -d
+          -f docker-compose.atlas-hive.yml up -d --wait
 
       - name: Check status of containers and remove them
         run: |
-          sleep 60
           containers=(atlas atlas-hadoop atlas-hbase atlas-kafka atlas-hive);
           flag=true;
           for container in "${containers[@]}"; do

--- a/dev-support/atlas-docker/docker-compose.atlas-hadoop.yml
+++ b/dev-support/atlas-docker/docker-compose.atlas-hadoop.yml
@@ -15,8 +15,6 @@ services:
     ports:
       - "9000:9000"
       - "8088:8088"
-    depends_on:
-      - atlas-base
     healthcheck:
       test: [ "CMD-SHELL", "su hdfs -c \"/opt/hadoop/bin/hdfs dfsadmin -report | grep -q 'Live datanodes'\"" ]
       interval: 30s

--- a/dev-support/atlas-docker/docker-compose.atlas-hive.yml
+++ b/dev-support/atlas-docker/docker-compose.atlas-hive.yml
@@ -14,6 +14,12 @@ services:
     tty: true
     networks:
       - atlas
+    healthcheck:
+      test: [ "CMD-SHELL", "su hdfs -c \"/opt/hadoop/bin/hdfs dfsadmin -report | grep -q 'Live datanodes'\"" ]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 40s
     ports:
       - "10000:10000"
     depends_on:
@@ -40,11 +46,10 @@ services:
     networks:
       - atlas
     healthcheck:
-      test: [ "CMD-SHELL", "su hdfs -c \"/opt/hadoop/bin/hdfs dfsadmin -report | grep -q 'Live datanodes'\"" ]
-      interval: 30s
-      timeout: 10s
+      test: 'su -c "pg_isready -q" postgres'
+      interval: 10s
+      timeout: 2s
       retries: 30
-      start_period: 40s
 
 networks:
   atlas:


### PR DESCRIPTION
Since health checks for respective containers are in place, `ci.yml` can be updated to rely on this.

## How was this patch tested?
CI: https://github.com/kumaab/atlas/actions/runs/16156151540/job/45598946514
