### PR TITLE
ATLAS-5132: [REACT UI] Unique Advanced/Search queries do not work as expected

### DIFF
--- a/dashboard/src/components/muiComponents.tsx
+++ b/dashboard/src/components/muiComponents.tsx
@@ -104,18 +104,20 @@ const CustomButton = ({
   let mergedStyle = { ...defaultStyles, ...customStyles };
 
   return (
-    <Button
-      variant={variant}
-      color={color}
-      sx={mergedStyle}
-      onClick={onClick}
-      size={size}
-      endIcon={endIcon}
-      startIcon={startIcon}
-      disabled={disabled}
-    >
-      {children}
-    </Button>
+    <Box component="span" sx={{ display: 'inline-flex' }}>
+      <Button
+        variant={variant}
+        color={color}
+        sx={mergedStyle}
+        onClick={onClick}
+        size={size}
+        endIcon={endIcon}
+        startIcon={startIcon}
+        disabled={disabled}
+      >
+        {children}
+      </Button>
+    </Box>
   );
 };
 

--- a/dashboard/src/views/SearchResult/SearchResult.tsx
+++ b/dashboard/src/views/SearchResult/SearchResult.tsx
@@ -207,8 +207,17 @@ const SearchResult = ({ classificationParams, glossaryTypeParams }: any) => {
       globalSearchParams.basicParams = params;
       globalSearchParams.dslParams = dslParams;
 
-      let searchTypeParams =
-        searchParams.get("searchType") == "dsl" ? dslParams : params;
+      
+      const qParam = searchParams.get("query");
+      if (qParam) {
+        try {
+          (globalSearchParams as any).basicParams.query = qParam;
+          (globalSearchParams as any).dslParams.query = qParam;
+        } catch (_e) {}
+      }
+
+      const isDslSearch = searchParams.get("searchType") == "dsl";
+      let searchTypeParams = isDslSearch ? dslParams : params;
       try {
         const searchResp = await getBasicSearchResult(
           {
@@ -221,21 +230,43 @@ const SearchResult = ({ classificationParams, glossaryTypeParams }: any) => {
           searchParams.get("searchType") || "basic"
         );
         const { data = {} } = searchResp || {};
-        const { approximateCount, entities } = data || {};
-        let totalCount = approximateCount;
-        let dataLength;
-        if (entities) {
-          dataLength = entities?.length;
-        } else {
-          dataLength = searchResp?.data?.length;
+
+        const hasEntities = Array.isArray((data as any)?.entities);
+        const hasDslAttributes =
+          Array.isArray((data as any)?.attributes) ||
+          Array.isArray((data as any)?.attributes?.name);
+        const hasDslValues =
+          Array.isArray((data as any)?.attributes?.values) ||
+          Array.isArray((data as any)?.values);
+
+        if (isDslSearch && !hasEntities && !hasDslAttributes) {
+          setSearchData({ entities: [] });
+          setIsEmptyData(true);
+          setLoader(false);
+          return;
         }
+
+        let dataLength = 0;
+        let totalCountLocal = 0;
+        if (isDslSearch && !hasEntities && hasDslAttributes && hasDslValues) {
+          const vals = (data as any).attributes?.values || (data as any).values;
+          dataLength = (vals as any[])?.length || 0;
+          totalCountLocal = dataLength;
+        } else {
+          const { approximateCount, entities } = data as any;
+          dataLength = Array.isArray(entities) ? entities.length : 0;
+          totalCountLocal = approximateCount ?? dataLength;
+        }
+
         if (!dataLength) {
           setIsEmptyData(true);
           setLoader(false);
         } else {
           setSearchData(searchResp.data);
-          setTotalCount(totalCount || 0);
-          setPageCount(Math.ceil(totalCount / pagination.pageSize));
+          setTotalCount(totalCountLocal || 0);
+          setPageCount(
+            Math.ceil((totalCountLocal || dataLength) / (pagination.pageSize || pageSize))
+          );
           setLoader(false);
         }
       } catch (error: any) {
@@ -745,16 +776,48 @@ const SearchResult = ({ classificationParams, glossaryTypeParams }: any) => {
     }
   );
 
+  const isDslSearchMode = searchParams.get("searchType") === "dsl";
+  const getDslAttributeNames = () => {
+    const src: any = Array.isArray(searchData) ? searchData[0] : searchData;
+    if (!src) return [] as string[];
+    if (Array.isArray(src?.attributes)) {
+      return src.attributes
+        .map((a: any) => (typeof a === 'string' ? a : a?.name))
+        .filter(Boolean);
+    }
+    if (src?.attributes && Array.isArray(src?.attributes?.name)) {
+      return src.attributes.name as string[];
+    }
+    return [] as string[];
+  };
+  const sanitize = (name: string) =>
+    String(name).replace(/[^A-Za-z0-9_]/g, "_").replace(/_{2,}/g, "_");
+  const dslAttrNames = isDslSearchMode ? getDslAttributeNames() : [];
+  const dslColumns = dslAttrNames.map((label: string, idx: number) => {
+    const key = `dsl_${sanitize(label)}` || `dsl_${idx}`
+    return {
+      id: key,
+      accessorKey: key,
+      header: label,
+      cell: (info: any) => <span>{info.getValue()}</span>,
+      show: true
+    }
+  });
+
   let allColumns =
-    isEmpty(searchParams.get("type")) &&
-    isEmpty(searchParams.get("tag")) &&
-    !isEmpty(searchParams.get("term"))
+    isDslSearchMode && dslColumns.length > 0
+      ? dslColumns
+      : isEmpty(searchParams.get("type")) &&
+        isEmpty(searchParams.get("tag")) &&
+        !isEmpty(searchParams.get("term"))
       ? removeDuplicateObjects([...defaultColumns])
       : removeDuplicateObjects([
           ...defaultColumns,
           ...dynamicColumns,
           ...defaultHideColumns
         ]);
+
+  const isDslAggregate = isDslSearchMode && dslColumns.length > 0;
 
   const defaultColumnVisibility: any = (columns: any) => {
     let columnsParams: any = searchParams.get("attributes");
@@ -778,7 +841,12 @@ const SearchResult = ({ classificationParams, glossaryTypeParams }: any) => {
 
     return hideColumns;
   };
-  const getDefaultSort = useMemo(() => [{ id: "name", asc: true }], []);
+  const getDefaultSort = useMemo(() => {
+    if (isDslAggregate) {
+      return [] as any[]; // no default sorting for DSL aggregates
+    }
+    return [{ id: "name", asc: true }];
+  }, [isDslAggregate]);
 
   return (
     <Stack position="relative" gap={"1rem"}>
@@ -833,27 +901,49 @@ const SearchResult = ({ classificationParams, glossaryTypeParams }: any) => {
 
       <TableLayout
         fetchData={fetchSearchResult}
-        data={searchData.entities || []}
+        data={
+          isDslSearchMode && dslColumns.length > 0
+            ? (() => {
+                const src: any = Array.isArray(searchData)
+                  ? searchData[0]
+                  : searchData;
+                const values: any[] = Array.isArray(src?.values)
+                  ? src.values
+                  : Array.isArray(src?.attributes?.values)
+                  ? src.attributes.values
+                  : [];
+                return values.map((row: any[], idx: number) => {
+                  const obj: any = { id: `dsl-row-${idx}` };
+                  dslAttrNames.forEach((n: string, i: number) => {
+                    const colKey = `dsl_${sanitize(n)}`
+                    obj[colKey] = Array.isArray(row) ? row[i] : row
+                  });
+                  return obj;
+                });
+              })()
+            : searchData.entities || []
+        }
         columns={allColumns.filter(
           (value: {}) => Object.keys(value).length !== 0
         )}
         emptyText="No Records found!"
         isFetching={loader}
         pageCount={pageCount}
-        columnVisibilityParams={true}
-        defaultColumnVisibility={defaultColumnVisibility(allColumns)}
+        // columnVisibilityParams={true}
+        columnVisibilityParams={!isDslAggregate}
+        defaultColumnVisibility={isDslAggregate ? {} : defaultColumnVisibility(allColumns)}
         defaultColumnParams={defaultColumnsName.join(",")}
-        columnVisibility={true}
+        columnVisibility={!isDslAggregate}
+        // columnVisibility={true}
         refreshTable={refreshTable}
         defaultSortCol={getDefaultSort}
         clientSideSorting={true}
         isClientSidePagination={false}
         columnSort={true}
         showPagination={true}
-        showRowSelection={true}
-        tableFilters={
-          isEmpty(classificationParams || glossaryTypeParams) ? true : false
-        }
+        showRowSelection={!isDslAggregate}
+        // showRowSelection={true}
+        tableFilters={true}
         assignFilters={
           !isEmpty(classificationParams || glossaryTypeParams)
             ? {

--- a/dashboardv2/public/js/views/graph/LineageLayoutView.js
+++ b/dashboardv2/public/js/views/graph/LineageLayoutView.js
@@ -576,7 +576,9 @@ define(['require',
                                 if ((that.filterObj.isProcessHideCheck && obj && obj.isProcess) || (that.filterObj.isDeletedEntityHideCheck && obj && obj.isDeleted) || (Globals.isLineageOnDemandEnabled && obj && _.contains(["Input", "Output"], obj.btnType))) {
                                     return;
                                 }
-                                typeStr += '<option value="' + obj.guid + '">' + obj.displayText + '</option>';
+                                var label = _.escape(obj.displayText);
+                                var value = _.escape(obj.guid);
+                                typeStr += '<option value="' + value + '">' + label + '</option>';
                             });
                         }
                         that.ui.lineageTypeSearch.html(typeStr);

--- a/dashboardv2/public/js/views/graph/TypeSystemTreeView.js
+++ b/dashboardv2/public/js/views/graph/TypeSystemTreeView.js
@@ -460,10 +460,13 @@ define([
             var nodes = that.LineageHelperRef.getNodes();
             if (!_.isEmpty(nodes)) {
                 _.each(nodes, function(obj) {
-                    searchStr += '<option value="' + obj.guid + '">' + obj.name + "</option>";
+                    var label = _.escape(obj.name)
+                    var value = _.escape(obj.guid)
+                    searchStr += '<option value="' + value + '">' + label + "</option>";
                     if (obj.serviceType && !tempFilteMap[obj.serviceType]) {
                         tempFilteMap[obj.serviceType] = obj.serviceType;
-                        filterStr += '<option value="' + obj.serviceType + '">' + obj.serviceType + "</option>";
+                        var svc = _.escape(obj.serviceType)
+                        filterStr += '<option value="' + svc + '">' + svc + "</option>";
                     }
                 });
             }

--- a/dashboardv3/public/js/views/graph/LineageLayoutView.js
+++ b/dashboardv3/public/js/views/graph/LineageLayoutView.js
@@ -576,7 +576,9 @@ define(['require',
                                 if ((that.filterObj.isProcessHideCheck && obj && obj.isProcess) || (that.filterObj.isDeletedEntityHideCheck && obj && obj.isDeleted) || (Globals.isLineageOnDemandEnabled && obj && _.contains(["Input", "Output"], obj.btnType))) {
                                     return;
                                 }
-                                typeStr += '<option value="' + obj.guid + '">' + obj.displayText + '</option>';
+                                var label = _.escape(obj.displayText);
+                                var value = _.escape(obj.guid);
+                                typeStr += '<option value="' + value + '">' + label + '</option>';
                             });
                         }
                         that.ui.lineageTypeSearch.html(typeStr);

--- a/dashboardv3/public/js/views/graph/TypeSystemTreeView.js
+++ b/dashboardv3/public/js/views/graph/TypeSystemTreeView.js
@@ -460,10 +460,13 @@ define([
             var nodes = that.LineageHelperRef.getNodes();
             if (!_.isEmpty(nodes)) {
                 _.each(nodes, function(obj) {
-                    searchStr += '<option value="' + obj.guid + '">' + obj.name + "</option>";
+                    var label = _.escape(obj.name)
+                    var value = _.escape(obj.guid)
+                    searchStr += '<option value="' + value + '">' + label + "</option>";
                     if (obj.serviceType && !tempFilteMap[obj.serviceType]) {
                         tempFilteMap[obj.serviceType] = obj.serviceType;
-                        filterStr += '<option value="' + obj.serviceType + '">' + obj.serviceType + "</option>";
+                        var svc = _.escape(obj.serviceType)
+                        filterStr += '<option value="' + svc + '">' + svc + "</option>";
                     }
                 });
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Precondition: Data from quick_start.py should be present.

These DSL queries do not display data as expected:

Table select min(createTime)
Table groupby(owner)
Table groupby(createTime) select owner, name, max(createTime)
Table groupby(createTime) select owner, name, min(createTime)
Table groupby(owner) select owner, count()
hive_db select __timestamp, __modificationTimestamp, __state, __createdBy

The search results pages do not display aggregated information nor the columns stated in the queries.



## How was this patch tested?
manually tested

<img width="1845" height="1071" alt="Screenshot from 2025-09-25 12-37-45" src="https://github.com/user-attachments/assets/900f3720-be4c-462d-a7ed-8daee5ca0bee" />
<img width="1845" height="1071" alt="Screenshot from 2025-09-25 12-36-39" src="https://github.com/user-attachments/assets/bf41fc14-a232-43c5-90d5-7c7e1513913e" />
<img width="1845" height="1071" alt="Screenshot from 2025-09-25 12-36-26" src="https://github.com/user-attachments/assets/01b21d47-fb29-4053-9970-90eb1373e62f" />
