### PR TITLE
ATLAS-5151:React UI: Fix UI layout issue for tables when no records are present.

### DIFF
--- a/dashboard/src/styles/table.scss
+++ b/dashboard/src/styles/table.scss
@@ -69,6 +69,23 @@
   width: auto !important;
 }
 
+/* Ensure the content wrapper inside header spans full cell width */
+.table-header-cell > div,
+.table-header-wrap {
+  display: flex;
+  width: 100%;
+  min-width: 0; /* allow flex children to shrink instead of overflowing */
+}
+
+/* Header text wrapper to avoid inline styles in JSX */
+.table-header-text {
+  display: flex;
+  align-items: center;
+  line-height: 20px;
+  width: 100%;
+  min-width: 0;
+}
+
 /* table-pagination */
 
 .table-pagination {


### PR DESCRIPTION

## What changes were proposed in this pull request?

Currently, the table headers in the Search and Business Metadata sections appear visually constrained or misaligned when there are zero records. This impacts the layout consistency and user experience.


## How was this patch tested?
Manually tested
<img width="1854" height="1011" alt="Screenshot from 2025-10-07 17-11-53" src="https://github.com/user-attachments/assets/d1f94dd4-8491-4863-8979-b9f762f8fc7f" />
