### PR TITLE
ATLAS-5121: [REACT UI] The glossary dropdown menu does not disappear after clicking any of the options in the dropdown menu

### DIFF
--- a/dashboard/src/components/TreeNodeIcons.tsx
+++ b/dashboard/src/components/TreeNodeIcons.tsx
@@ -246,6 +246,7 @@ const TreeNodeIcons = (props: {
               ) {
                 setCategoryModal(true);
               }
+              handleCloseNode();
             }}
             className="sidebar-menu-item"
             data-cy="createClassification"
@@ -288,6 +289,7 @@ const TreeNodeIcons = (props: {
               }
               if (treeName == "Glossary" && node.types == "parent") {
                 setGlossaryModal(true);
+                setExpandNode(null);
               }
               if (treeName == "Glossary" && node.types == "child") {
                 const searchParams = new URLSearchParams();
@@ -340,6 +342,7 @@ const TreeNodeIcons = (props: {
               if (treeName == "Glossary") {
                 setDeleteGlossaryModal(true);
               }
+              handleCloseNode();
             }}
             data-cy="createClassification"
             className="sidebar-menu-item"
@@ -407,6 +410,7 @@ const TreeNodeIcons = (props: {
             <MenuItem
               onClick={(_e) => {
                 setCategoryModal(true);
+                handleCloseNode();
               }}
               data-cy="createClassification"
               className="sidebar-menu-item"
@@ -427,6 +431,7 @@ const TreeNodeIcons = (props: {
             onClick={(e) => {
               e.stopPropagation();
               setRenameModal(true);
+              handleCloseNode();
             }}
             data-cy="createClassification"
             className="sidebar-menu-item"
@@ -443,6 +448,7 @@ const TreeNodeIcons = (props: {
             onClick={(e) => {
               e.stopPropagation();
               setDeleteModal(true);
+              handleCloseNode();
             }}
             data-cy="downloadBusinessMetadata"
             className="sidebar-menu-item"

--- a/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
@@ -1024,6 +1024,7 @@ const BarTreeView: FC<{
                         if (setisGroupView) {
                           setisGroupView(!isGroupView);
                         }
+                        handleClose();
                       }}
                       data-cy="groupOrFlatTreeView"
                       className="sidebar-menu-item"
@@ -1059,6 +1060,7 @@ const BarTreeView: FC<{
                         } else if (treeName == "Glossary") {
                           setGlossaryModal(true);
                         }
+                        handleClose();
                       }}
                       data-cy="createClassification"
                       className="sidebar-menu-item"
@@ -1082,6 +1084,7 @@ const BarTreeView: FC<{
                       onClick={(e) => {
                         e.stopPropagation();
                         downloadFile();
+                        handleClose();
                       }}
                       data-cy="downloadBusinessMetadata"
                       disabled={
@@ -1107,6 +1110,7 @@ const BarTreeView: FC<{
                       onClick={(e) => {
                         e.stopPropagation();
                         handleOpenModal();
+                        handleClose();
                       }}
                       data-cy="importBusinessMetadata"
                       disabled={


### PR DESCRIPTION
## What changes were proposed in this pull request?

The dropdown menu now closes automatically after selecting any option, and this behavior has been fixed for all sidebar trees.

## How was this patch tested?
Manually tested

<img width="1843" height="1044" alt="Screenshot from 2025-09-22 14-58-21" src="https://github.com/user-attachments/assets/fbff8dcd-b077-4ef3-b334-cad810053179" />
<img width="1843" height="1044" alt="Screenshot from 2025-09-22 14-58-05" src="https://github.com/user-attachments/assets/ec5f817d-eec0-4c8f-b8d8-13db10d62f8a" />
<img width="1843" height="1044" alt="Screenshot from 2025-09-22 14-57-55" src="https://github.com/user-attachments/assets/c53f4e53-e27a-4cee-9ad9-3e0f36798d4a" />
