### PR TITLE
ATLAS-5067:UI: Apache Atlas Glossary becomes unresponsive when the pa…

### DIFF
--- a/dashboardv2/public/js/views/glossary/GlossaryDetailLayoutView.js
+++ b/dashboardv2/public/js/views/glossary/GlossaryDetailLayoutView.js
@@ -245,11 +245,8 @@ define(['require',
                     }
                 } else {;
                     Utils.showTitleLoader(this.$('.page-title .fontLoader'), this.ui.details);
-                    var getApiFunctionKey = "getCategory",
+                    var getApiFunctionKey =this.isTermView? "getTerm" : "getCategory",
                         that = this;
-                    if (this.isTermView) {
-                        getApiFunctionKey = "getTerm";
-                    }
                     this.glossaryCollection[getApiFunctionKey]({
                         "guid": this.guid,
                         "ajaxOptions": {
@@ -542,7 +539,9 @@ define(['require',
                             "value": {
                                 "searchType": "basic",
                                 "term": that.data.qualifiedName,
-                                "includeDE": options.value.includeDE || false
+                                "includeDE": options.value.includeDE || false,
+                                "pageLimit": options.value.pageLimit || 25,
+                                "pageOffset": options.value.pageOffset || 0,
                             },
                             "fromView": "glossary"
                         })));

--- a/dashboardv2/public/js/views/search/SearchResultLayoutView.js
+++ b/dashboardv2/public/js/views/search/SearchResultLayoutView.js
@@ -363,7 +363,7 @@ define(['require',
                 Utils.setUrl(_.extend({
                     url: Utils.getUrlState.getQueryUrl().queyParams[0],
                     urlParams: this.columnOrder ? _.extend(this.value, { 'uiParameters': this.getColumnOrderWithPosition() }) : this.value,
-                    mergeBrowserUrl: false,
+                    mergeBrowserUrl: Utils.getUrlState.isGlossaryTab()?true:false,
                     trigger: false,
                     updateTabState: true
                 }, options));


### PR DESCRIPTION
[Atlas UI] Apache Atlas Glossary becomes unresponsive when the page size is set to 50.

## What changes were proposed in this pull request?

Atlas Classic UI becomes unresponsive in the Glossary section after changing the page limit to 50.

Steps to Reproduce:

Log in to Apache Atlas.
Navigate to the Glossary section.
Select a glossary item that has more than 25 associated entities.
At the bottom of the page, change the page limit to 50.
Actual Result:
An alert is displayed with the following error message:

+++
"expected type AtlasGlossaryCategory; found AtlasGlossaryTerm"
+++

This error was occurring because of the incorrect API; now the correct API is being hit.

## How was this patch tested?

Tested manually and now working fine with the changes. Uploaded a screenshot showing 50 results without error.
![Screenshot from 2025-07-10 15-29-35](https://github.com/user-attachments/assets/a1fd2649-4fc8-4a65-a8dd-fb4b2678c858)
