### PR TITLE
ATLAS-5101: Enable concurrent import requests and retry locking

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraph.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraph.java
@@ -446,7 +446,6 @@ public class AtlasJanusGraph implements AtlasGraph<AtlasJanusVertex, AtlasJanusE
         return uniqueKeyHandler;
     }
 
-
     public Iterable<AtlasVertex<AtlasJanusVertex, AtlasJanusEdge>> wrapVertices(Iterable<? extends Vertex> it) {
         return Iterables.transform(it, (Function<Vertex, AtlasVertex<AtlasJanusVertex, AtlasJanusEdge>>) input -> GraphDbObjectFactory.createVertex(AtlasJanusGraph.this, input));
     }

--- a/repository/src/main/java/org/apache/atlas/repository/impexp/ImportService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/impexp/ImportService.java
@@ -247,7 +247,7 @@ public class ImportService implements AsyncImporter {
 
     @Override
     public void onImportTypeDef(AtlasTypesDef typesDef, String importId) throws AtlasBaseException {
-        LOG.info("==> onImportTypeDef(typesDef={}, importId={})", typesDef, importId);
+        LOG.info("==> onImportTypeDef(importId={})", importId);
 
         AtlasAsyncImportRequest importRequest = asyncImportService.fetchImportRequestByImportId(importId);
 
@@ -272,13 +272,13 @@ public class ImportService implements AsyncImporter {
 
             asyncImportService.updateImportRequest(importRequest);
 
-            LOG.info("<== onImportTypeDef(typesDef={}, importResult={})", typesDef, importRequest.getImportResult());
+            LOG.info("<== onImportTypeDef()");
         }
     }
 
     @Override
     public Boolean onImportEntity(AtlasEntityWithExtInfo entityWithExtInfo, String importId, int position) throws AtlasBaseException {
-        LOG.info("==> onImportEntity(entityWithExtInfo={}, importId={}, position={})", entityWithExtInfo, importId, position);
+        LOG.info("==> onImportEntity(importId={}, position={})", importId, position);
 
         AtlasAsyncImportRequest importRequest = asyncImportService.fetchImportRequestByImportId(importId);
 
@@ -309,6 +309,7 @@ public class ImportService implements AsyncImporter {
 
             importRequest.getImportDetails().setImportProgress(resp.right);
         } catch (AtlasBaseException abe) {
+            LOG.warn("Failed to import entity: {} at position: {} for import: {}", entityWithExtInfo.getEntity().getGuid(), position, importId, abe);
             failedEntitiesCounter += 1;
 
             importRequest.getImportDetails().setFailedEntitiesCount(failedEntitiesCounter);
@@ -324,7 +325,7 @@ public class ImportService implements AsyncImporter {
 
             asyncImportService.updateImportRequest(importRequest);
 
-            LOG.info("<== onImportEntity(entityWithExtInfo={}, importId={}, position={})", entityWithExtInfo, importId, position);
+            LOG.info("<== onImportEntity(importId={}, position={})", importId, position);
         }
 
         if (importRequest.getImportDetails().getPublishedEntityCount() <=

--- a/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
@@ -692,19 +692,9 @@ public class AdminResource {
         AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_IMPORT), "asyncImportData");
 
         AtlasAsyncImportRequest asyncImportRequest;
-        boolean                 releaseExportImportLockOnCompletion = false;
-
         try {
-            AtlasImportRequest request                 = AtlasType.fromJson(jsonData, AtlasImportRequest.class);
-            boolean            preventMultipleRequests = request != null && request.getOptions() != null && !request.getOptions().containsKey(AtlasImportRequest.OPTION_KEY_REPLICATED_FROM);
-
-            if (preventMultipleRequests) {
-                acquireExportImportLock("import");
-
-                releaseExportImportLockOnCompletion = true;
-            }
-
-            asyncImportRequest = importService.run(request, inputStream, Servlets.getUserName(httpServletRequest), Servlets.getHostName(httpServletRequest), AtlasAuthorizationUtils.getRequestIpAddress(httpServletRequest));
+            AtlasImportRequest request  = AtlasType.fromJson(jsonData, AtlasImportRequest.class);
+            asyncImportRequest          = importService.run(request, inputStream, Servlets.getUserName(httpServletRequest), Servlets.getHostName(httpServletRequest), AtlasAuthorizationUtils.getRequestIpAddress(httpServletRequest));
         } catch (AtlasBaseException excp) {
             if (excp.getAtlasErrorCode().equals(AtlasErrorCode.IMPORT_ATTEMPTING_EMPTY_ZIP)) {
                 LOG.info(excp.getMessage());
@@ -720,10 +710,6 @@ public class AdminResource {
 
             throw new AtlasBaseException(excp);
         } finally {
-            if (releaseExportImportLockOnCompletion) {
-                releaseExportImportLock();
-            }
-
             LOG.debug("<== AdminResource.importAsync(binary)");
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The changes are to allow multiple / concurrent requests to Async Import. Also handle locking contentions in JG with retries. 
Also added necessary unit tests to cover the scenarios possible and fix the for but: [ATLAS-5101](https://issues.apache.org/jira/browse/ATLAS-5101)


## How was this patch tested?

A cluster was manually patched with the changes and testing was done manually. 