### PR TITLE
ATLAS-5098: option to customize name of the configuration filename

### DIFF
--- a/intg/src/main/java/org/apache/atlas/ApplicationProperties.java
+++ b/intg/src/main/java/org/apache/atlas/ApplicationProperties.java
@@ -44,6 +44,7 @@ public final class ApplicationProperties extends PropertiesConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(ApplicationProperties.class);
 
     public static final String       ATLAS_CONFIGURATION_DIRECTORY_PROPERTY = "atlas.conf";
+    public static final String       ATLAS_PROPERTIES_FILENAME_SYSTEM_CONF  = "atlas.properties";
     public static final String       APPLICATION_PROPERTIES           = "atlas-application.properties";
     public static final String       GRAPHDB_BACKEND_CONF             = "atlas.graphdb.backend";
     public static final String       STORAGE_BACKEND_CONF             = "atlas.graph.storage.backend";
@@ -104,7 +105,8 @@ public final class ApplicationProperties extends PropertiesConfiguration {
                 me = instance;
 
                 if (me == null) {
-                    set(get(APPLICATION_PROPERTIES));
+                    String propertyFilename = System.getProperty(ATLAS_PROPERTIES_FILENAME_SYSTEM_CONF, APPLICATION_PROPERTIES);
+                    set(get(propertyFilename));
 
                     me = instance;
                 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Issue: 
Currently Atlas only supports '`atlas-application.properties`' fileName to be loaded as 
PropertiesConfiguration, which makes difficult for utilities to load the properties having under different property fileName.

Solution:
Add a system property named '`atlas.properties`' which maps to the property fileName to be used.

## How was this patch tested?

manually