### PR TITLE
ATLAS-5131:[REACT UI] Glossary import being used instead of business metadata import.

### DIFF
--- a/dashboard/src/components/ImportDialog.tsx
+++ b/dashboard/src/components/ImportDialog.tsx
@@ -78,7 +78,7 @@ export const ImportDialog: React.FC<CustomModalProps> = ({
     if (fileData) {
       try {
         let apiMethod =
-          title == "Import Business Template"
+          title == "Import Business Metadata"
             ? getBusinessMetadataImport
             : getGlossaryImport;
         let formData = new FormData();


### PR DESCRIPTION

## What changes were proposed in this pull request?
Importing Business metadata UI is calling Import Glossary functionality and data never gets imported in Atlas entity, but instead a glossary gets created. On repeating the import again it throws an error.


## How was this patch tested?
Manually tested
<img width="1845" height="1071" alt="image" src="https://github.com/user-attachments/assets/a2eec8c1-6f54-4041-b257-8dd206d3d6c8" />
