### PR TITLE
ATLAS-5123: ATLAS-5142: When creating a business metadata attribute, the attribute is always an array even if 'Multivalues' checkbox was not selected. . Custom Filters - Basic and Advanced search displays ellipsis menu incorrectly.

### DIFF
--- a/dashboard/src/components/TreeNodeIcons.tsx
+++ b/dashboard/src/components/TreeNodeIcons.tsx
@@ -164,7 +164,8 @@ const TreeNodeIcons = (props: {
   };
   return (
     <>
-      {(node.types == "child" || node.types == undefined) &&
+      {((node.types == "child") ||
+        (node.types == undefined && treeName != "CustomFilters")) &&
         ((treeName == "Classifications" && node.types == "child"
           ? !isEmpty(node.children)
           : isEmpty(node.children)) ||
@@ -192,7 +193,8 @@ const TreeNodeIcons = (props: {
         (node.types == "parent" && isEmpty(node.children)) ||
         (node.types == "child" &&
           !isEmpty(node.children) &&
-          node.cGuid != undefined)) && (
+          node.cGuid != undefined)) &&
+        !(treeName == "CustomFilters" && node.types == "parent") && (
         <IconButton
           onClick={(e) => {
             handleClickNodeMenu(e);

--- a/dashboard/src/index.scss
+++ b/dashboard/src/index.scss
@@ -33,8 +33,8 @@
 @use "@styles/stats.scss" as *;
 @use "@styles/filters.scss" as *;
 @use "@styles/errorPage.scss" as *;
-@use "@styles/errorPage.scss" as *;
 @use "@styles/customdatepPicker.scss" as *;
+@use "@styles/administration.scss" as *;
 
 @font-face {
   font-family: "Source Sans 3";

--- a/dashboard/src/styles/administration.scss
+++ b/dashboard/src/styles/administration.scss
@@ -32,11 +32,27 @@
   padding-left: 20px;
 }
 
-.audit-results-lsit-item {
-  display: list-item;
-  padding-left: 0;
-}
-
 .audit-results-entityid {
   display: block;
+}
+
+.enum-value-selector {
+  display: inline-grid !important;
+  grid-template-columns: 1fr !important;
+}
+
+.bmattributes-key .MuiAutocomplete-inputRoot,
+.enum-value-selector .MuiAutocomplete-inputRoot {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.bmattributes-key .MuiAutocomplete-listbox,
+.enum-value-selector .MuiAutocomplete-listbox {
+  max-height: 280px;
+}
+
+.bm-empty-field {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
 }

--- a/dashboard/src/utils/CommonViewFunction.ts
+++ b/dashboard/src/utils/CommonViewFunction.ts
@@ -279,9 +279,7 @@ export const generateObjectForSaveSearchApi = (options) => {
           if (val !== undefined && val !== null) {
             if (k === "attributes") {
               val = val.split(",");
-            } else if (
-              ["tagFilters", "entityFilters", "relationshipFilters"].includes(k)
-            ) {
+            } else if (["tagFilters", "entityFilters", "relationshipFilters"].includes(k)) {
               val = attributeFilter.generateAPIObj(val);
             } else if (["includeDE", "excludeST", "excludeSC"].includes(k)) {
               val = val ? false : true;
@@ -305,3 +303,25 @@ export const generateObjectForSaveSearchApi = (options) => {
     return obj;
   }
 };
+
+export const getTypeName = (
+  multiValueSelect: boolean,
+  enumType: string,
+  rest: any
+) => {
+  if (multiValueSelect) {
+    switch (rest.typeName) {
+      case 'enumeration':
+        return `array<${enumType}>`
+      default:
+        return `array<${rest.typeName}>`
+    }
+  } else {
+    switch (rest.typeName) {
+      case 'enumeration':
+        return enumType
+      default:
+        return rest.typeName
+    }
+  }
+}

--- a/dashboard/src/views/BusinessMetadata/BusinessMetadataAtrributeForm.tsx
+++ b/dashboard/src/views/BusinessMetadata/BusinessMetadataAtrributeForm.tsx
@@ -154,13 +154,23 @@ const BusinessMetadataAttributeForm = ({
         await updateEnum(data);
         toast.dismiss(toastId.current);
         toastId.current = toast.success(
-          `Enumeration ${enumType} updated
-                 successfully`
+          `Enumeration ${enumType} updated successfully`
         );
       } else {
         toast.dismiss(toastId.current);
         toastId.current = toast.success("No updated values");
       }
+      fields?.forEach((fieldItem: any, idx: number) => {
+        const fieldEnumType =
+          attributeDefsWatch &&
+          attributeDefsWatch(`attributeDefs.${idx}.enumType`);
+        if (fieldEnumType === enumType) {
+          attributeDefsSetValue(
+            `attributeDefs.${idx}.enumValues`,
+            elementValues
+          );
+        }
+      });
       handleCloseEnumModal();
       reset({ enumType: "", enumValues: [] });
       dispatchState(fetchEnumData());
@@ -170,6 +180,7 @@ const BusinessMetadataAttributeForm = ({
     }
   };
   const handleCloseEnumModal = () => {
+    reset({ enumType: "", enumValues: [] });
     setEnumModal(false);
   };
 
@@ -258,7 +269,13 @@ const BusinessMetadataAttributeForm = ({
               data-cy={`attributeDefs.${index}.name`}
               key={`attributeDefs.${index}.name`}
               defaultValue={field?.name}
-              render={({ field: { value, onChange } }) => (
+              rules={{
+                required: true
+              }}
+              render={({
+                field: { value, onChange },
+                fieldState: { error }
+              }) => (
                 <Grid
                   container
                   columnSpacing={{ xs: 1, sm: 2, md: 2 }}
@@ -281,6 +298,7 @@ const BusinessMetadataAttributeForm = ({
                       }}
                       onChange={onChange}
                       margin="none"
+                      error={!!error}
                       fullWidth
                       variant="outlined"
                       size="small"
@@ -297,6 +315,9 @@ const BusinessMetadataAttributeForm = ({
               data-cy={`attributeDefs.${index}.typeName`}
               key={`attributeDefs.${index}.typeName`}
               defaultValue={field?.typeName}
+              rules={{
+                required: true
+              }}
               render={({ field: { value, onChange } }) => (
                 <>
                   <Grid
@@ -547,7 +568,13 @@ const BusinessMetadataAttributeForm = ({
                   data-cy={`attributeDefs.${index}.enumType`}
                   key={`attributeDefs.${index}.enumType`}
                   defaultValue={field?.enumType}
-                  render={({ field: { value, onChange } }) => (
+                  rules={{
+                    required: true
+                  }}
+                  render={({
+                    field: { value, onChange },
+                    fieldState: { error }
+                  }) => (
                     <>
                       <Grid
                         container
@@ -571,7 +598,7 @@ const BusinessMetadataAttributeForm = ({
                               }}
                               size="small"
                               id="search-by-type"
-                              value={value || []}
+                              value={value || null}
                               clearIcon={null}
                               onChange={(_event, newValue) => {
                                 onChange(newValue);
@@ -596,9 +623,6 @@ const BusinessMetadataAttributeForm = ({
                                 }
                               }}
                               filterSelectedOptions
-                              isOptionEqualToValue={(option, value) =>
-                                option === value
-                              }
                               options={
                                 !isEmpty(enumTypes)
                                   ? enumTypes.map((option: any) => option)
@@ -608,11 +632,11 @@ const BusinessMetadataAttributeForm = ({
                               renderInput={(params) => (
                                 <TextField
                                   {...params}
+                                  error={!!error}
                                   fullWidth
                                   disabled={
                                     isEmpty(editbmAttribute) ? false : true
                                   }
-                                  // label="Select type"
                                   InputLabelProps={{
                                     style: {
                                       top: "unset",
@@ -663,9 +687,6 @@ const BusinessMetadataAttributeForm = ({
                 data-cy={`attributeDefs.${index}.enumValues`}
                 key={`attributeDefs.${index}.enumValues` as const}
                 defaultValue={field?.enumValues}
-                rules={{
-                  required: true
-                }}
                 render={({ field }) => {
                   return (
                     <>
@@ -681,11 +702,15 @@ const BusinessMetadataAttributeForm = ({
                         <Grid item md={7}>
                           <Autocomplete
                             size="small"
+                            className="enum-value-selector"
                             readOnly
                             disableClearable={true}
                             multiple={true}
                             value={watched?.[index]?.enumValues || []}
                             getOptionLabel={(option) => option.value}
+                            isOptionEqualToValue={(option, value) =>
+                              option.value === value.value
+                            }
                             data-cy="enumValueSelector"
                             options={
                               !isEmpty(enumTypeOptions)

--- a/dashboard/src/views/BusinessMetadata/EnumCreateUpdate.tsx
+++ b/dashboard/src/views/BusinessMetadata/EnumCreateUpdate.tsx
@@ -131,7 +131,12 @@ const EnumCreateUpdate = ({
                           sx={{ flex: "1" }}
                           size="small"
                           value={value}
-                          onChange={(_event, newValue) => {
+                          onChange={(_event, newValue, reason) => {
+                            if (reason == "clear") {
+                              onChange("");
+                              setValue("enumValues", []);
+                              return;
+                            }
                             if (!isEmpty(newValue.label)) {
                               onChange(newValue.value);
                             } else {
@@ -170,6 +175,7 @@ const EnumCreateUpdate = ({
 
                             return filtered;
                           }}
+                          clearIcon={null}
                           filterSelectedOptions
                           onBlur={onBlur}
                           options={
@@ -261,7 +267,6 @@ const EnumCreateUpdate = ({
                               : []
                           }
                           onBlur={onBlur}
-                          className="advanced-search-autocomplete"
                           renderInput={(params) => (
                             <TextField
                               {...params}

--- a/dashboard/src/views/DetailPage/BusinessMetadataDetails/BusinessMetadataAtrribute.tsx
+++ b/dashboard/src/views/DetailPage/BusinessMetadataDetails/BusinessMetadataAtrribute.tsx
@@ -56,7 +56,8 @@ const BusinessMetadataAtrribute = ({ componentProps, row }: any) => {
             <span>N/A</span>
           ),
         header: "Type Name",
-        enableSorting: true
+        enableSorting: true,
+        width: "30%"
       },
       {
         accessorKey: "searchWeight",
@@ -176,7 +177,9 @@ const BusinessMetadataAtrribute = ({ componentProps, row }: any) => {
                     : "enumeration";
                 let selectedEnumObj = !isEmpty(enumDefs)
                   ? enumDefs.find((obj: { name: any }) => {
-                      return obj.name == typeName;
+                      return (
+                        obj.name == (str.indexOf("<") != -1 ? extracted : str)
+                      );
                     })
                   : {};
                 let selectedEnumValues = !isEmpty(selectedEnumObj)
@@ -208,7 +211,7 @@ const BusinessMetadataAtrribute = ({ componentProps, row }: any) => {
                         ? typeName
                         : "enumeration",
                     ...(currentTypeName == "enumeration" && {
-                      enumType: typeName
+                      enumType: str.indexOf("<") != -1 ? extracted : str
                     }),
                     ...(currentTypeName == "enumeration" && {
                       enumValues: enumTypeOptions

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/PropertiesTab/BMAttributes.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/PropertiesTab/BMAttributes.tsx
@@ -572,12 +572,20 @@ const BMAttributes = ({ loading, bmAttributes, entity }: any) => {
                       </CustomButton>
                     </LightTooltip>
                     {fields.map((field, index) => {
+                      const keySelected = !isEmpty(
+                        bmAttributesValues?.[index]?.key
+                      );
                       return (
                         <Stack
                           gap="0.5rem"
                           direction="row"
                           key={field?.id}
-                          alignItems="center"
+                          alignItems={keySelected ? "flex-start" : "center"}
+                          sx={{
+                            '& .MuiAutocomplete-root': {
+                              alignSelf: keySelected ? 'stretch' : 'center'
+                            }
+                          }}
                         >
                           <Controller
                             control={control}
@@ -596,7 +604,12 @@ const BMAttributes = ({ loading, bmAttributes, entity }: any) => {
                                     onChange={(_, selectedOption) => {
                                       onChange(selectedOption);
                                     }}
-                                    sx={{ flexBasis: "35%" }}
+                                    sx={{
+                                      flexBasis: "35%",
+                                      '& .MuiOutlinedInput-root': {
+                                        height: 36
+                                      }
+                                    }}
                                     getOptionLabel={(option) => option.label}
                                     groupBy={(option) => option.group}
                                     noOptionsText="No results found"
@@ -630,7 +643,11 @@ const BMAttributes = ({ loading, bmAttributes, entity }: any) => {
                               </>
                             )}
                           />
-                          <span style={{ margin: "12px 0" }}>:</span>
+                          <span
+                            style={{ margin: 0, alignSelf: "center" }}
+                          >
+                            :
+                          </span>
                           {isEmpty(bmAttributesValues?.[index]?.key) ? (
                             <Controller
                               control={control}
@@ -644,29 +661,30 @@ const BMAttributes = ({ loading, bmAttributes, entity }: any) => {
                                 fieldState: { error }
                               }) => (
                                 <>
-                                  <div style={{ flex: "1" }}>
+                                  <div
+                                    style={{
+                                      flex: "1",
+                                      display: "flex",
+                                      alignItems: "center"
+                                    }}
+                                  >
                                     <TextField
-                                      margin="normal"
+                                      margin="none"
                                       error={!!error}
-                                      className="form-textfield"
+                                      className="form-textfield bm-empty-field"
                                       onChange={onChange}
                                       value={value}
                                       variant="outlined"
                                       size="small"
                                       disabled
                                       sx={{
+                                        '& .MuiInputBase-root': {
+                                          height: 36
+                                        },
                                         "& .MuiInputBase-root.Mui-disabled": {
                                           backgroundColor: "#eee",
                                           cursor: "not-allowed"
-                                        },
-                                        "& .MuiOutlinedInput-root.Mui-error": {
-                                          "& fieldset": {
-                                            borderColor: "red"
-                                          }
-                                        },
-                                        marginTop: "8px !important",
-                                        marginBottom: "8px !important",
-                                        width: "100%"
+                                        }
                                       }}
                                       type={"string"}
                                     />

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/PropertiesTab/BMAttributesFields.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/PropertiesTab/BMAttributesFields.tsx
@@ -249,8 +249,10 @@ const BMAttributesFields = ({ obj, control, index }: any) => {
                   paddingTop: "4px",
                   paddingBottom: "4px",
                   paddingLeft: "6px",
-                  height: "34px",
-                  gap: "4px"
+                  gap: "4px",
+                  '& .MuiAutocomplete-inputRoot': {
+                    flexWrap: 'wrap'
+                  }
                 }}
                 filterOptions={(options, params) => {
                   const filtered = filter(options, params);

--- a/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
@@ -339,6 +339,10 @@ const BarTreeView: FC<{
     });
   }, [treeData, searchTerm]);
 
+  const displayTreeName = useMemo(() => {
+    return treeName === "CustomFilters" ? "Custom Filters" : treeName
+  }, [treeName]);
+
   const highlightText = useMemo(() => {
     return (text: string) => {
       if (!searchTerm) return text;
@@ -557,6 +561,9 @@ const BarTreeView: FC<{
   };
 
   const shouldSetSearchParams = (node: TreeNode, treeName: string) => {
+    if (treeName === "CustomFilters" && node.types === "parent") {
+      return false;
+    }
     return (
       node.children === undefined ||
       isEmpty(node.children) ||
@@ -906,7 +913,7 @@ const BarTreeView: FC<{
                 className="tree-item-parent-label"
               >
                 <Stack flexGrow={1}>
-                  <span>{treeName}</span>
+                  <span>{displayTreeName}</span>
                 </Stack>
                 <Stack direction="row" alignItems="center" gap="0.375rem">
                   <LightTooltip title="Refresh">


### PR DESCRIPTION
## What changes were proposed in this pull request?

1) When creating a business metadata attribute, the attribute is always an array even if the 'Multivalues' checkbox was not selected. This results in forcing the user to use API or a different UI to set simple attributes for business metadata.

2) When there are no saved custom filters, the Advanced Search and Basic Search sections show a functionally incorrect ellipsis menu.


## How was this patch tested?
Manually tested 

<img width="1840" height="1074" alt="Screenshot from 2025-09-24 14-12-07" src="https://github.com/user-attachments/assets/a64e215a-5c26-4f05-a41d-ad359f5b1abf" />
<img width="1840" height="1074" alt="Screenshot from 2025-09-24 14-11-38" src="https://github.com/user-attachments/assets/a2f6f73d-21f3-4c70-96c3-73ea24fd9c4d" />
<img width="1444" height="1074" alt="Screenshot from 2025-09-24 14-10-07" src="https://github.com/user-attachments/assets/516ce440-4f97-4527-b656-917a6cfe7328" />
