### PR TITLE
ATLAS-5081: React UI all API's are failing when accessing through KNOX.

### DIFF
--- a/dashboard/src/api/apiUrlLinks/commonApiUrl.ts
+++ b/dashboard/src/api/apiUrlLinks/commonApiUrl.ts
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
-export const apiBaseurl = window.location.origin;
-const baseUrl = apiBaseurl + "/api/atlas";
-const baseUrlV2 = apiBaseurl + "/api/atlas/v2";
+import { getBaseUrl } from "@utils/Utils";
+
+export const apiBaseurl = window.location.pathname;
+const baseUrl = getBaseUrl(apiBaseurl) + "/api/atlas";
+const baseUrlV2 = getBaseUrl(apiBaseurl) + "/api/atlas/v2";
 
 const getBaseApiUrl = (url: string) => {
   if (url == "url") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the Apache Atlas service is up using KNOX, on React UI, all the API's are giving 404 error (no network connected).

Solution:
API path doesn't contain the full path with KNOX. By adding the full URL in the API, including the Knox part, this will fix the issue.


## How was this patch tested?

Tested Manually.
<img width="1847" height="1006" alt="ATLAS-5081API_issueFixed" src="https://github.com/user-attachments/assets/e1875679-9b42-4c69-b0bb-083ca5df6f63" />
