### PR TITLE
ATLAS-5072: Make default landing UI as React UI.

### DIFF
--- a/dashboard/src/views/Layout/Header.tsx
+++ b/dashboard/src/views/Layout/Header.tsx
@@ -144,7 +144,7 @@ const Header: React.FC<Header> = ({
   };
 
   const handleLogout = () => {
-    localStorage.setItem("atlas_ui", "beta");
+    localStorage.setItem("atlas_ui", "v3");
     let path = getBaseUrl(window.location.pathname);
     window.location.href = path + "/logout.html";
     handleClose();

--- a/dashboard/src/views/Layout/Layout.tsx
+++ b/dashboard/src/views/Layout/Layout.tsx
@@ -89,7 +89,7 @@ const Layout: React.FC = () => {
   }, [getRemainingTime, isPrompted]);
 
   const handleLogout = () => {
-    localStorage.setItem("atlas_ui", "beta");
+    localStorage.setItem("atlas_ui", "v3");
     let path = getBaseUrl(window.location.pathname);
     window.location.href = path + "/logout.html";
     handleCloseSessionModal();

--- a/dashboardv2/public/js/modules/atlasLogin.js
+++ b/dashboardv2/public/js/modules/atlasLogin.js
@@ -96,20 +96,26 @@ function doLogin() {
 function redirect(baseUrl) {
     $.ajax({
         url: baseUrl + "api/atlas/admin/session",
-        success: function(data) {
-            var PRIMARY_UI = "v2",
-                indexpath = "/n/index.html";
-            if (data && data["atlas.ui.default.version"]) {
-                PRIMARY_UI = data["atlas.ui.default.version"];
+        success: function(data)  {
+            // Default to react UI (v3)
+            var PRIMARY_UI = (data && data["atlas.ui.default.version"]) ? data["atlas.ui.default.version"] : "v3";
+            var lastUILoad = window.localStorage && window.localStorage.last_ui_load;
+            var uiVersion = lastUILoad || PRIMARY_UI;
+            var indexpath;
+
+            switch (uiVersion) {
+                case "v1":
+                    indexpath = "/index.html";      // classic UI
+                    break;
+                case "v2":
+                    indexpath = "/n/index.html";    // beta UI
+                    break;
+                case "v3":
+                default:
+                    indexpath = "/n3/index.html";   // react UI
+                    break;
             }
-            if (PRIMARY_UI !== "v2") {
-                indexpath = "/index.html";
-            }
-            if (window.localStorage.last_ui_load === "v1") {
-                indexpath = "/index.html";
-            } else if (window.localStorage.last_ui_load === "v2") {
-                indexpath = "/n/index.html";
-            }
+
             indexpath = baseUrl + indexpath;
             if (location.hash.length > 2) {
                 indexpath += location.hash;

--- a/dashboardv3/public/js/modules/atlasLogin.js
+++ b/dashboardv3/public/js/modules/atlasLogin.js
@@ -96,20 +96,26 @@ function doLogin() {
 function redirect(baseUrl) {
     $.ajax({
         url: baseUrl + "api/atlas/admin/session",
-        success: function(data) {
-            var PRIMARY_UI = "v2",
-                indexpath = "/n/index.html";
-            if (data && data["atlas.ui.default.version"]) {
-                PRIMARY_UI = data["atlas.ui.default.version"];
+        success:  function(data)  {
+            // Default to react UI (v3)
+            var PRIMARY_UI = (data && data["atlas.ui.default.version"]) ? data["atlas.ui.default.version"] : "v3";
+            var lastUILoad = window.localStorage && window.localStorage.last_ui_load;
+            var uiVersion = lastUILoad || PRIMARY_UI;
+            var indexpath;
+
+            switch (uiVersion) {
+                case "v1":
+                    indexpath = "/index.html";      // classic UI
+                    break;
+                case "v2":
+                    indexpath = "/n/index.html";    // beta UI
+                    break;
+                case "v3":
+                default:
+                    indexpath = "/n3/index.html";   // react UI
+                    break;
             }
-            if (PRIMARY_UI !== "v2") {
-                indexpath = "/index.html";
-            }
-            if (window.localStorage.last_ui_load === "v1") {
-                indexpath = "/index.html";
-            } else if (window.localStorage.last_ui_load === "v2") {
-                indexpath = "/n/index.html";
-            }
+
             indexpath = baseUrl + indexpath;
             if (location.hash.length > 2) {
                 indexpath += location.hash;

--- a/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
@@ -153,7 +153,7 @@ public class AdminResource {
     private static final String        editableEntityTypes              = "atlas.ui.editable.entity.types";
     private static final String        DEFAULT_EDITABLE_ENTITY_TYPES    = "hdfs_path";
     private static final String        DEFAULT_UI_VERSION               = "atlas.ui.default.version";
-    private static final String        UI_VERSION_V2                    = "v2";
+    private static final String        UI_VERSION_V3                    = "v3"; //v1:Classic UI, v2:Beta UI, v3:react ui
     private static final String        UI_DATE_TIMEZONE_FORMAT_ENABLED  = "atlas.ui.date.timezone.format.enabled";
     private static final String        UI_DATE_FORMAT                   = "atlas.ui.date.format";
     private static final String        UI_DATE_DEFAULT_FORMAT           = "MM/DD/YYYY hh:mm:ss A";
@@ -226,7 +226,7 @@ public class AdminResource {
         this.atlasMetricsUtil          = atlasMetricsUtil;
 
         if (atlasProperties != null) {
-            this.defaultUIVersion            = atlasProperties.getString(DEFAULT_UI_VERSION, UI_VERSION_V2);
+            this.defaultUIVersion            = atlasProperties.getString(DEFAULT_UI_VERSION, UI_VERSION_V3);
             this.isTimezoneFormatEnabled     = atlasProperties.getBoolean(UI_DATE_TIMEZONE_FORMAT_ENABLED, true);
             this.uiDateFormat                = atlasProperties.getString(UI_DATE_FORMAT, UI_DATE_DEFAULT_FORMAT);
             this.isDebugMetricsEnabled       = AtlasConfiguration.DEBUG_METRICS_ENABLED.getBoolean();
@@ -236,7 +236,7 @@ public class AdminResource {
             this.defaultLineageNodeCount     = AtlasConfiguration.LINEAGE_ON_DEMAND_DEFAULT_NODE_COUNT.getInt();
             this.isRelationshipSearchEnabled = AtlasConfiguration.RELATIONSHIP_SEARCH_ENABLED.getBoolean();
         } else {
-            this.defaultUIVersion            = UI_VERSION_V2;
+            this.defaultUIVersion            = UI_VERSION_V3;
             this.isTimezoneFormatEnabled     = true;
             this.uiDateFormat                = UI_DATE_DEFAULT_FORMAT;
             this.isDebugMetricsEnabled       = false;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a user logs in to Atlas, React UI should be displayed instead of Classic/ Beta (Classic/ New).


## How was this patch tested?

Manually tested.

After logging following ReactUI screen gets displayed.

<img width="1847" height="1006" alt="ATLAS-5072_AfterChanges" src="https://github.com/user-attachments/assets/9d1028f5-ab8e-40a2-b882-ba5dca70a192" />
