### PR TITLE
Fix flaky test in AtlasJanusGraphIndexClientTest#testGetTopTermsRandom4

### DIFF
--- a/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
+++ b/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphIndexClientTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -148,7 +149,7 @@ public class AtlasJanusGraphIndexClientTest {
 
     private Map<String, AtlasJanusGraphIndexClient.TermFreq> generateTerms(int... termFreqs) {
         int                                              i     = 0;
-        Map<String, AtlasJanusGraphIndexClient.TermFreq> terms = new HashMap<>();
+        Map<String, AtlasJanusGraphIndexClient.TermFreq> terms = new LinkedHashMap<>();
 
         for (int count : termFreqs) {
             AtlasJanusGraphIndexClient.TermFreq termFreq1 = new AtlasJanusGraphIndexClient.TermFreq(Integer.toString(i++), count);


### PR DESCRIPTION

## What changes were proposed in this pull request?

The test `AtlasJanusGraphIndexClientTest#testGetTopTermsRandom4` failed intermittently because `HashMap` iteration order is non-deterministic.
Changed `generateTerms(...)` to use `LinkedHashMap` so iteration order is consistent.

This is a **test-only** change.

## How was this patch tested?

* Reproduced flaky failures with [NonDex](https://github.com/TestingResearchIllinois/NonDex), a tool that systematically perturbs iteration order to expose order-dependent bugs.
* Example command:

  ```bash
  mvn -pl graphdb/janus edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.apache.atlas.repository.graphdb.janus.AtlasJanusGraphIndexClientTest#testGetTopTermsRandom4 \
    -Drat.skip
  ```
* Before fix:
```
[INFO] Running org.apache.atlas.repository.graphdb.janus.AtlasJanusGraphIndexClientTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.806 s <<< FAILURE! - in org.apache.atlas.repository.graphdb.janus.AtlasJanusGraphIndexClientTest
[ERROR] org.apache.atlas.repository.graphdb.janus.AtlasJanusGraphIndexClientTest.testGetTopTermsRandom4  Time elapsed: 0.423 s  <<< FAILURE!
java.lang.AssertionError: expected [8] but found [7]
        at org.apache.atlas.repository.graphdb.janus.AtlasJanusGraphIndexClientTest.assertOrder(AtlasJanusGraphIndexClientTest.java:143)
        at org.apache.atlas.repository.graphdb.janus.AtlasJanusGraphIndexClientTest.testGetTopTermsRandom4(AtlasJanusGraphIndexClientTest.java:99)
```
* After fix: test passes consistently under repeated NonDex runs.
