### PR TITLE
ATLAS-5155: Upgrading logback version to 1.5.19 due to CVE-2025-11226

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <kafka.scala.binary.version>2.12</kafka.scala.binary.version>
         <kafka.version>2.8.2</kafka.version>
         <keycloak.version>6.0.1</keycloak.version>
-        <logback.version>1.3.15</logback.version>
+        <logback.version>1.5.19</logback.version>
         <lucene-solr.version>8.11.3</lucene-solr.version>
         <maven-plugin-sortpom.version>3.0.1</maven-plugin-sortpom.version>
         <maven-site-plugin.version>3.7</maven-site-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

upgrading logback version from 1.3.15  to 1.5.19 due to CVE-2025-11226

## How was this patch tested?

manual testing