### PR TITLE
ATLAS-5112: [REACT UI] Double clicking on Basic Search under Custom Filters with no saved filters throws errors.

### DIFF
--- a/dashboard/src/views/SideBar/SideBarTree/CustomFiltersTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/CustomFiltersTree.tsx
@@ -119,10 +119,10 @@ const CustomFiltersTree = ({ sideBarOpen, searchTerm }: Props) => {
       emptySearchTypes.forEach((typeObj) => {
         if (!existingSearchTypes.includes(typeObj.searchType)) {
           savedSearchTypeArr.push({
-            name: typeObj.searchType,
+            name: typeObj.name,
             children: [],
             types: "parent",
-            parent: typeObj.searchType
+            parent: typeObj.searchType,
           });
         }
       });

--- a/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
@@ -557,6 +557,9 @@ const BarTreeView: FC<{
   };
 
   const shouldSetSearchParams = (node: TreeNode, treeName: string) => {
+    if (treeName === "CustomFilters") {
+      return node.types === "child";
+    }
     return (
       node.children === undefined ||
       isEmpty(node.children) ||


### PR DESCRIPTION

## What changes were proposed in this pull request?

Double-clicking on Basic Search, Advanced Search, or Relationship Search under Custom Filters will no longer trigger an API call, preventing the error from appearing. Additionally, the issue where the text changed after saving a search has also been fixed.


## How was this patch tested?

Manually tested

<img width="1843" height="1044" alt="Screenshot from 2025-09-22 13-05-52" src="https://github.com/user-attachments/assets/24978b8b-08df-47f8-96b5-cf91d1e10813" />
