### PR TITLE
Atlas-5063: [Backend] Fix for improving logout mechanism in Atlas Backend code base

### DIFF
--- a/webapp/src/main/java/org/apache/atlas/web/filters/HeadersUtil.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/HeadersUtil.java
@@ -50,6 +50,8 @@ public class HeadersUtil {
     public static final String X_REQUESTED_WITH_VALUE              = "XMLHttpRequest";
     public static final int    SC_AUTHENTICATION_TIMEOUT           = 419;
     public static final String CONFIG_PREFIX_HTTP_RESPONSE_HEADER  = "atlas.headers";
+    public static final String CACHE_CONTROL                       = "Cache-Control";
+    public static final String CACHE_CONTROL_VAL                   = "no-cache";
 
     private static final Map<String, String> HEADER_MAP = new HashMap<>();
 

--- a/webapp/src/main/java/org/apache/atlas/web/filters/RestUtil.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/RestUtil.java
@@ -30,7 +30,7 @@ public class RestUtil {
     private static final Logger LOG = LoggerFactory.getLogger(RestUtil.class);
 
     public static final  String TIMEOUT_ACTION = "timeout";
-    public static final  String LOGOUT_URL     = "/logout.html";
+    public static final  String LOGOUT_URL     = "/logout";
     public static final  String DELIMITTER     = "://";
 
     private static final String PROXY_ATLAS_URL_PATH = "/atlas";

--- a/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
@@ -1098,6 +1098,15 @@ public class AdminResource {
         }
     }
 
+    @GET
+    @Path("/checksso")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String checkSSO(@Context HttpServletRequest httpServletRequest) {
+        Object ssoFlag = httpServletRequest.getAttribute("ssoEnabled");
+        LOG.debug("SSO attribute Value: {}", ssoFlag);
+        return String.valueOf(ssoFlag);
+    }
+
     private void updateCriteriaWithDefaultValues(AuditReductionCriteria auditReductionCriteria) {
         if (auditReductionCriteria.getDefaultAgeoutTTLInDays() <= 0) {
             auditReductionCriteria.setDefaultAgeoutTTLInDays(AtlasConfiguration.ATLAS_AUDIT_DEFAULT_AGEOUT_TTL.getInt());

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityCommonConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityCommonConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.atlas.web.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AtlasSecurityCommonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -103,6 +103,7 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
     private final StaleTransactionCleanupFilter staleTransactionCleanupFilter;
     private final ActiveServerFilter            activeServerFilter;
     private final boolean                       keycloakEnabled;
+    private final CustomLogoutSuccessHandler        customLogoutSuccessHandler;
 
     @Value("${keycloak.configurationFile:WEB-INF/keycloak.json}")
     private Resource keycloakConfigFileResource;
@@ -120,7 +121,7 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
             AtlasAuthenticationEntryPoint atlasAuthenticationEntryPoint,
             Configuration configuration,
             StaleTransactionCleanupFilter staleTransactionCleanupFilter,
-            ActiveServerFilter activeServerFilter) {
+            ActiveServerFilter activeServerFilter, CustomLogoutSuccessHandler customLogoutSuccessHandler) {
         this.ssoAuthenticationFilter       = ssoAuthenticationFilter;
         this.csrfPreventionFilter          = atlasCSRFPreventionFilter;
         this.atlasAuthenticationFilter     = atlasAuthenticationFilter;
@@ -131,6 +132,7 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
         this.configuration                 = configuration;
         this.staleTransactionCleanupFilter = staleTransactionCleanupFilter;
         this.activeServerFilter            = activeServerFilter;
+        this.customLogoutSuccessHandler    = customLogoutSuccessHandler;
 
         this.keycloakEnabled = configuration.getBoolean(AtlasAuthenticationProvider.KEYCLOAK_AUTH_METHOD, false);
     }
@@ -220,10 +222,9 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
                 .passwordParameter("j_password")
                 .and()
                 .logout()
-                .logoutSuccessUrl("/login.jsp")
+                .logoutSuccessHandler(customLogoutSuccessHandler)
                 .deleteCookies("ATLASSESSIONID")
-                .logoutUrl("/logout.html");
-
+                .logoutUrl("/logout");
         //@formatter:on
 
         boolean configMigrationEnabled = !StringUtils.isEmpty(configuration.getString(ATLAS_MIGRATION_MODE_FILENAME));

--- a/webapp/src/main/java/org/apache/atlas/web/security/CustomLogoutSuccessHandler.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/CustomLogoutSuccessHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.atlas.web.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.atlas.web.filters.HeadersUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler implements LogoutSuccessHandler {
+    private final ObjectMapper mapper;
+    private static final Logger LOG = LoggerFactory.getLogger(CustomLogoutSuccessHandler.class);
+
+    @Inject
+    public CustomLogoutSuccessHandler(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        request.getServletContext().removeAttribute(request.getRequestedSessionId());
+        response.setContentType("application/json;charset=UTF-8");
+        response.setHeader(HeadersUtil.CACHE_CONTROL, HeadersUtil.CACHE_CONTROL_VAL);
+        response.setHeader(HeadersUtil.X_FRAME_OPTIONS_KEY, HeadersUtil.X_FRAME_OPTIONS_VAL);
+
+        try {
+            Map<String, Object> responseMap = new HashMap<>();
+            responseMap.put("statusCode", HttpServletResponse.SC_OK);
+            responseMap.put("msgDesc", "Logout Successful");
+            String jsonStr = mapper.writeValueAsString(responseMap);
+
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.getWriter().write(jsonStr);
+
+            LOG.debug("Log-out Successfully done. Returning Json : {}", jsonStr);
+        } catch (IOException e) {
+            LOG.debug("Error while writing JSON in HttpServletResponse");
+        }
+    }
+}

--- a/webapp/src/test/java/org/apache/atlas/web/filters/AtlasKnoxSSOAuthenticationFilterTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/filters/AtlasKnoxSSOAuthenticationFilterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.atlas.web.filters;
+
+import org.apache.atlas.web.resources.AdminResource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class AtlasKnoxSSOAuthenticationFilterTest {
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private AtlasKnoxSSOAuthenticationFilter filter;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private MockHttpSession session;
+
+    @InjectMocks
+    AdminResource adminResource;
+
+    @BeforeMethod
+    public void testSetup() {
+        MockitoAnnotations.openMocks(this);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        session = new MockHttpSession();
+        request.setSession(session);
+
+        request.setRequestURI("/api/atlas/admin/checksso");
+        request.addHeader("User-Agent", "Chrome");
+    }
+
+    @Test
+    public void testDoFilter_withoutJwt_setsSsoDisabled() throws IOException, ServletException {
+        request.setCookies();  // clear cookies for this test
+        filter.doFilter(request, response, filterChain);
+
+        assertNull(filter.getJWTFromCookie(request));
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    public void testDoFilter_withJwt_setsSsoEnabledTrue() throws IOException, ServletException {
+        request.setCookies(new Cookie("hadoop-jwt", "dummy-jwt-token"));
+        filter.doFilter(request, response, filterChain);
+
+        assertNotNull(filter.getJWTFromCookie(request));
+        assertNotNull(request.getCookies());
+        assertTrue(Arrays.stream(request.getCookies())
+                .anyMatch(cookie -> cookie.getValue().equals("dummy-jwt-token")));
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    public void test_CheckSSO_API_true() {
+        request.setAttribute("ssoEnabled", true);
+        String result = adminResource.checkSSO(request);
+        assertEquals(result, "true");
+    }
+
+    @Test
+    public void test_CheckSSO_API_false() {
+        request.setAttribute("ssoEnabled", false);
+        String result = adminResource.checkSSO(request);
+        assertEquals(result, "false");
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR improves the Knox logout behavior in Apache Atlas. 
1. Previously, logging out of Atlas when accessed via Knox led to a blank page. 
2. To handle this, a new checkSso API was introduced to determine if the session is SSO-based by checking the presence of the hadoop-jwt cookie. 
3. Based on the response (true or false), the frontend now redirects either to a default action page (for SSO sessions) or to the traditional login.jsp. 
4. Additionally, a CustomLogoutSuccessHandler has been added for proper logout handling. Changes were also made to AtlasKnoxSSOAuthenticationFilter to support this logic.
5. Some changes were done in AtlasSecurityConfig for logout.

## How was this patch tested?
1. Unit Test added
2. UI testing - cluster: http://ccycloud-1.fsknox.root.comops.site:7180/cmf/home
3. CI Build - Passed
4. PC: https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/1933/