### PR TITLE
ATLAS-5147: Search API approximateCount value shows pageLimit value instead of total entity count

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusIndexQuery.java
@@ -77,7 +77,7 @@ public class AtlasJanusIndexQuery implements AtlasIndexQuery<AtlasJanusVertex, A
 
     @Override
     public Long vertexTotals() {
-        return query.vertexTotals();
+        return query.offset(0).limit(Integer.MAX_VALUE).vertexTotals();
     }
 
     @Override


### PR DESCRIPTION
Example: When performing a search of entities i particular typedef let's say: "hdfs_path",  if the number of entities exceeds the default pagination limit (25), the approximateCount field in the AtlasSearchResult incorrectly reports only 25, even when more entities exist.
Also, if we decrease the pagination limit to any random number lets say 5, the approximate count will be shown as 5

Before the Fix:
Create 26 entities of a type.
Perform a search using the API without explicitly setting limit and offset (defaults to 25).
Observe that approximateCount is reported as 25 instead of 26

After the Fix
approximateCount value is reported as totalEntityCount present in particular typedefinition

Fix Done:
updating vertexTotals() in  AtlasIndexJanusQuery Class, that returns:     return query.offset(0).limit(Integer.MAX_VALUE).vertexTotals();


Repro of the Issue:
as we have 26 entities.

request:
curl 'http://localhost:21000/api/atlas/v2/search/basic' \ -H 'Accept: application/json, text/plain, /' \ -H 'Accept-Language: en-US,en;q=0.9' \ -H 'Connection: keep-alive' \ -H 'Content-Type: application/json' \ -b 'ATLASSESSIONID=node0ilpfq8b9zw701pbgowuqmrjqf1.node0' \ -H 'Origin: http://localhost:21000/' \ -H 'Referer: http://localhost:21000/n3/index.html' \ -H 'Sec-Fetch-Dest: empty' \ -H 'Sec-Fetch-Mode: cors' \ -H 'Sec-Fetch-Site: same-origin' \ -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36' \ -H 'X-XSRF-HEADER: eDoGUqSdiDGwTZoV88ui' \ -H 'sec-ch-ua: "Chromium";v="140", "Not=A?Brand";v="24", "Google Chrome";v="140"' \ -H 'sec-ch-ua-mobile: ?0' \ -H 'sec-ch-ua-platform: "Linux"' \ --data-raw '{"excludeDeletedEntities":true,"includeSubClassifications":true,"includeSubTypes":true,"includeClassificationAttributes":true,"entityFilters":null,"tagFilters":null,"attributes":[],"limit":25,"offset":0,"relationshipFilters":null,"typeName":"hdfs_path","classification":null,"termName":null}'

setting limit as 25 as above in curl request shown.

so were getting in the respone:
], "approximateCount": 25



After the changes:
A Request:
{"excludeDeletedEntities":true,"includeSubClassifications":true,"includeSubTypes":true,"includeClassificationAttributes":true,"entityFilters":null,"tagFilters":null,"attributes":[],"limit":5,"offset":0,"relationshipFilters":null,"typeName":"hdfs_path","classification":null,"termName":null}


A Response:

{queryType: "BASIC",…}
approximateCount
: 
26



B Request
{"excludeDeletedEntities":true,"includeSubClassifications":true,"includeSubTypes":true,"includeClassificationAttributes":true,"entityFilters":null,"tagFilters":null,"attributes":[],"limit":50,"offset":0,"relationshipFilters":null,"typeName":"hdfs_path","classification":null,"termName":null}

B Respone:
{queryType: "BASIC",…}
approximateCount
: 
26





How Testing Done:
UI Test, Mvn Build for whole Atlas, CI Build 