### PR TITLE
ATLAS-5091: ensure commit/rollback is called on AtlasGraphManagement instances

### DIFF
--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraphManagement.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraphManagement.java
@@ -24,7 +24,7 @@ import java.util.List;
  * Management interface for a graph.
  *
  */
-public interface AtlasGraphManagement {
+public interface AtlasGraphManagement extends AutoCloseable {
     /**
      * Checks whether a property with the given key has been defined in the graph schema.
      *
@@ -32,17 +32,6 @@ public interface AtlasGraphManagement {
      * @return
      */
     boolean containsPropertyKey(String key);
-
-    /**
-     * Rolls back the changes that have been made to the management system.
-     */
-    void rollback();
-
-    /**
-     * Commits the changes that have been made to the management system.
-     */
-
-    void commit();
 
     /**
      * @param propertyName
@@ -203,4 +192,6 @@ public interface AtlasGraphManagement {
      * @param txRecoveryObject
      */
     void printIndexRecoveryStats(Object txRecoveryObject);
+
+    void setIsSuccess(boolean isSuccess);
 }

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClient.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClient.java
@@ -24,7 +24,6 @@ import org.apache.atlas.model.discovery.AtlasAggregationEntry;
 import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.graphdb.AggregationContext;
 import org.apache.atlas.repository.graphdb.AtlasGraphIndexClient;
-import org.apache.atlas.repository.graphdb.AtlasGraphManagement;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
@@ -482,24 +481,6 @@ public class AtlasJanusGraphIndexClient implements AtlasGraphIndexClient {
         String              janusVertexIndex = ApplicationProperties.DEFAULT_INDEX_NAME + "_" + Constants.VERTEX_INDEX;
 
         return client != null && client.indexExists(janusVertexIndex);
-    }
-
-    private void graphManagementCommit(AtlasGraphManagement management) {
-        try {
-            management.commit();
-        } catch (Exception ex) {
-            LOG.warn("Graph transaction management commit failed; attempting rollback", ex);
-
-            graphManagementRollback(management);
-        }
-    }
-
-    private void graphManagementRollback(AtlasGraphManagement management) {
-        try {
-            management.rollback();
-        } catch (Exception ex) {
-            LOG.warn("Graph transaction management rollback failed", ex);
-        }
     }
 
     private SolrResponse updateFreeTextRequestHandler(SolrClient solrClient, String collectionName, Map<String, Integer> indexFieldName2SearchWeightMap, Solr6Index.Mode mode) throws IOException, SolrServerException, AtlasBaseException {

--- a/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AbstractGraphDatabaseTest.java
+++ b/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AbstractGraphDatabaseTest.java
@@ -56,24 +56,25 @@ public abstract class AbstractGraphDatabaseTest {
             LocalSolrRunner.start();
         }
 
-        AtlasJanusGraphDatabase db   = new AtlasJanusGraphDatabase();
-        AtlasGraphManagement    mgmt = db.getGraph().getManagementSystem();
+        AtlasJanusGraphDatabase db = new AtlasJanusGraphDatabase();
 
-        if (mgmt.getGraphIndex(BACKING_INDEX_NAME) == null) {
-            mgmt.createVertexMixedIndex(BACKING_INDEX_NAME, Constants.BACKING_INDEX, Collections.emptyList());
+        try (AtlasGraphManagement mgmt = db.getGraph().getManagementSystem()) {
+            if (mgmt.getGraphIndex(BACKING_INDEX_NAME) == null) {
+                mgmt.createVertexMixedIndex(BACKING_INDEX_NAME, Constants.BACKING_INDEX, Collections.emptyList());
+            }
+            mgmt.makePropertyKey("age13", Integer.class, AtlasCardinality.SINGLE);
+
+            createIndices(mgmt, "name", String.class, false, AtlasCardinality.SINGLE);
+            createIndices(mgmt, WEIGHT_PROPERTY, Integer.class, false, AtlasCardinality.SINGLE);
+            createIndices(mgmt, "size15", String.class, false, AtlasCardinality.SINGLE);
+            createIndices(mgmt, "typeName", String.class, false, AtlasCardinality.SINGLE);
+            createIndices(mgmt, "__type", String.class, false, AtlasCardinality.SINGLE);
+            createIndices(mgmt, Constants.GUID_PROPERTY_KEY, String.class, true, AtlasCardinality.SINGLE);
+            createIndices(mgmt, Constants.TRAIT_NAMES_PROPERTY_KEY, String.class, false, AtlasCardinality.SET);
+            createIndices(mgmt, Constants.SUPER_TYPES_PROPERTY_KEY, String.class, false, AtlasCardinality.SET);
+
+            mgmt.setIsSuccess(true);
         }
-        mgmt.makePropertyKey("age13", Integer.class, AtlasCardinality.SINGLE);
-
-        createIndices(mgmt, "name", String.class, false, AtlasCardinality.SINGLE);
-        createIndices(mgmt, WEIGHT_PROPERTY, Integer.class, false, AtlasCardinality.SINGLE);
-        createIndices(mgmt, "size15", String.class, false, AtlasCardinality.SINGLE);
-        createIndices(mgmt, "typeName", String.class, false, AtlasCardinality.SINGLE);
-        createIndices(mgmt, "__type", String.class, false, AtlasCardinality.SINGLE);
-        createIndices(mgmt, Constants.GUID_PROPERTY_KEY, String.class, true, AtlasCardinality.SINGLE);
-        createIndices(mgmt, Constants.TRAIT_NAMES_PROPERTY_KEY, String.class, false, AtlasCardinality.SET);
-        createIndices(mgmt, Constants.SUPER_TYPES_PROPERTY_KEY, String.class, false, AtlasCardinality.SET);
-
-        mgmt.commit();
     }
 
     @AfterClass

--- a/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusDatabaseTest.java
+++ b/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusDatabaseTest.java
@@ -391,21 +391,21 @@ public class AtlasJanusDatabaseTest {
 
             atlasGraph = db.getGraph();
 
-            AtlasGraphManagement mgmt = atlasGraph.getManagementSystem();
+            try (AtlasGraphManagement mgmt = atlasGraph.getManagementSystem()) {
+                // create the index (which defines these properties as being mult
+                // many)
+                for (String propertyName : new String[] {"__superTypeNames", "__traitNames"}) {
+                    AtlasPropertyKey propertyKey = mgmt.getPropertyKey(propertyName);
 
-            // create the index (which defines these properties as being mult
-            // many)
-            for (String propertyName : new String[] {"__superTypeNames", "__traitNames"}) {
-                AtlasPropertyKey propertyKey = mgmt.getPropertyKey(propertyName);
+                    if (propertyKey == null) {
+                        propertyKey = mgmt.makePropertyKey(propertyName, String.class, AtlasCardinality.SET);
 
-                if (propertyKey == null) {
-                    propertyKey = mgmt.makePropertyKey(propertyName, String.class, AtlasCardinality.SET);
-
-                    mgmt.createVertexCompositeIndex(propertyName, false, Collections.singletonList(propertyKey));
+                        mgmt.createVertexCompositeIndex(propertyName, false, Collections.singletonList(propertyKey));
+                    }
                 }
-            }
 
-            mgmt.commit();
+                mgmt.setIsSuccess(true);
+            }
         }
 
         return (AtlasGraph<V, E>) atlasGraph;

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -256,12 +256,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
     public void onChange(ChangedTypeDefs changedTypeDefs) throws AtlasBaseException {
         LOG.debug("Processing changed typedefs {}", changedTypeDefs);
 
-        AtlasGraphManagement management       = null;
-        boolean              isRollbackNeeded = true;
-
-        try {
-            management = provider.get().getManagementSystem();
-
+        try (AtlasGraphManagement management = provider.get().getManagementSystem()) {
             // Update index for newly created types
             if (CollectionUtils.isNotEmpty(changedTypeDefs.getCreatedTypeDefs())) {
                 for (AtlasBaseTypeDef typeDef : changedTypeDefs.getCreatedTypeDefs()) {
@@ -289,22 +284,11 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             createEdgeLabels(management, changedTypeDefs.getCreatedTypeDefs());
             createEdgeLabels(management, changedTypeDefs.getUpdatedTypeDefs());
 
-            isRollbackNeeded = false;
-
-            //Commit indexes
-            commit(management);
-        } catch (RepositoryException | IndexException e) {
+            management.setIsSuccess(true);
+        } catch (Exception e) {
             LOG.error("Failed to update indexes for changed typedefs", e);
-
-            isRollbackNeeded = false;
-
-            attemptRollback(changedTypeDefs, management);
         } finally {
-            if (isRollbackNeeded) {
-                LOG.warn("onChange({}): was not committed. Rolling back...", changedTypeDefs);
-
-                attemptRollback(changedTypeDefs, management);
-            }
+            recomputeIndexedKeys = true;
         }
 
         notifyChangeListeners(changedTypeDefs);
@@ -319,33 +303,26 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
         typeDefs.addAll(typeRegistry.getAllEntityDefs());
         typeDefs.addAll(typeRegistry.getAllBusinessMetadataDefs());
 
-        ChangedTypeDefs      changedTypeDefs = new ChangedTypeDefs(null, new ArrayList<>(typeDefs), null);
-        AtlasGraphManagement management      = null;
+        ChangedTypeDefs changedTypeDefs = new ChangedTypeDefs(null, new ArrayList<>(typeDefs), null);
 
-        try {
-            management = provider.get().getManagementSystem();
-
+        try (AtlasGraphManagement management = provider.get().getManagementSystem()) {
             //resolve index fields names
             resolveIndexFieldNames(management, changedTypeDefs);
 
             //Commit indexes
-            commit(management);
+            management.setIsSuccess(true);
 
             notifyInitializationCompletion(changedTypeDefs);
-        } catch (RepositoryException | IndexException e) {
+        } catch (Exception e) {
             LOG.error("Failed to update indexes for changed typedefs", e);
-
-            attemptRollback(changedTypeDefs, management);
+        } finally {
+            recomputeIndexedKeys = true;
         }
     }
 
     public Set<String> getVertexIndexKeys() {
         if (recomputeIndexedKeys) {
-            AtlasGraphManagement management = null;
-
-            try {
-                management = provider.get().getManagementSystem();
-
+            try (AtlasGraphManagement management = provider.get().getManagementSystem()) {
                 if (management != null) {
                     AtlasGraphIndex vertexIndex = management.getGraphIndex(VERTEX_INDEX);
 
@@ -361,18 +338,10 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
                         recomputeIndexedKeys = false;
                     }
 
-                    management.commit();
+                    management.setIsSuccess(true);
                 }
             } catch (Exception excp) {
                 LOG.error("getVertexIndexKeys(): failed to get indexedKeys from graph", excp);
-
-                if (management != null) {
-                    try {
-                        management.rollback();
-                    } catch (Exception e) {
-                        LOG.error("getVertexIndexKeys(): rollback failed", e);
-                    }
-                }
             }
         }
 
@@ -381,11 +350,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
 
     public Set<String> getEdgeIndexKeys() {
         if (recomputeEdgeIndexedKeys) {
-            AtlasGraphManagement management = null;
-
-            try {
-                management = provider.get().getManagementSystem();
-
+            try (AtlasGraphManagement management = provider.get().getManagementSystem()) {
                 if (management != null) {
                     AtlasGraphIndex edgeIndex = management.getGraphIndex(EDGE_INDEX);
 
@@ -401,18 +366,10 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
                         recomputeEdgeIndexedKeys = false;
                     }
 
-                    management.commit();
+                    management.setIsSuccess(true);
                 }
             } catch (Exception excp) {
                 LOG.error("getEdgeIndexKeys(): failed to get indexedKeys from graph", excp);
-
-                if (management != null) {
-                    try {
-                        management.rollback();
-                    } catch (Exception e) {
-                        LOG.error("getEdgeIndexKeys(): rollback failed", e);
-                    }
-                }
             }
         }
 
@@ -494,6 +451,8 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
                     createVertexCompositeIndexWithTypeName(management, propertyClass, propertyKey, uniqueKind == UniqueKind.PER_TYPE_UNIQUE);
                     createVertexCompositeIndexWithSuperTypeName(management, propertyClass, propertyKey);
                 }
+
+                recomputeIndexedKeys = true;
             } else {
                 LOG.warn("Index not created for {}: propertyKey is null", propertyName);
             }
@@ -528,30 +487,6 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
         }
     }
 
-    public void commit(AtlasGraphManagement management) throws IndexException {
-        try {
-            management.commit();
-
-            recomputeIndexedKeys = true;
-        } catch (Exception e) {
-            LOG.error("Index commit failed", e);
-
-            throw new IndexException("Index commit failed ", e);
-        }
-    }
-
-    public void rollback(AtlasGraphManagement management) throws IndexException {
-        try {
-            management.rollback();
-
-            recomputeIndexedKeys = true;
-        } catch (Exception e) {
-            LOG.error("Index rollback failed ", e);
-
-            throw new IndexException("Index rollback failed ", e);
-        }
-    }
-
     /**
      * Initializes the indices for the graph - create indices for Global AtlasVertex Keys
      */
@@ -563,9 +498,7 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
      * Initializes the indices for the graph - create indices for Global AtlasVertex and AtlasEdge Keys
      */
     private void initialize(AtlasGraph graph) throws RepositoryException, IndexException {
-        AtlasGraphManagement management = graph.getManagementSystem();
-
-        try {
+        try (AtlasGraphManagement management = graph.getManagementSystem()) {
             LOG.info("Creating indexes for graph.");
 
             if (management.getGraphIndex(VERTEX_INDEX) == null) {
@@ -670,14 +603,15 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
             createPropertyKey(management, RELATIONSHIPTYPE_LABEL_KEY, String.class, SINGLE);
             createPropertyKey(management, RELATIONSHIPTYPE_TAG_PROPAGATION_KEY, String.class, SINGLE);
 
-            commit(management);
+            management.setIsSuccess(true);
 
             LOG.info("Index creation for global keys complete.");
         } catch (Throwable t) {
             LOG.error("GraphBackedSearchIndexer.initialize() failed", t);
 
-            rollback(management);
             throw new RepositoryException(t);
+        } finally {
+            recomputeIndexedKeys = true;
         }
     }
 
@@ -1091,18 +1025,6 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
 
     private boolean isIndexApplicable(Class<?> propertyClass, AtlasCardinality cardinality) {
         return !(INDEX_EXCLUSION_CLASSES.contains(propertyClass) || cardinality.isMany());
-    }
-
-    private void attemptRollback(ChangedTypeDefs changedTypeDefs, AtlasGraphManagement management) throws AtlasBaseException {
-        if (null != management) {
-            try {
-                rollback(management);
-            } catch (IndexException e) {
-                LOG.error("Index rollback has failed", e);
-
-                throw new AtlasBaseException(AtlasErrorCode.INDEX_ROLLBACK_FAILED, e, changedTypeDefs.toString());
-            }
-        }
     }
 
     private void updateIndexForTypeDef(AtlasGraphManagement management, AtlasBaseTypeDef typeDef) {

--- a/repository/src/main/java/org/apache/atlas/repository/patches/IndexConsistencyPatch.java
+++ b/repository/src/main/java/org/apache/atlas/repository/patches/IndexConsistencyPatch.java
@@ -20,6 +20,7 @@ package org.apache.atlas.repository.patches;
 import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasGraphManagement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,10 +50,15 @@ public class IndexConsistencyPatch extends AtlasPatchHandler {
 
         AtlasGraph graph = context.getGraph();
 
-        try {
+        try (AtlasGraphManagement management = graph.getManagementSystem()) {
             LOG.info("IndexConsistencyPatch: Starting...");
 
-            graph.getManagementSystem().updateUniqueIndexesForConsistencyLock();
+            management.updateUniqueIndexesForConsistencyLock();
+            management.setIsSuccess(true);
+        } catch (Exception excp) {
+            LOG.warn("IndexConsistencyPatch: failed", excp);
+
+            throw (excp instanceof AtlasBaseException) ? (AtlasBaseException) excp : new AtlasBaseException("IndexConsistencyPatch failed", excp);
         } finally {
             LOG.info("IndexConsistencyPatch: Done!");
         }

--- a/repository/src/main/java/org/apache/atlas/repository/patches/ReIndexPatch.java
+++ b/repository/src/main/java/org/apache/atlas/repository/patches/ReIndexPatch.java
@@ -26,6 +26,7 @@ import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.graphdb.AtlasEdge;
 import org.apache.atlas.repository.graphdb.AtlasElement;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
+import org.apache.atlas.repository.graphdb.AtlasGraphManagement;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -188,8 +189,10 @@ public class ReIndexPatch extends AtlasPatchHandler {
 
         private void attemptCommit() {
             for (String indexName : indexNames) {
-                try {
-                    this.graph.getManagementSystem().reindex(indexName, list);
+                try (AtlasGraphManagement management = this.graph.getManagementSystem()) {
+                    management.reindex(indexName, list);
+
+                    management.setIsSuccess(true);
                 } catch (IllegalStateException e) {
                     LOG.error("IllegalStateException: Exception", e);
 

--- a/repository/src/main/java/org/apache/atlas/repository/patches/UniqueAttributePatch.java
+++ b/repository/src/main/java/org/apache/atlas/repository/patches/UniqueAttributePatch.java
@@ -134,9 +134,7 @@ public class UniqueAttributePatch extends AtlasPatchHandler {
         }
 
         private void createIndexForUniqueAttributes(String typeName, Collection<AtlasAttribute> attributes) {
-            try {
-                AtlasGraphManagement management = getGraph().getManagementSystem();
-
+            try (AtlasGraphManagement management = getGraph().getManagementSystem()) {
                 for (AtlasAttribute attribute : attributes) {
                     String uniquePropertyName = attribute.getVertexUniquePropertyName();
 
@@ -160,12 +158,11 @@ public class UniqueAttributePatch extends AtlasPatchHandler {
                             AtlasAttributeDef.IndexType.STRING.equals(attribute.getIndexType()));
                 }
 
-                getIndexer().commit(management);
-                getGraph().commit();
-
                 LOG.info("Unique attributes: type: {}: Registered!", typeName);
-            } catch (IndexException e) {
+            } catch (Exception e) {
                 LOG.error("Error creating index: type: {}", typeName, e);
+            } finally {
+                getGraph().commit();
             }
         }
 

--- a/repository/src/main/java/org/apache/atlas/repository/patches/UpdateCompositeIndexStatusPatch.java
+++ b/repository/src/main/java/org/apache/atlas/repository/patches/UpdateCompositeIndexStatusPatch.java
@@ -48,25 +48,18 @@ public class UpdateCompositeIndexStatusPatch extends AtlasPatchHandler {
             return;
         }
 
-        AtlasGraphManagement management       = context.getGraph().getManagementSystem();
-        boolean              isRollbackNeeded = true;
-
-        try {
+        try (AtlasGraphManagement management = context.getGraph().getManagementSystem()) {
             LOG.info("UpdateCompositeIndexStatusPatch: Starting...");
 
             management.updateSchemaStatus();
 
-            isRollbackNeeded = false;
-
-            management.commit();
+            management.setIsSuccess(true);
 
             LOG.info("UpdateCompositeIndexStatusPatch: Done!");
-        } finally {
-            if (isRollbackNeeded) {
-                LOG.warn("UpdateCompositeIndexStatusPatch: was not committed. Rolling back...");
+        } catch (Exception excp) {
+            LOG.warn("UpdateCompositeIndexStatusPatch: failed", excp);
 
-                management.rollback();
-            }
+            throw (excp instanceof AtlasBaseException) ? (AtlasBaseException) excp : new AtlasBaseException(excp);
         }
 
         setStatus(UNKNOWN);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEnumDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEnumDefStoreV2.java
@@ -25,7 +25,6 @@ import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.typedef.AtlasEnumDef;
 import org.apache.atlas.model.typedef.AtlasEnumDef.AtlasEnumElementDef;
 import org.apache.atlas.repository.Constants;
-import org.apache.atlas.repository.IndexException;
 import org.apache.atlas.repository.graphdb.AtlasCardinality;
 import org.apache.atlas.repository.graphdb.AtlasGraphManagement;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
@@ -308,12 +307,7 @@ class AtlasEnumDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasEnumDef> {
     }
 
     private void createPropertyKeys(AtlasEnumDef enumDef) throws AtlasBaseException {
-        AtlasGraphManagement management = typeDefStore.atlasGraph.getManagementSystem();
-        boolean              isSuccess  = false;
-        Exception            err        = null;
-
-        try {
-
+        try (AtlasGraphManagement management = typeDefStore.atlasGraph.getManagementSystem()) {
             // create property keys first
             for (AtlasEnumElementDef element : enumDef.getElementDefs()) {
                 // Validate the enum element
@@ -332,29 +326,11 @@ class AtlasEnumDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasEnumDef> {
             createPropertyKey(encodePropertyKey(typeDefKey), Object.class, AtlasCardinality.SINGLE, management);
             createPropertyKey(encodePropertyKey(defaultValueKey), String.class, AtlasCardinality.SINGLE, management);
 
-            isSuccess = true;
+            management.setIsSuccess(true);
         } catch (Exception e) {
-            err = e;
-        } finally {
-            try {
-                if (isSuccess) {
-                    management.commit();
-                } else {
-                    management.rollback();
-                }
-            } catch (Exception e) {
-                if (err == null) {
-                    err = new AtlasBaseException(new IndexException("Index " + (isSuccess ? "commit" : "rollback") + " failed", e));
-                } else {
-                    LOG.error("Index {} failed", (isSuccess ? "commit" : "rollback"), e);
-                }
-            }
-        }
+            LOG.error("PropertyKey creation failed for enum {}", enumDef.getName(), e);
 
-        if (err != null) {
-            LOG.error("PropertyKey creation failed for enum {}", enumDef.getName(), err);
-
-            throw (err instanceof AtlasBaseException) ? (AtlasBaseException) err : new AtlasBaseException(err);
+            throw (e instanceof AtlasBaseException) ? (AtlasBaseException) e : new AtlasBaseException(e);
         }
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a continuatiion of previous patch to address evicted/stale transaction warnings in log. AtlasGraphManagement is now AutoCloseable, which will ensure that commit or rollback is called on all instances, which will avoid transaction leaks and hence evicted/stale transaction warning messages.


## How was this patch tested?
Verified that Atlas startsup successfully, with no errors in loading initial typedef models.