### PR TITLE
ATLAS-5039: Page for TeamList doesn't render Atlas team members in atlas.apache.org

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node ./docz-lib/docz/bin/index.js dev",
+    "fetch-team": "node scripts/fetchTeamList.js",
+    "prebuild": "npm run fetch-team",
     "build": "node ./docz-lib/docz/bin/index.js build",
     "predeploy": "npm install && npm run build",
     "deploy": "gh-pages -d .docz/dist"

--- a/docs/scripts/fetchTeamList.js
+++ b/docs/scripts/fetchTeamList.js
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const https = require("https");
+const fs = require("fs");
+const { parseString } = require("xml2js");
+
+const POM_URL = "https://raw.githubusercontent.com/apache/atlas/master/pom.xml";
+const OUTPUT_PATH = "src/resources/public/data/team.json";
+
+function fetchXML(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, res => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Request failed. Status code: ${res.statusCode}`));
+          res.resume(); // drain
+          return;
+        }
+
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", chunk => (data += chunk));
+        res.on("end", () => resolve(data));
+      })
+      .on("error", reject);
+  });
+}
+
+(async () => {
+  try {
+    const xmlData = await fetchXML(POM_URL);
+
+    parseString(xmlData, (err, result) => {
+      if (err) {
+        console.error("❌ XML parsing failed:", err);
+        process.exit(1);
+      }
+
+      let developersList = [];
+      if (
+        result &&
+        result.project &&
+        result.project.developers &&
+        Array.isArray(result.project.developers) &&
+        result.project.developers[0] &&
+        result.project.developers[0].developer
+      ) {
+        developersList = result.project.developers[0].developer;
+      }
+
+      const keys = developersList.length > 0 ? Object.keys(developersList[0]) : [];
+
+      const output = developersList.map(dev => {
+        const obj = {};
+        keys.forEach(k => {
+          obj[k] = dev[k] || [""];
+        });
+        return obj;
+      });
+
+      // Ensure the directory exists
+      const outputDir = require("path").dirname(OUTPUT_PATH);
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+
+      fs.writeFileSync(OUTPUT_PATH, JSON.stringify(output, null, 2));
+      console.log(`✅ Team data written to ${OUTPUT_PATH}`);
+    });
+  } catch (err) {
+    console.error("❌ Failed to fetch pom.xml:", err.message);
+    process.exit(1);
+  }
+})();

--- a/docs/theme/components/shared/TeamList/index.js
+++ b/docs/theme/components/shared/TeamList/index.js
@@ -20,6 +20,7 @@ import React, { Component } from "react";
 import axios from "axios";
 import { parseString } from "xml2js";
 import styled from "styled-components";
+import teamData from "src/resources/public/data/team.json";
 
 const TeamListStyle = styled.div`
   width: 100%;
@@ -73,33 +74,9 @@ export default class TeamList extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      isLoading: true,
-      displayData: []
+      displayData: teamData || [],
+      isLoading: false
     };
-    this.fetchData();
-  }
-
-  fetchData() {
-    axios
-      .get(`https://raw.githubusercontent.com/apache/atlas/master/pom.xml`)
-      .then(res => {
-        // Transform the raw data by extracting the nested posts
-        parseString(res.data, (err, result) => {
-          const developersList = result.project.developers[0].developer;
-          const developersListLength = developersList.length;
-          let t_displayData = [];
-          const keys = Object.keys(developersList[0]);
-          for (var i = 0; i < developersListLength; i++) {
-            const obj = {};
-            keys.map(k => (obj[k] = developersList[i][k]));
-            t_displayData.push(obj);
-          }
-          this.setState({ displayData: t_displayData, isLoading: false });
-        });
-      })
-      .catch(err => {
-        console.log("fetching data from pom.xml is failed.");
-      });
   }
 
   render() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Problem: The Apache Atlas Team List in the website is rendered from github pom.xml dynamically.
Since the response header `content-security-policy` from apache atlas website doesn't allow GitHub URL, Team List is not loading

Solution: Team List is fetched in a pre build step and saved in a file and rendered from that file, instead of fetching from github url.
Another Solution is mentioned [here](https://infra.apache.org/tools/csp.html)

## How was this patch tested?

Locally build the doc module and checked