### PR TITLE
ATLAS-5115: [REACT UI] When assigning classification, Add button can be enabled without selecting classification.

### DIFF
--- a/dashboard/src/components/DialogShowMoreLess.tsx
+++ b/dashboard/src/components/DialogShowMoreLess.tsx
@@ -540,6 +540,7 @@ const DialogShowMoreLess = ({
           button2Label="Remove"
           button2Handler={handleRemove}
           disableButton2={removeLoader}
+          isDirty={true}
         >
           {relatedTerm ? (
             <Typography fontSize={15}>

--- a/dashboard/src/components/Modal.tsx
+++ b/dashboard/src/components/Modal.tsx
@@ -171,12 +171,12 @@ export const CustomModal: React.FC<CustomModalProps> = ({
                     })
                   }}
                   startIcon={
-                    disableButton2 && (
+                    disableButton2 && isDirty ? (
                       <CircularProgress
                         sx={{ color: "white", fontWeight: "600" }}
                         size="14px"
                       />
-                    )
+                    ) : undefined
                   }
                   onClick={(e: Event) => {
                     e.stopPropagation();

--- a/dashboard/src/views/Classification/AddTag.tsx
+++ b/dashboard/src/views/Classification/AddTag.tsx
@@ -353,8 +353,16 @@ const AddTag = (props: {
       button2Label={`${isAdd ? "Add" : "Update"}`}
       maxWidth="md"
       button2Handler={handleSubmit(onSubmit)}
-      disableButton2={isEmpty(classificationData) ? true : isSubmitting}
-      isDirty={isEmpty(classificationData) ? true : isDirty}
+      disableButton2={
+        isEmpty(classificationData) ? true : isSubmitting
+      }
+      isDirty={
+        isEmpty(classificationData)
+          ? false
+          : isAdd
+          ? !isEmpty(tagName)
+          : true
+      }
     >
       <form onSubmit={handleSubmit(onSubmit)}>
         <Stack>


### PR DESCRIPTION

## What changes were proposed in this pull request?

While assigning a classification, the "Add" button will be enabled only when a classification is selected. Upon clicking "Add," a loader will be displayed on the button. The same loader functionality will also be shown when removing a classification from an entity.


## How was this patch tested?
Manuallt tested
<img width="1843" height="1044" alt="Screenshot from 2025-09-22 14-01-45" src="https://github.com/user-attachments/assets/a7bdb72e-e901-40fe-9dd2-ac3e30184dc1" />
<img width="1843" height="1044" alt="Screenshot from 2025-09-22 14-02-14" src="https://github.com/user-attachments/assets/37cc5a51-860a-4626-9cd3-322f6a08b4d2" />
<img width="1843" height="1044" alt="Screenshot from 2025-09-22 14-02-43" src="https://github.com/user-attachments/assets/2fef6596-070a-40fc-ae34-f5df776eecff" />
