### PR TITLE
ATLAS-4988: BusinessMetadata with attribute of data type Array takes time to Delete.

### DIFF
--- a/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
+++ b/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
@@ -353,7 +353,19 @@ public class AtlasClientV2 extends AtlasBaseClient {
     }
 
     public void deleteTypeByName(String typeName) throws AtlasServiceException {
-        callAPI(API_V2.DELETE_TYPE_DEF_BY_NAME, (Class) null, null, typeName);
+        callAPI(API_V2.DELETE_TYPE_DEF_BY_NAME, (Class<?>) null, null, typeName);
+    }
+
+    public void deleteTypeByName(String typeName, boolean forceDelete) throws AtlasServiceException {
+        if (forceDelete) {
+
+            MultivaluedMap<String, String> queryParams = new MultivaluedMapImpl();
+            queryParams.add("force", "true");
+            callAPI(API_V2.DELETE_TYPE_DEF_BY_NAME, (Class<?>) null, queryParams, typeName);
+        } else {
+
+            callAPI(API_V2.DELETE_TYPE_DEF_BY_NAME, (Class<?>) null, null, typeName);
+        }
     }
 
     // Entity APIs

--- a/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
+++ b/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
@@ -357,15 +357,14 @@ public class AtlasClientV2 extends AtlasBaseClient {
     }
 
     public void deleteTypeByName(String typeName, boolean forceDelete) throws AtlasServiceException {
+        MultivaluedMap<String, String> queryParams = null;
+
         if (forceDelete) {
-
-            MultivaluedMap<String, String> queryParams = new MultivaluedMapImpl();
+            queryParams = new MultivaluedMapImpl();
             queryParams.add("force", "true");
-            callAPI(API_V2.DELETE_TYPE_DEF_BY_NAME, (Class<?>) null, queryParams, typeName);
-        } else {
-
-            callAPI(API_V2.DELETE_TYPE_DEF_BY_NAME, (Class<?>) null, null, typeName);
         }
+
+        callAPI(API_V2.DELETE_TYPE_DEF_BY_NAME, (Class<?>) null, queryParams, typeName);
     }
 
     // Entity APIs

--- a/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
+++ b/client/client-v2/src/main/java/org/apache/atlas/AtlasClientV2.java
@@ -349,7 +349,18 @@ public class AtlasClientV2 extends AtlasBaseClient {
      * @param typesDef A composite object that captures all types to be deleted
      */
     public void deleteAtlasTypeDefs(AtlasTypesDef typesDef) throws AtlasServiceException {
-        callAPI(API_V2.DELETE_TYPE_DEFS, (Class<?>) null, AtlasType.toJson(typesDef));
+        deleteAtlasTypeDefs(typesDef, false);
+    }
+
+    public void deleteAtlasTypeDefs(AtlasTypesDef typesDef, boolean forceDelete) throws AtlasServiceException {
+        MultivaluedMap<String, String> queryParams = null;
+
+        if (forceDelete) {
+            queryParams = new MultivaluedMapImpl();
+            queryParams.add("force", "true");
+        }
+
+        callAPI(API_V2.DELETE_TYPE_DEFS, (Class<?>) null, AtlasType.toJson(typesDef), queryParams);
     }
 
     public void deleteTypeByName(String typeName) throws AtlasServiceException {

--- a/client/client-v2/src/test/java/org/apache/atlas/AtlasClientV2Test.java
+++ b/client/client-v2/src/test/java/org/apache/atlas/AtlasClientV2Test.java
@@ -82,6 +82,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -808,6 +809,7 @@ public class AtlasClientV2Test {
         private Object mockResponse;
         private Class<?> expectedReturnType;
         private boolean shouldThrowException;
+        private javax.ws.rs.core.MultivaluedMap<String, String> lastQueryParams;
 
         public TestableAtlasClientV2() {
             super(mock(WebResource.class), mock(Configuration.class));
@@ -823,8 +825,13 @@ public class AtlasClientV2Test {
             this.shouldThrowException = shouldThrow;
         }
 
+        public javax.ws.rs.core.MultivaluedMap<String, String> getLastQueryParams() {
+            return lastQueryParams;
+        }
+
         @Override
         public <T> T callAPI(API api, Class<T> responseType, Object requestObject, String... params) throws AtlasServiceException {
+            lastQueryParams = null;
             return handleCallAPI(responseType);
         }
 
@@ -838,11 +845,13 @@ public class AtlasClientV2Test {
 
         @Override
         public <T> T callAPI(API api, Class<T> responseType, javax.ws.rs.core.MultivaluedMap<String, String> queryParams, String... params) throws AtlasServiceException {
+            lastQueryParams = queryParams;
             return handleCallAPI(responseType);
         }
 
         @Override
         public <T> T callAPI(API api, Class<T> responseType, Object requestObject, javax.ws.rs.core.MultivaluedMap<String, String> queryParams, String... params) throws AtlasServiceException {
+            lastQueryParams = queryParams;
             return handleCallAPI(responseType);
         }
 
@@ -1053,6 +1062,19 @@ public class AtlasClientV2Test {
         // Should not throw exception
         client.deleteAtlasTypeDefs(input);
         assertTrue(true);
+        assertNull(client.getLastQueryParams());
+    }
+
+    @Test
+    public void testDeleteAtlasTypeDefsRealExecutionWithForceDelete() throws Exception {
+        TestableAtlasClientV2 client = new TestableAtlasClientV2();
+        client.setMockResponse(null, Object.class);
+
+        AtlasTypesDef input = new AtlasTypesDef();
+        client.deleteAtlasTypeDefs(input, true);
+
+        assertNotNull(client.getLastQueryParams());
+        assertEquals(client.getLastQueryParams().getFirst("force"), "true");
     }
 
     @Test

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -261,7 +261,7 @@ public enum AtlasErrorCode {
     ABORT_IMPORT_FAILED(500, "ATLAS-500-00-022", "Failed to abort import with id {0}"),
     IMPORT_QUEUEING_FAILED(500, "ATLAS-500-00-023", "Failed to add import with id {0} to request queue, please try again later"),
 
-    NON_INDEXABLE_BM_DELETE_NOT_ALLOWED(400, "ATLAS-400-00-106", "Deletion not allowed for non-indexable Business Metadata ''{0}'' without force-delete. Please use the force-delete parameter to remove.");
+    NON_INDEXABLE_BM_DELETE_NOT_ALLOWED(400, "ATLAS-400-00-106", "Deletion not allowed for non-indexable Business Metadata ''{0}'' without force=true. Non-indexable attributes cannot be validated efficiently for references; use force=true to skip validation and delete (warning: orphaned references may remain).");
 
     private static final Logger LOG = LoggerFactory.getLogger(AtlasErrorCode.class);
     private final        String errorCode;

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -183,6 +183,7 @@ public enum AtlasErrorCode {
     BLANK_NAME_ATTRIBUTE(400, "ATLAS-400-00-104", "Name Attribute can't be empty!"),
     BLANK_VALUE_ATTRIBUTE(400, "ATLAS-400-00-105", "Value Attribute can't be empty!"),
     INVALID_RELATIONSHIP_LABEL(400, "ATLAS-400-00-106", "Invalid relationship label {0}. The referenced entity type {1} could not be resolved from the type registry."),
+    NON_INDEXABLE_BM_DELETE_NOT_ALLOWED(400, "ATLAS-400-00-107", "Deletion not allowed for non-indexable Business Metadata ''{0}'' without force=true. Non-indexable attributes cannot be validated efficiently for references; use force=true to skip validation and delete (warning: orphaned references may remain)."),
 
     UNAUTHORIZED_ACCESS(403, "ATLAS-403-00-001", "{0} is not authorized to perform {1}"),
 
@@ -259,9 +260,7 @@ public enum AtlasErrorCode {
     IMPORT_REGISTRATION_FAILED(500, "ATLAS-500-00-020", "Failed to register import request"),
     IMPORT_FAILED(500, "ATLAS-500-00-021", "Import with id {0} failed"),
     ABORT_IMPORT_FAILED(500, "ATLAS-500-00-022", "Failed to abort import with id {0}"),
-    IMPORT_QUEUEING_FAILED(500, "ATLAS-500-00-023", "Failed to add import with id {0} to request queue, please try again later"),
-
-    NON_INDEXABLE_BM_DELETE_NOT_ALLOWED(400, "ATLAS-400-00-106", "Deletion not allowed for non-indexable Business Metadata ''{0}'' without force=true. Non-indexable attributes cannot be validated efficiently for references; use force=true to skip validation and delete (warning: orphaned references may remain).");
+    IMPORT_QUEUEING_FAILED(500, "ATLAS-500-00-023", "Failed to add import with id {0} to request queue, please try again later");
 
     private static final Logger LOG = LoggerFactory.getLogger(AtlasErrorCode.class);
     private final        String errorCode;

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -259,7 +259,9 @@ public enum AtlasErrorCode {
     IMPORT_REGISTRATION_FAILED(500, "ATLAS-500-00-020", "Failed to register import request"),
     IMPORT_FAILED(500, "ATLAS-500-00-021", "Import with id {0} failed"),
     ABORT_IMPORT_FAILED(500, "ATLAS-500-00-022", "Failed to abort import with id {0}"),
-    IMPORT_QUEUEING_FAILED(500, "ATLAS-500-00-023", "Failed to add import with id {0} to request queue, please try again later");
+    IMPORT_QUEUEING_FAILED(500, "ATLAS-500-00-023", "Failed to add import with id {0} to request queue, please try again later"),
+
+    NON_INDEXABLE_BM_DELETE_NOT_ALLOWED(400, "ATLAS-400-00-106", "Deletion not allowed for non-indexable Business Metadata ''{0}'' without force-delete. Please use the force-delete parameter to remove.");
 
     private static final Logger LOG = LoggerFactory.getLogger(AtlasErrorCode.class);
     private final        String errorCode;

--- a/intg/src/main/java/org/apache/atlas/type/AtlasBusinessMetadataType.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasBusinessMetadataType.java
@@ -44,10 +44,16 @@ public class AtlasBusinessMetadataType extends AtlasStructType {
 
     private final AtlasBusinessMetadataDef businessMetadataDef;
 
+    private boolean hasNonIndexableAttributes;
+
     public AtlasBusinessMetadataType(AtlasBusinessMetadataDef businessMetadataDef) {
         super(businessMetadataDef);
 
         this.businessMetadataDef = businessMetadataDef;
+    }
+
+    public boolean hasNonIndexableAttributes() {
+        return hasNonIndexableAttributes;
     }
 
     @Override
@@ -70,6 +76,8 @@ public class AtlasBusinessMetadataType extends AtlasStructType {
         super.resolveReferences(typeRegistry);
 
         Map<String, AtlasBusinessAttribute> a = new HashMap<>();
+
+        hasNonIndexableAttributes = false;
 
         for (AtlasAttribute attribute : super.allAttributes.values()) {
             AtlasAttributeDef attributeDef = attribute.getAttributeDef();
@@ -115,10 +123,16 @@ public class AtlasBusinessMetadataType extends AtlasStructType {
                 bmAttribute = new AtlasBusinessAttribute(attribute, entityTypes);
             }
 
+            if (!hasNonIndexableAttributes && !Boolean.TRUE.equals(attributeDef.getIsIndexable())) {
+                hasNonIndexableAttributes = true;
+            }
+
             a.put(attrName, bmAttribute);
         }
 
         super.allAttributes = Collections.unmodifiableMap(a);
+        LOG.debug("CACHE-POPULATE [Phase1] BM='{}' hasNonIndexableAttributes={} totalAttributes={}",
+                getTypeName(), hasNonIndexableAttributes, a.size());
     }
 
     @Override
@@ -137,6 +151,29 @@ public class AtlasBusinessMetadataType extends AtlasStructType {
         }
     }
 
+    @Override
+    void resolveReferencesPhase3(AtlasTypeRegistry typeRegistry) throws AtlasBaseException {
+        super.resolveReferencesPhase3(typeRegistry);
+
+        for (AtlasAttribute attribute : super.allAttributes.values()) {
+            AtlasBusinessAttribute bmAttribute = (AtlasBusinessAttribute) attribute;
+            Set<AtlasEntityType>   entityTypes = bmAttribute.getApplicableEntityTypes();
+
+            if (CollectionUtils.isNotEmpty(entityTypes)) {
+                Set<String> expandedTypeNames = new HashSet<>();
+
+                for (AtlasEntityType entityType : entityTypes) {
+                    expandedTypeNames.add(entityType.getTypeName());
+                    expandedTypeNames.addAll(entityType.getAllSubTypes());
+                }
+
+                bmAttribute.applicableEntityTypeNamesWithSubTypes = Collections.unmodifiableSet(expandedTypeNames);
+                LOG.debug("CACHE-POPULATE [Phase3] BM='{}' attr='{}' expandedTypes={}",
+                        getTypeName(), bmAttribute.getName(), expandedTypeNames);
+            }
+        }
+    }
+
     public AtlasBusinessMetadataDef getBusinessMetadataDef() {
         return businessMetadataDef;
     }
@@ -145,6 +182,8 @@ public class AtlasBusinessMetadataType extends AtlasStructType {
         private final Set<AtlasEntityType> applicableEntityTypes;
         private final int                  maxStringLength;
         private final String               validPattern;
+
+        private Set<String> applicableEntityTypeNamesWithSubTypes = Collections.emptySet();
 
         public AtlasBusinessAttribute(AtlasAttribute attribute, Set<AtlasEntityType> applicableEntityTypes) {
             super(attribute);
@@ -169,6 +208,10 @@ public class AtlasBusinessMetadataType extends AtlasStructType {
 
         public Set<AtlasEntityType> getApplicableEntityTypes() {
             return applicableEntityTypes;
+        }
+
+        public Set<String> getApplicableEntityTypeNamesWithSubTypes() {
+            return applicableEntityTypeNamesWithSubTypes;
         }
 
         public String getValidPattern() {

--- a/intg/src/main/java/org/apache/atlas/type/AtlasBusinessMetadataType.java
+++ b/intg/src/main/java/org/apache/atlas/type/AtlasBusinessMetadataType.java
@@ -123,7 +123,7 @@ public class AtlasBusinessMetadataType extends AtlasStructType {
                 bmAttribute = new AtlasBusinessAttribute(attribute, entityTypes);
             }
 
-            if (!hasNonIndexableAttributes && !Boolean.TRUE.equals(attributeDef.getIsIndexable())) {
+            if (!hasNonIndexableAttributes && !attributeDef.getIsIndexable()) {
                 hasNonIndexableAttributes = true;
             }
 

--- a/intg/src/test/java/org/apache/atlas/TestUtilsV2.java
+++ b/intg/src/test/java/org/apache/atlas/TestUtilsV2.java
@@ -625,6 +625,11 @@ public final class TestUtilsV2 {
                 createOptionalAttrDef("attrSuperBoolean", AtlasBusinessMetadataDef.ATLAS_TYPE_BOOLEAN, options, description),
                 createOptionalAttrDef("attrSuperString", AtlasBusinessMetadataDef.ATLAS_TYPE_STRING, options, description));
 
+        setBusinessMetadataAttributesIndexable(bmNoApplicableTypes);
+        setBusinessMetadataAttributesIndexable(bmWithAllTypes);
+        setBusinessMetadataAttributesIndexable(bmWithAllTypesMV);
+        setBusinessMetadataAttributesIndexable(bmWithSuperType);
+
         AtlasTypesDef ret = AtlasTypeUtil.getTypesDef(new ArrayList<>(),
                 new ArrayList<>(), new ArrayList<>(),
                 new ArrayList<>(), new ArrayList<>(),
@@ -633,6 +638,16 @@ public final class TestUtilsV2 {
         populateSystemAttributes(ret);
 
         return ret;
+    }
+
+    private static void setBusinessMetadataAttributesIndexable(AtlasBusinessMetadataDef def) {
+        if (def == null || CollectionUtils.isEmpty(def.getAttributeDefs())) {
+            return;
+        }
+
+        for (AtlasAttributeDef ad : def.getAttributeDefs()) {
+            ad.setIsIndexable(true);
+        }
     }
 
     public static AtlasTypesDef defineHiveTypes() {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasDefStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasDefStore.java
@@ -45,9 +45,25 @@ public interface AtlasDefStore<T extends AtlasBaseTypeDef> {
 
     AtlasVertex preDeleteByName(String name) throws AtlasBaseException;
 
-    void deleteByName(String name, AtlasVertex preDeleteResult) throws AtlasBaseException;
-
     AtlasVertex preDeleteByGuid(String guid) throws AtlasBaseException;
 
+    void deleteByName(String name, AtlasVertex preDeleteResult) throws AtlasBaseException;
+
     void deleteByGuid(String guid, AtlasVertex preDeleteResult) throws AtlasBaseException;
+
+    default AtlasVertex preDeleteByName(String name, boolean forceDelete) throws AtlasBaseException {
+        return preDeleteByName(name);
+    }
+
+    default void deleteByName(String name, AtlasVertex preDeleteResult, boolean forceDelete) throws AtlasBaseException {
+        deleteByName(name, preDeleteResult);
+    }
+
+    default AtlasVertex preDeleteByGuid(String guid, boolean forceDelete) throws AtlasBaseException {
+        return preDeleteByGuid(guid);
+    }
+
+    default void deleteByGuid(String guid, AtlasVertex preDeleteResult, boolean forceDelete) throws AtlasBaseException {
+        deleteByGuid(guid, preDeleteResult);
+    }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasDefStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasDefStore.java
@@ -20,6 +20,8 @@ package org.apache.atlas.repository.store.graph;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -27,6 +29,8 @@ import java.util.List;
  * Interface for graph persistence store for AtlasTypeDef
  */
 public interface AtlasDefStore<T extends AtlasBaseTypeDef> {
+    Logger LOG = LoggerFactory.getLogger(AtlasDefStore.class);
+
     AtlasVertex preCreate(T typeDef) throws AtlasBaseException;
 
     T create(T typeDef, AtlasVertex preCreateResult) throws AtlasBaseException;
@@ -52,6 +56,10 @@ public interface AtlasDefStore<T extends AtlasBaseTypeDef> {
     void deleteByGuid(String guid, AtlasVertex preDeleteResult) throws AtlasBaseException;
 
     default AtlasVertex preDeleteByName(String name, boolean forceDelete) throws AtlasBaseException {
+        if (forceDelete) {
+            LOG.debug("Force-delete flag ignored in {}.preDeleteByName() for type '{}'; feature is implemented only for BusinessMetadata.", getClass().getSimpleName(), name);
+        }
+
         return preDeleteByName(name);
     }
 
@@ -60,6 +68,10 @@ public interface AtlasDefStore<T extends AtlasBaseTypeDef> {
     }
 
     default AtlasVertex preDeleteByGuid(String guid, boolean forceDelete) throws AtlasBaseException {
+        if (forceDelete) {
+            LOG.debug("Force-delete flag ignored in {}.preDeleteByGuid() for guid '{}'; feature is implemented only for BusinessMetadata.", getClass().getSimpleName(), guid);
+        }
+
         return preDeleteByGuid(guid);
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasDefStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasDefStore.java
@@ -20,8 +20,6 @@ package org.apache.atlas.repository.store.graph;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -29,8 +27,6 @@ import java.util.List;
  * Interface for graph persistence store for AtlasTypeDef
  */
 public interface AtlasDefStore<T extends AtlasBaseTypeDef> {
-    Logger LOG = LoggerFactory.getLogger(AtlasDefStore.class);
-
     AtlasVertex preCreate(T typeDef) throws AtlasBaseException;
 
     T create(T typeDef, AtlasVertex preCreateResult) throws AtlasBaseException;
@@ -56,10 +52,6 @@ public interface AtlasDefStore<T extends AtlasBaseTypeDef> {
     void deleteByGuid(String guid, AtlasVertex preDeleteResult) throws AtlasBaseException;
 
     default AtlasVertex preDeleteByName(String name, boolean forceDelete) throws AtlasBaseException {
-        if (forceDelete) {
-            LOG.debug("Force-delete flag ignored in {}.preDeleteByName() for type '{}'; feature is implemented only for BusinessMetadata.", getClass().getSimpleName(), name);
-        }
-
         return preDeleteByName(name);
     }
 
@@ -68,10 +60,6 @@ public interface AtlasDefStore<T extends AtlasBaseTypeDef> {
     }
 
     default AtlasVertex preDeleteByGuid(String guid, boolean forceDelete) throws AtlasBaseException {
-        if (forceDelete) {
-            LOG.debug("Force-delete flag ignored in {}.preDeleteByGuid() for guid '{}'; feature is implemented only for BusinessMetadata.", getClass().getSimpleName(), guid);
-        }
-
         return preDeleteByGuid(guid);
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
@@ -539,14 +539,20 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
     @Override
     @GraphTransaction
     public void deleteTypesDef(AtlasTypesDef typesDef) throws AtlasBaseException {
+        deleteTypesDef(typesDef, false);
+    }
+
+    @GraphTransaction
+    public void deleteTypesDef(AtlasTypesDef typesDef, boolean forceDelete) throws AtlasBaseException {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("==> AtlasTypeDefGraphStore.deleteTypesDef(enums={}, structs={}, classfications={}, entities={}, relationships={}, businessMetadataDefs={})",
+            LOG.debug("==> AtlasTypeDefGraphStore.deleteTypesDef(enums={}, structs={}, classfications={}, entities={}, relationships={}, businessMetadataDefs={}, forceDelete={})",
                     CollectionUtils.size(typesDef.getEnumDefs()),
                     CollectionUtils.size(typesDef.getStructDefs()),
                     CollectionUtils.size(typesDef.getClassificationDefs()),
                     CollectionUtils.size(typesDef.getEntityDefs()),
                     CollectionUtils.size(typesDef.getRelationshipDefs()),
-                    CollectionUtils.size(typesDef.getBusinessMetadataDefs()));
+                    CollectionUtils.size(typesDef.getBusinessMetadataDefs()),
+                    forceDelete);
         }
 
         AtlasTransientTypeRegistry ttr = lockTypeRegistryAndReleasePostCommit();
@@ -678,9 +684,9 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
         if (CollectionUtils.isNotEmpty(typesDef.getBusinessMetadataDefs())) {
             for (AtlasBusinessMetadataDef businessMetadataDef : typesDef.getBusinessMetadataDefs()) {
                 if (StringUtils.isNotBlank(businessMetadataDef.getGuid())) {
-                    businessMetadataDefStore.deleteByGuid(businessMetadataDef.getGuid(), null);
+                    businessMetadataDefStore.deleteByGuid(businessMetadataDef.getGuid(), null, forceDelete);
                 } else {
-                    businessMetadataDefStore.deleteByName(businessMetadataDef.getName(), null);
+                    businessMetadataDefStore.deleteByName(businessMetadataDef.getName(), null, forceDelete);
                 }
             }
         }
@@ -777,7 +783,7 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
 
     @Override
     @GraphTransaction
-    public void deleteTypeByName(String typeName) throws AtlasBaseException {
+    public void deleteTypeByName(String typeName, boolean forceDelete) throws AtlasBaseException {
         AtlasType atlasType = typeRegistry.getType(typeName);
 
         if (atlasType == null) {
@@ -801,7 +807,7 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
             typesDef.setStructDefs(Collections.singletonList((AtlasStructDef) baseTypeDef));
         }
 
-        deleteTypesDef(typesDef);
+        deleteTypesDef(typesDef, forceDelete);
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStore.java
@@ -544,16 +544,14 @@ public abstract class AtlasTypeDefGraphStore implements AtlasTypeDefStore {
 
     @GraphTransaction
     public void deleteTypesDef(AtlasTypesDef typesDef, boolean forceDelete) throws AtlasBaseException {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("==> AtlasTypeDefGraphStore.deleteTypesDef(enums={}, structs={}, classfications={}, entities={}, relationships={}, businessMetadataDefs={}, forceDelete={})",
-                    CollectionUtils.size(typesDef.getEnumDefs()),
-                    CollectionUtils.size(typesDef.getStructDefs()),
-                    CollectionUtils.size(typesDef.getClassificationDefs()),
-                    CollectionUtils.size(typesDef.getEntityDefs()),
-                    CollectionUtils.size(typesDef.getRelationshipDefs()),
-                    CollectionUtils.size(typesDef.getBusinessMetadataDefs()),
-                    forceDelete);
-        }
+        LOG.debug("==> AtlasTypeDefGraphStore.deleteTypesDef(enums={}, structs={}, classfications={}, entities={}, relationships={}, businessMetadataDefs={}, forceDelete={})",
+                CollectionUtils.size(typesDef.getEnumDefs()),
+                CollectionUtils.size(typesDef.getStructDefs()),
+                CollectionUtils.size(typesDef.getClassificationDefs()),
+                CollectionUtils.size(typesDef.getEntityDefs()),
+                CollectionUtils.size(typesDef.getRelationshipDefs()),
+                CollectionUtils.size(typesDef.getBusinessMetadataDefs()),
+                forceDelete);
 
         AtlasTransientTypeRegistry ttr = lockTypeRegistryAndReleasePostCommit();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasAbstractDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasAbstractDefStoreV2.java
@@ -148,24 +148,46 @@ abstract class AtlasAbstractDefStoreV2<T extends AtlasBaseTypeDef> implements At
 
     @Override
     public void deleteByName(String name, AtlasVertex preDeleteResult) throws AtlasBaseException {
-        LOG.debug("==> AtlasAbstractDefStoreV1.deleteByName({}, {})", name, preDeleteResult);
+        LOG.debug("==> AtlasAbstractDefStoreV2.deleteByName({}, {})", name, preDeleteResult);
 
         AtlasVertex vertex = (preDeleteResult == null) ? preDeleteByName(name) : preDeleteResult;
 
         typeDefStore.deleteTypeVertex(vertex);
 
-        LOG.debug("<== AtlasAbstractDefStoreV1.deleteByName({}, {})", name, preDeleteResult);
+        LOG.debug("<== AtlasAbstractDefStoreV2.deleteByName({}, {})", name, preDeleteResult);
     }
 
     @Override
     public void deleteByGuid(String guid, AtlasVertex preDeleteResult) throws AtlasBaseException {
-        LOG.debug("==> AtlasAbstractDefStoreV1.deleteByGuid({}, {})", guid, preDeleteResult);
+        LOG.debug("==> AtlasAbstractDefStoreV2.deleteByGuid({}, {})", guid, preDeleteResult);
 
         AtlasVertex vertex = (preDeleteResult == null) ? preDeleteByGuid(guid) : preDeleteResult;
 
         typeDefStore.deleteTypeVertex(vertex);
 
-        LOG.debug("<== AtlasAbstractDefStoreV1.deleteByGuid({}, {})", guid, preDeleteResult);
+        LOG.debug("<== AtlasAbstractDefStoreV2.deleteByGuid({}, {})", guid, preDeleteResult);
+    }
+
+    @Override
+    public void deleteByName(String name, AtlasVertex preDeleteResult, boolean forceDelete) throws AtlasBaseException {
+        LOG.debug("==> AtlasAbstractDefStoreV2.deleteByName({}, {}, {})", name, preDeleteResult, forceDelete);
+
+        AtlasVertex vertex = (preDeleteResult == null) ? preDeleteByName(name, forceDelete) : preDeleteResult;
+
+        typeDefStore.deleteTypeVertex(vertex);
+
+        LOG.debug("<== AtlasAbstractDefStoreV2.deleteByName({}, {}, {})", name, preDeleteResult, forceDelete);
+    }
+
+    @Override
+    public void deleteByGuid(String guid, AtlasVertex preDeleteResult, boolean forceDelete) throws AtlasBaseException {
+        LOG.debug("==> AtlasAbstractDefStoreV2.deleteByGuid({}, {}, {})", guid, preDeleteResult, forceDelete);
+
+        AtlasVertex vertex = (preDeleteResult == null) ? preDeleteByGuid(guid, forceDelete) : preDeleteResult;
+
+        typeDefStore.deleteTypeVertex(vertex);
+
+        LOG.debug("<== AtlasAbstractDefStoreV2.deleteByGuid({}, {}, {})", guid, preDeleteResult, forceDelete);
     }
 
     public boolean isInvalidTypeDefName(String typeName) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasAbstractDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasAbstractDefStoreV2.java
@@ -148,24 +148,12 @@ abstract class AtlasAbstractDefStoreV2<T extends AtlasBaseTypeDef> implements At
 
     @Override
     public void deleteByName(String name, AtlasVertex preDeleteResult) throws AtlasBaseException {
-        LOG.debug("==> AtlasAbstractDefStoreV2.deleteByName({}, {})", name, preDeleteResult);
-
-        AtlasVertex vertex = (preDeleteResult == null) ? preDeleteByName(name) : preDeleteResult;
-
-        typeDefStore.deleteTypeVertex(vertex);
-
-        LOG.debug("<== AtlasAbstractDefStoreV2.deleteByName({}, {})", name, preDeleteResult);
+        deleteByName(name, preDeleteResult, false);
     }
 
     @Override
     public void deleteByGuid(String guid, AtlasVertex preDeleteResult) throws AtlasBaseException {
-        LOG.debug("==> AtlasAbstractDefStoreV2.deleteByGuid({}, {})", guid, preDeleteResult);
-
-        AtlasVertex vertex = (preDeleteResult == null) ? preDeleteByGuid(guid) : preDeleteResult;
-
-        typeDefStore.deleteTypeVertex(vertex);
-
-        LOG.debug("<== AtlasAbstractDefStoreV2.deleteByGuid({}, {})", guid, preDeleteResult);
+        deleteByGuid(guid, preDeleteResult, false);
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
@@ -21,12 +21,8 @@ import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
 import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.authorize.AtlasTypeAccessRequest;
-import org.apache.atlas.discovery.EntityDiscoveryService;
-import org.apache.atlas.discovery.SearchContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.TypeCategory;
-import org.apache.atlas.model.discovery.AtlasSearchResult;
-import org.apache.atlas.model.discovery.SearchParameters;
 import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
 import org.apache.atlas.model.typedef.AtlasBusinessMetadataDef;
 import org.apache.atlas.model.typedef.AtlasStructDef;
@@ -35,10 +31,9 @@ import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasGraphQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.type.AtlasBusinessMetadataType;
+import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasStructType;
 import org.apache.atlas.type.AtlasType;
-import org.apache.atlas.type.AtlasEntityType;
-import org.apache.atlas.type.AtlasArrayType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.typesystem.types.DataTypes;
 import org.apache.atlas.utils.AtlasJson;
@@ -50,26 +45,24 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.HashSet;
 
 import static org.apache.atlas.model.typedef.AtlasBusinessMetadataDef.ATTR_OPTION_APPLICABLE_ENTITY_TYPES;
 
 public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasBusinessMetadataDef> {
     private static final Logger LOG = LoggerFactory.getLogger(AtlasBusinessMetadataDefStoreV2.class);
 
-    private final EntityDiscoveryService entityDiscoveryService;
-
     private final AtlasGraph graph;
 
     @Inject
-    public AtlasBusinessMetadataDefStoreV2(AtlasTypeDefGraphStoreV2 typeDefStore, AtlasTypeRegistry typeRegistry, EntityDiscoveryService entityDiscoveryService, AtlasGraph graph) {
+    public AtlasBusinessMetadataDefStoreV2(AtlasTypeDefGraphStoreV2 typeDefStore, AtlasTypeRegistry typeRegistry, AtlasGraph graph) {
         super(typeDefStore, typeRegistry);
 
-        this.entityDiscoveryService = entityDiscoveryService;
         this.graph = graph;
     }
 
@@ -285,15 +278,7 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
             throw new AtlasBaseException(AtlasErrorCode.TYPE_NAME_NOT_FOUND, name);
         }
 
-        if (!forceDelete) {
-            boolean hasIndexableAttribute = hasIndexableAttribute(existingDef);
-
-            if (!hasIndexableAttribute) {
-                LOG.warn("Deletion blocked for non-indexable Business Metadata '{}' without force-delete flag", name);
-                throw new AtlasBaseException(AtlasErrorCode.NON_INDEXABLE_BM_DELETE_NOT_ALLOWED, name);
-            }
-            checkBusinessMetadataRef(existingDef.getName());
-        }
+        validateDeletion(existingDef, forceDelete, name);
 
         LOG.debug("<== AtlasBusinessMetadataDefStoreV2.preDeleteByName({}, {}): {}", name, forceDelete, ret);
 
@@ -319,28 +304,38 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
             throw new AtlasBaseException(AtlasErrorCode.TYPE_GUID_NOT_FOUND, guid);
         }
 
-        if (existingDef != null && !forceDelete) {
-            boolean hasIndexableAttribute = hasIndexableAttribute(existingDef);
-
-            if (!hasIndexableAttribute) {
-                LOG.warn("Deletion blocked for non-indexable Business Metadata '{}' without force-delete flag", existingDef.getName());
-                throw new AtlasBaseException(AtlasErrorCode.NON_INDEXABLE_BM_DELETE_NOT_ALLOWED, existingDef.getName());
-            }
-            checkBusinessMetadataRef(existingDef.getName());
-        }
+        validateDeletion(existingDef, forceDelete, guid);
 
         LOG.debug("<== AtlasBusinessMetadataDefStoreV2.preDeleteByGuid({}, {}): ret={}", guid, forceDelete, ret);
 
         return ret;
     }
 
-    private boolean hasIndexableAttribute(AtlasBusinessMetadataDef bmDef) {
+    private void validateDeletion(AtlasBusinessMetadataDef businessMetadataDef, boolean forceDelete, String identifier) throws AtlasBaseException {
+        if (businessMetadataDef == null) {
+            return;
+        }
+
+        if (forceDelete) {
+            LOG.warn("Force-deleting BusinessMetadata '{}'. Skipping validation - orphaned references may remain.", businessMetadataDef.getName());
+            return;
+        }
+
+        if (hasNonIndexableAttribute(businessMetadataDef)) {
+            LOG.warn("Deletion blocked for non-indexable Business Metadata '{}' without force-delete flag", businessMetadataDef.getName());
+            throw new AtlasBaseException(AtlasErrorCode.NON_INDEXABLE_BM_DELETE_NOT_ALLOWED, businessMetadataDef.getName());
+        }
+
+        checkBusinessMetadataRef(businessMetadataDef, identifier);
+    }
+
+    private boolean hasNonIndexableAttribute(AtlasBusinessMetadataDef bmDef) {
         if (bmDef == null || CollectionUtils.isEmpty(bmDef.getAttributeDefs())) {
             return false;
         }
 
         for (AtlasStructDef.AtlasAttributeDef attributeDef : bmDef.getAttributeDefs()) {
-            if (attributeDef.getIsIndexable()) {
+            if (!Boolean.TRUE.equals(attributeDef.getIsIndexable())) {
                 return true;
             }
         }
@@ -408,47 +403,48 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
         return ret;
     }
 
-    private void checkBusinessMetadataRef(String typeName) throws AtlasBaseException {
-        AtlasBusinessMetadataDef businessMetadataDef = typeRegistry.getBusinessMetadataDefByName(typeName);
-
+    private void checkBusinessMetadataRef(AtlasBusinessMetadataDef businessMetadataDef, String identifier) throws AtlasBaseException {
         if (businessMetadataDef == null || CollectionUtils.isEmpty(businessMetadataDef.getAttributeDefs())) {
             return;
         }
 
+        Map<String, Set<String>> expandedTypeCache = new HashMap<>();
+
         for (AtlasStructDef.AtlasAttributeDef attributeDef : businessMetadataDef.getAttributeDefs()) {
-            validateAttributeReferences(businessMetadataDef, attributeDef);
+            String applicableTypesStr = attributeDef.getOption(ATTR_OPTION_APPLICABLE_ENTITY_TYPES);
+            Set<String> applicableTypes = StringUtils.isBlank(applicableTypesStr) ? null : AtlasJson.fromJson(applicableTypesStr, Set.class);
+
+            if (CollectionUtils.isEmpty(applicableTypes)) {
+                continue;
+            }
+
+            Set<String> allApplicableTypes = expandedTypeCache.get(applicableTypesStr);
+
+            if (allApplicableTypes == null) {
+                allApplicableTypes = getApplicableTypesWithSubTypes(applicableTypes);
+                expandedTypeCache.put(applicableTypesStr, allApplicableTypes);
+            }
+
+            validateAttributeReferences(businessMetadataDef, attributeDef, allApplicableTypes, identifier);
         }
     }
 
-    private void validateAttributeReferences(AtlasBusinessMetadataDef bmDef, AtlasStructDef.AtlasAttributeDef attributeDef) throws AtlasBaseException {
-        String applicableTypesStr = attributeDef.getOption(ATTR_OPTION_APPLICABLE_ENTITY_TYPES);
-        Set<String> applicableTypes = StringUtils.isBlank(applicableTypesStr) ? null : AtlasJson.fromJson(applicableTypesStr, Set.class);
-
-        if (CollectionUtils.isEmpty(applicableTypes)) {
-            return;
-        }
-
-        Set<String> allApplicableTypes = getApplicableTypesWithSubTypes(applicableTypes);
+    private void validateAttributeReferences(AtlasBusinessMetadataDef bmDef, AtlasStructDef.AtlasAttributeDef attributeDef,
+                                             Set<String> allApplicableTypes, String identifier) throws AtlasBaseException {
         String qualifiedName      = AtlasStructType.AtlasAttribute.getQualifiedAttributeName(bmDef, attributeDef.getName());
         String vertexPropertyName = AtlasStructType.AtlasAttribute.generateVertexPropertyName(bmDef, attributeDef, qualifiedName);
-
-        long startTime = System.currentTimeMillis();
-
-        boolean isPresent = isBusinessAttributePresentInGraph(vertexPropertyName, allApplicableTypes);
-
-        if (LOG.isDebugEnabled()) {
-            LOG.info("Reference check for attribute {} took {} ms. Found: {}",
-                    attributeDef.getName(), (System.currentTimeMillis() - startTime), isPresent);
-        }
+        boolean isPresent         = isBusinessAttributePresentInGraph(vertexPropertyName, allApplicableTypes);
 
         if (isPresent) {
+            LOG.error("Cannot delete BusinessMetadata '{}' (request='{}') - attribute '{}' (vertex property: '{}') has references in entity types: {}",
+                      bmDef.getName(), identifier, attributeDef.getName(), vertexPropertyName, allApplicableTypes);
             throw new AtlasBaseException(AtlasErrorCode.TYPE_HAS_REFERENCES, bmDef.getName());
         }
     }
 
 
-    private boolean isBusinessAttributePresentInGraph(String vertexPropertyName, Set<String> allApplicableTypes) {
-        if (graph == null || CollectionUtils.isEmpty(allApplicableTypes)) {
+    private boolean isBusinessAttributePresentInGraph(String vertexPropertyName, Set<String> allApplicableTypes) throws AtlasBaseException {
+        if (CollectionUtils.isEmpty(allApplicableTypes)) {
             return false;
         }
 
@@ -459,7 +455,7 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
             Iterable<AtlasVertex> verticesDirect = graph.query()
                     .has(vertexPropertyName, AtlasGraphQuery.ComparisionOperator.NOT_EQUAL, (Object) null)
                     .in(Constants.ENTITY_TYPE_PROPERTY_KEY, typesList)
-                    .vertices();
+                    .vertices(1);
 
             if (verticesDirect != null && verticesDirect.iterator().hasNext()) {
                 return true;
@@ -470,18 +466,22 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
             Iterable<AtlasVertex> verticesInherited = graph.query()
                     .has(vertexPropertyName, AtlasGraphQuery.ComparisionOperator.NOT_EQUAL, (Object) null)
                     .in(Constants.SUPER_TYPES_PROPERTY_KEY, typesList)
-                    .vertices();
+                    .vertices(1);
 
             if (verticesInherited != null && verticesInherited.iterator().hasNext()) {
                 return true;
             }
         } catch (Exception e) {
-            LOG.error("Error occurred while querying graph for references of property: {}", vertexPropertyName, e);
-            return true;
+            throw new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR,
+                    e, String.format("failed to validate BusinessMetadata references for property %s", vertexPropertyName));
         }
         return false;
     }
 
+    /**
+     * Expands configured applicable entity types to include all concrete sub-types.
+     * Without this expansion, deletion checks can miss references present only on inherited child entity types.
+     */
     private Set<String> getApplicableTypesWithSubTypes(Set<String> applicableTypes) throws AtlasBaseException {
         Set<String> allTypes = new HashSet<>();
 

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
@@ -444,11 +444,10 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
 
         if (isPresent) {
             LOG.error("Cannot delete BusinessMetadata '{}' (request='{}') - attribute '{}' (vertex property: '{}') has references in entity types: {}",
-                      bmDef.getName(), identifier, attributeDef.getName(), vertexPropertyName, allApplicableTypes);
+                    bmDef.getName(), identifier, attributeDef.getName(), vertexPropertyName, allApplicableTypes);
             throw new AtlasBaseException(AtlasErrorCode.TYPE_HAS_REFERENCES, bmDef.getName());
         }
     }
-
 
     private boolean isBusinessAttributePresentInGraph(String vertexPropertyName, Set<String> allApplicableTypes) throws AtlasBaseException {
         if (CollectionUtils.isEmpty(allApplicableTypes)) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
@@ -425,7 +425,7 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
                 allApplicableTypes = getApplicableTypesWithSubTypes(attributeDef);
             }
 
-            LOG.info("REF-CHECK [ApplicableTypes] BM='{}' attr='{}' types={}",
+            LOG.debug("REF-CHECK [ApplicableTypes] BM='{}' attr='{}' types={}",
                     businessMetadataDef.getName(), attributeDef.getName(), allApplicableTypes);
 
             if (CollectionUtils.isEmpty(allApplicableTypes)) {
@@ -443,7 +443,7 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
         boolean isPresent         = isBusinessAttributePresentInGraph(vertexPropertyName, allApplicableTypes);
 
         if (isPresent) {
-            LOG.error("Cannot delete BusinessMetadata '{}' (request='{}') - attribute '{}' (vertex property: '{}') has references in entity types: {}",
+            LOG.warn("Cannot delete BusinessMetadata '{}' (request='{}') - attribute '{}' (vertex property: '{}') has references in entity types: {}",
                     bmDef.getName(), identifier, attributeDef.getName(), vertexPropertyName, allApplicableTypes);
             throw new AtlasBaseException(AtlasErrorCode.TYPE_HAS_REFERENCES, bmDef.getName());
         }
@@ -457,15 +457,11 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
         try {
             List<String> typesList = new ArrayList<>(allApplicableTypes);
 
-            // Single combined query
             AtlasGraphQuery query = graph.query()
                     .has(vertexPropertyName, AtlasGraphQuery.ComparisionOperator.NOT_EQUAL, (Object) null);
 
             List<AtlasGraphQuery> orConditions = new ArrayList<>();
-            // Arm 1: direct type match (vertex's __typeName is in the applicable set)
             orConditions.add(query.createChildQuery().in(Constants.ENTITY_TYPE_PROPERTY_KEY, typesList));
-            // Arm 2: inherited type match — catches child entities whose super-type is in the applicable set
-            // This is crucial for Case 6 (Parent -> Child)
             orConditions.add(query.createChildQuery().in(Constants.SUPER_TYPES_PROPERTY_KEY, typesList));
 
             query.or(orConditions);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
@@ -36,7 +36,6 @@ import org.apache.atlas.type.AtlasStructType;
 import org.apache.atlas.type.AtlasType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.typesystem.types.DataTypes;
-import org.apache.atlas.utils.AtlasJson;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -45,11 +44,10 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.atlas.model.typedef.AtlasBusinessMetadataDef.ATTR_OPTION_APPLICABLE_ENTITY_TYPES;
@@ -329,14 +327,18 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
         checkBusinessMetadataRef(businessMetadataDef, identifier);
     }
 
-    private boolean hasNonIndexableAttribute(AtlasBusinessMetadataDef bmDef) {
-        if (bmDef == null || CollectionUtils.isEmpty(bmDef.getAttributeDefs())) {
-            return false;
+    private boolean hasNonIndexableAttribute(AtlasBusinessMetadataDef businessMetadataDef) {
+        AtlasBusinessMetadataType bmType = typeRegistry.getBusinessMetadataTypeByName(businessMetadataDef.getName());
+
+        if (bmType != null && bmType.hasNonIndexableAttributes()) {
+            return true;
         }
 
-        for (AtlasStructDef.AtlasAttributeDef attributeDef : bmDef.getAttributeDefs()) {
-            if (!Boolean.TRUE.equals(attributeDef.getIsIndexable())) {
-                return true;
+        if (CollectionUtils.isNotEmpty(businessMetadataDef.getAttributeDefs())) {
+            for (AtlasStructDef.AtlasAttributeDef attributeDef : businessMetadataDef.getAttributeDefs()) {
+                if (!Boolean.TRUE.equals(attributeDef.getIsIndexable())) {
+                    return true;
+                }
             }
         }
 
@@ -408,21 +410,26 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
             return;
         }
 
-        Map<String, Set<String>> expandedTypeCache = new HashMap<>();
+        AtlasBusinessMetadataType bmType = typeRegistry.getBusinessMetadataTypeByName(businessMetadataDef.getName());
 
         for (AtlasStructDef.AtlasAttributeDef attributeDef : businessMetadataDef.getAttributeDefs()) {
-            String applicableTypesStr = attributeDef.getOption(ATTR_OPTION_APPLICABLE_ENTITY_TYPES);
-            Set<String> applicableTypes = StringUtils.isBlank(applicableTypesStr) ? null : AtlasJson.fromJson(applicableTypesStr, Set.class);
+            Set<String> allApplicableTypes;
 
-            if (CollectionUtils.isEmpty(applicableTypes)) {
-                continue;
+            if (bmType != null) {
+                AtlasBusinessMetadataType.AtlasBusinessAttribute bmAttr =
+                        (AtlasBusinessMetadataType.AtlasBusinessAttribute) bmType.getAttribute(attributeDef.getName());
+                Set<String> cachedTypes = bmAttr != null ? bmAttr.getApplicableEntityTypeNamesWithSubTypes() : Collections.emptySet();
+
+                allApplicableTypes = CollectionUtils.isNotEmpty(cachedTypes) ? cachedTypes : getApplicableTypesWithSubTypes(attributeDef);
+            } else {
+                allApplicableTypes = getApplicableTypesWithSubTypes(attributeDef);
             }
 
-            Set<String> allApplicableTypes = expandedTypeCache.get(applicableTypesStr);
+            LOG.info("REF-CHECK [ApplicableTypes] BM='{}' attr='{}' types={}",
+                    businessMetadataDef.getName(), attributeDef.getName(), allApplicableTypes);
 
-            if (allApplicableTypes == null) {
-                allApplicableTypes = getApplicableTypesWithSubTypes(applicableTypes);
-                expandedTypeCache.put(applicableTypesStr, allApplicableTypes);
+            if (CollectionUtils.isEmpty(allApplicableTypes)) {
+                continue;
             }
 
             validateAttributeReferences(businessMetadataDef, attributeDef, allApplicableTypes, identifier);
@@ -451,24 +458,22 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
         try {
             List<String> typesList = new ArrayList<>(allApplicableTypes);
 
-            // 1. To Check if the BM property exists on a vertex where the direct type matches
-            Iterable<AtlasVertex> verticesDirect = graph.query()
-                    .has(vertexPropertyName, AtlasGraphQuery.ComparisionOperator.NOT_EQUAL, (Object) null)
-                    .in(Constants.ENTITY_TYPE_PROPERTY_KEY, typesList)
-                    .vertices(1);
+            // Single combined query
+            AtlasGraphQuery query = graph.query()
+                    .has(vertexPropertyName, AtlasGraphQuery.ComparisionOperator.NOT_EQUAL, (Object) null);
 
-            if (verticesDirect != null && verticesDirect.iterator().hasNext()) {
-                return true;
-            }
-
-            // 2. To Check if the BM property exists on a vertex where it inherits from one of parent Types
+            List<AtlasGraphQuery> orConditions = new ArrayList<>();
+            // Arm 1: direct type match (vertex's __typeName is in the applicable set)
+            orConditions.add(query.createChildQuery().in(Constants.ENTITY_TYPE_PROPERTY_KEY, typesList));
+            // Arm 2: inherited type match — catches child entities whose super-type is in the applicable set
             // This is crucial for Case 6 (Parent -> Child)
-            Iterable<AtlasVertex> verticesInherited = graph.query()
-                    .has(vertexPropertyName, AtlasGraphQuery.ComparisionOperator.NOT_EQUAL, (Object) null)
-                    .in(Constants.SUPER_TYPES_PROPERTY_KEY, typesList)
-                    .vertices(1);
+            orConditions.add(query.createChildQuery().in(Constants.SUPER_TYPES_PROPERTY_KEY, typesList));
 
-            if (verticesInherited != null && verticesInherited.iterator().hasNext()) {
+            query.or(orConditions);
+
+            Iterable<AtlasVertex> vertices = query.vertices(1);
+
+            if (vertices != null && vertices.iterator().hasNext()) {
                 return true;
             }
         } catch (Exception e) {
@@ -482,20 +487,23 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
      * Expands configured applicable entity types to include all concrete sub-types.
      * Without this expansion, deletion checks can miss references present only on inherited child entity types.
      */
-    private Set<String> getApplicableTypesWithSubTypes(Set<String> applicableTypes) throws AtlasBaseException {
-        Set<String> allTypes = new HashSet<>();
+    private Set<String> getApplicableTypesWithSubTypes(AtlasStructDef.AtlasAttributeDef attributeDef) {
+        String      applicableTypesJson = attributeDef.getOption(ATTR_OPTION_APPLICABLE_ENTITY_TYPES);
+        Set<String> applicableTypeNames = StringUtils.isBlank(applicableTypesJson) ? null : AtlasType.fromJson(applicableTypesJson, Set.class);
 
-        for (String typeName : applicableTypes) {
-            AtlasType type = typeRegistry.getType(typeName);
+        if (CollectionUtils.isEmpty(applicableTypeNames)) {
+            return Collections.emptySet();
+        }
 
-            if (type instanceof AtlasEntityType) {
-                AtlasEntityType entityType = (AtlasEntityType) type;
-                allTypes.add(entityType.getTypeName());
-                allTypes.addAll(entityType.getAllSubTypes());
-            } else {
-                allTypes.add(typeName);
+        Set<String> result = new HashSet<>(applicableTypeNames);
+
+        for (String typeName : applicableTypeNames) {
+            AtlasEntityType entityType = typeRegistry.getEntityTypeByName(typeName);
+
+            if (entityType != null) {
+                result.addAll(entityType.getAllSubTypes());
             }
         }
-        return allTypes;
+        return result;
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2.java
@@ -336,7 +336,7 @@ public class AtlasBusinessMetadataDefStoreV2 extends AtlasAbstractDefStoreV2<Atl
 
         if (CollectionUtils.isNotEmpty(businessMetadataDef.getAttributeDefs())) {
             for (AtlasStructDef.AtlasAttributeDef attributeDef : businessMetadataDef.getAttributeDefs()) {
-                if (!Boolean.TRUE.equals(attributeDef.getIsIndexable())) {
+                if (!attributeDef.getIsIndexable()) {
                     return true;
                 }
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -177,7 +177,7 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
 
     @Override
     protected AtlasDefStore<AtlasBusinessMetadataDef> getBusinessMetadataDefStore(AtlasTypeRegistry typeRegistry) {
-        return new AtlasBusinessMetadataDefStoreV2(this, typeRegistry, this.entityDiscoveryService);
+        return new AtlasBusinessMetadataDefStoreV2(this, typeRegistry, this.entityDiscoveryService, this.atlasGraph);
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -179,11 +179,11 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
     @Override
     @GraphTransaction
     public void init() throws AtlasBaseException {
-        LOG.info("==> AtlasTypeDefGraphStoreV1.init()");
+        LOG.info("==> AtlasTypeDefGraphStoreV2.init()");
 
         super.init();
 
-        LOG.info("<== AtlasTypeDefGraphStoreV1.init()");
+        LOG.info("<== AtlasTypeDefGraphStoreV2.init()");
     }
 
     AtlasGraph getAtlasGraph() {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -73,14 +73,11 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
 
     protected final AtlasGraph atlasGraph;
 
-    private final EntityDiscoveryService entityDiscoveryService;
-
     @Inject
     public AtlasTypeDefGraphStoreV2(AtlasTypeRegistry typeRegistry, List<TypeDefChangeListener> typeDefChangeListeners, AtlasGraph atlasGraph, EntityDiscoveryService entityDiscoveryService) {
         super(typeRegistry, typeDefChangeListeners);
 
-        this.atlasGraph             = atlasGraph;
-        this.entityDiscoveryService = entityDiscoveryService;
+        this.atlasGraph = atlasGraph;
 
         LOG.debug("<== AtlasTypeDefGraphStoreV1()");
     }
@@ -177,7 +174,7 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
 
     @Override
     protected AtlasDefStore<AtlasBusinessMetadataDef> getBusinessMetadataDefStore(AtlasTypeRegistry typeRegistry) {
-        return new AtlasBusinessMetadataDefStoreV2(this, typeRegistry, this.entityDiscoveryService, this.atlasGraph);
+        return new AtlasBusinessMetadataDefStoreV2(this, typeRegistry, this.atlasGraph);
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasTypeDefGraphStoreV2.java
@@ -21,7 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.annotation.GraphTransaction;
-import org.apache.atlas.discovery.EntityDiscoveryService;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.listener.TypeDefChangeListener;
 import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
@@ -64,7 +63,7 @@ import static org.apache.atlas.repository.Constants.VERTEX_TYPE_PROPERTY_KEY;
 import static org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2.VERTEX_TYPE;
 
 /**
- * Graph persistence store for TypeDef - v1
+ * Graph persistence store for TypeDef - v2
  */
 @Singleton
 @Component
@@ -74,12 +73,12 @@ public class AtlasTypeDefGraphStoreV2 extends AtlasTypeDefGraphStore {
     protected final AtlasGraph atlasGraph;
 
     @Inject
-    public AtlasTypeDefGraphStoreV2(AtlasTypeRegistry typeRegistry, List<TypeDefChangeListener> typeDefChangeListeners, AtlasGraph atlasGraph, EntityDiscoveryService entityDiscoveryService) {
+    public AtlasTypeDefGraphStoreV2(AtlasTypeRegistry typeRegistry, List<TypeDefChangeListener> typeDefChangeListeners, AtlasGraph atlasGraph) {
         super(typeRegistry, typeDefChangeListeners);
 
         this.atlasGraph = atlasGraph;
 
-        LOG.debug("<== AtlasTypeDefGraphStoreV1()");
+        LOG.debug("<== AtlasTypeDefGraphStoreV2()");
     }
 
     public static String getCurrentUser() {

--- a/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
+++ b/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
@@ -109,7 +109,7 @@ public interface AtlasTypeDefStore {
 
     AtlasBaseTypeDef getByGuid(String guid) throws AtlasBaseException;
 
-    void deleteTypeByName(String typeName) throws AtlasBaseException;
+    void deleteTypeByName(String typeName, boolean forceDelete) throws AtlasBaseException;
 
     void notifyLoadCompletion();
 }

--- a/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
+++ b/repository/src/main/java/org/apache/atlas/store/AtlasTypeDefStore.java
@@ -102,6 +102,8 @@ public interface AtlasTypeDefStore {
 
     void deleteTypesDef(AtlasTypesDef typesDef) throws AtlasBaseException;
 
+    void deleteTypesDef(AtlasTypesDef typesDef, boolean forceDelete) throws AtlasBaseException;
+
     AtlasTypesDef searchTypesDef(SearchFilter searchFilter) throws AtlasBaseException;
 
     /* Generic operation */

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStoreTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/AtlasTypeDefGraphStoreTest.java
@@ -369,10 +369,10 @@ public class AtlasTypeDefGraphStoreTest extends AtlasTestBase {
             AtlasTypesDef typesDef            = TestResourceFileUtils.readObjectFromJson(".", hivedbV2Json, AtlasTypesDef.class);
 
             typeDefStore.createTypesDef(typesDef);
-            typeDefStore.deleteTypeByName(hiveDB2);
-            typeDefStore.deleteTypeByName(relationshipDefName);
-            typeDefStore.deleteTypeByName(hostEntityDef);
-            typeDefStore.deleteTypeByName(clusterEntityDef);
+            typeDefStore.deleteTypeByName(hiveDB2, false);
+            typeDefStore.deleteTypeByName(relationshipDefName, false);
+            typeDefStore.deleteTypeByName(hostEntityDef, false);
+            typeDefStore.deleteTypeByName(clusterEntityDef, false);
         } catch (AtlasBaseException e) {
             fail("Deletion should've succeeded");
         }

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2Test.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2Test.java
@@ -59,6 +59,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 /* Please note that for these tests, since the typeRegistry can be injected only once,
  * any new tests should make sure that they flush the type registry at the end of the test.
@@ -203,6 +204,39 @@ public class AtlasBusinessMetadataDefStoreV2Test {
 
         for (AtlasBusinessMetadataDef businessMetadataDef : typeRegistry.getAllBusinessMetadataDefs()) {
             assertNotEquals(businessMetadataDef.getName(), businessMetadataName);
+        }
+    }
+
+    @Test
+    public void deleteBusinessMetadataDefWithMixedIndexableAttributesWithoutForceShouldFail() throws AtlasBaseException {
+        createBusinessMetadataTypesWithMixedIndexability(businessMetadataName);
+
+        AtlasBusinessMetadataDef businessMetadataDef = findBusinessMetadataDef(businessMetadataName);
+        assertNotNull(businessMetadataDef);
+
+        typesDefs = new AtlasTypesDef(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.singletonList(businessMetadataDef));
+
+        try {
+            typeDefStore.deleteTypesDef(typesDefs, false);
+            fail("Deletion without force should fail when BM has non-indexable attributes");
+        } catch (AtlasBaseException e) {
+            assertEquals(e.getAtlasErrorCode(), AtlasErrorCode.NON_INDEXABLE_BM_DELETE_NOT_ALLOWED);
+        }
+    }
+
+    @Test
+    public void deleteBusinessMetadataDefWithMixedIndexableAttributesWithForceShouldSucceed() throws AtlasBaseException {
+        createBusinessMetadataTypesWithMixedIndexability(businessMetadataName);
+
+        AtlasBusinessMetadataDef businessMetadataDef = findBusinessMetadataDef(businessMetadataName);
+        assertNotNull(businessMetadataDef);
+
+        typesDefs = new AtlasTypesDef(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.singletonList(businessMetadataDef));
+
+        typeDefStore.deleteTypesDef(typesDefs, true);
+
+        for (AtlasBusinessMetadataDef def : typeRegistry.getAllBusinessMetadataDefs()) {
+            assertNotEquals(def.getName(), businessMetadataName);
         }
     }
 
@@ -494,6 +528,29 @@ public class AtlasBusinessMetadataDefStoreV2Test {
         return businessMetadataDef1;
     }
 
+    private void createBusinessMetadataTypesWithMixedIndexability(String businessMetadataName) throws AtlasBaseException {
+        List<AtlasBusinessMetadataDef> businessMetadataDefs = new ArrayList<>(typesDefs.getBusinessMetadataDefs());
+
+        businessMetadataDefs.add(createBusinessMetadataDefWithMixedIndexability(businessMetadataName));
+
+        typesDefs.setBusinessMetadataDefs(businessMetadataDefs);
+
+        AtlasTypesDef createdTypesDef = typeDefStore.createTypesDef(typesDefs);
+
+        assertEquals(createdTypesDef.getBusinessMetadataDefs(), businessMetadataDefs, "Data integrity issue while persisting");
+    }
+
+    private AtlasBusinessMetadataDef createBusinessMetadataDefWithMixedIndexability(String businessMetadataName) {
+        AtlasBusinessMetadataDef businessMetadataDef = new AtlasBusinessMetadataDef(businessMetadataName, "test_mixed_indexability", null);
+
+        addBusinessAttribute(businessMetadataDef, "mixed_indexable_attr", Collections.singleton("hive_table"), "string", AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE, true);
+        addBusinessAttribute(businessMetadataDef, "mixed_non_indexable_attr", Collections.singleton("hive_table"), "string", AtlasStructDef.AtlasAttributeDef.Cardinality.SINGLE, false);
+
+        TestUtilsV2.populateSystemAttributes(businessMetadataDef);
+
+        return businessMetadataDef;
+    }
+
     private AtlasBusinessMetadataDef createBusinessMetadataDef2(String businessMetadataName) {
         AtlasBusinessMetadataDef businessMetadataDef1 = new AtlasBusinessMetadataDef(businessMetadataName, "test_description", null);
 
@@ -525,6 +582,27 @@ public class AtlasBusinessMetadataDefStoreV2Test {
             attributeDef.setOption(ATTR_MAX_STRING_LENGTH, "20");
         }
 
+        attributeDef.setIsOptional(true);
+        attributeDef.setValuesMinCount(0);
+        attributeDef.setValuesMaxCount(1);
+        attributeDef.setIsUnique(false);
+        attributeDef.setDisplayName(name);
+
+        businessMetadataDef.addAttribute(attributeDef);
+    }
+
+    private void addBusinessAttribute(AtlasBusinessMetadataDef businessMetadataDef, String name, Set<String> applicableEntityTypes, String typeName,
+                                      AtlasStructDef.AtlasAttributeDef.Cardinality cardinality, boolean isIndexable) {
+        AtlasStructDef.AtlasAttributeDef attributeDef = new AtlasStructDef.AtlasAttributeDef(name, typeName);
+
+        attributeDef.setCardinality(cardinality);
+        attributeDef.setOption(ATTR_OPTION_APPLICABLE_ENTITY_TYPES, AtlasType.toJson(applicableEntityTypes));
+
+        if (typeName.contains(AtlasBaseTypeDef.ATLAS_TYPE_STRING)) {
+            attributeDef.setOption(ATTR_MAX_STRING_LENGTH, "20");
+        }
+
+        attributeDef.setIsIndexable(isIndexable);
         attributeDef.setIsOptional(true);
         attributeDef.setValuesMinCount(0);
         attributeDef.setValuesMaxCount(1);

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2Test.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasBusinessMetadataDefStoreV2Test.java
@@ -587,6 +587,7 @@ public class AtlasBusinessMetadataDefStoreV2Test {
         attributeDef.setValuesMaxCount(1);
         attributeDef.setIsUnique(false);
         attributeDef.setDisplayName(name);
+        attributeDef.setIsIndexable(true);
 
         businessMetadataDef.addAttribute(attributeDef);
     }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -407,19 +407,24 @@ public class TypesREST {
      * @HTTP 204 On successful deletion of the requested type definitions
      * @HTTP 400 On validation failure for any type definitions
      */
+    public void deleteAtlasTypeDefs(final AtlasTypesDef typesDef) throws AtlasBaseException {
+        deleteAtlasTypeDefs(typesDef, false);
+    }
+
     @DELETE
     @Path("/typedefs")
     @Experimental
     @Timed
-    public void deleteAtlasTypeDefs(final AtlasTypesDef typesDef) throws AtlasBaseException {
+    public void deleteAtlasTypeDefs(final AtlasTypesDef typesDef,
+                                    @QueryParam("force") @DefaultValue("false") final boolean forceDelete) throws AtlasBaseException {
         AtlasPerfTracer perf = null;
 
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
-                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "TypesREST.deleteAtlasTypeDefs(" + AtlasTypeUtil.toDebugString(typesDef) + ")");
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "TypesREST.deleteAtlasTypeDefs(" + AtlasTypeUtil.toDebugString(typesDef) + ", force=" + forceDelete + ")");
             }
 
-            typeDefStore.deleteTypesDef(typesDef);
+            typeDefStore.deleteTypesDef(typesDef, forceDelete);
         } finally {
             AtlasPerfTracer.log(perf);
         }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -401,16 +401,20 @@ public class TypesREST {
     }
 
     /**
-     * Bulk delete API for all types
-     * @param typesDef A composite object that captures all types to be deleted
+     * Bulk delete API for all types.
+     *
+     * @param typesDef A composite object that captures all types to be deleted.
+     * @param forceDelete If true, bypasses pre-delete validation checks and forcefully removes type definitions.
+     *                    For BusinessMetadata types:
+     *                    - If isIndexable=true and force=false: performs normal graph scan validation
+     *                    - If isIndexable=false and force=false: blocks deletion (requires force=true)
+     *                    - If force=true: skips all validation and deletes the type
+     *                    Defaults to false for backward compatibility.
      * @throws AtlasBaseException
      * @HTTP 204 On successful deletion of the requested type definitions
-     * @HTTP 400 On validation failure for any type definitions
+     * @HTTP 400 On validation failure for any type definitions or when attempting to delete
+     *           non-indexable BusinessMetadata without force-delete parameter
      */
-    public void deleteAtlasTypeDefs(final AtlasTypesDef typesDef) throws AtlasBaseException {
-        deleteAtlasTypeDefs(typesDef, false);
-    }
-
     @DELETE
     @Path("/typedefs")
     @Experimental

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -43,6 +43,7 @@ import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -50,7 +51,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 

--- a/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/TypesREST.java
@@ -404,8 +404,9 @@ public class TypesREST {
      * Bulk delete API for all types.
      *
      * @param typesDef A composite object that captures all types to be deleted.
-     * @param forceDelete If true, bypasses pre-delete validation checks and forcefully removes type definitions.
-     *                    For BusinessMetadata types:
+     * @param forceDelete Supported only for BusinessMetadata typedefs:
+     *                    If true, bypasses pre-delete validation checks and forcefully removes the type definition.
+     *                    For BusinessMetadata only:
      *                    - If isIndexable=true and force=false: performs normal graph scan validation
      *                    - If isIndexable=false and force=false: blocks deletion (requires force=true)
      *                    - If force=true: skips all validation and deletes the type
@@ -437,8 +438,9 @@ public class TypesREST {
     /**
      * Delete API for type identified by its name.
      * @param typeName Name of the type to be deleted.
-     * @param forceDelete If true, bypasses pre-delete validation checks and forcefully removes the type definition.
-     *                    For BusinessMetadata types:
+     * @param forceDelete Supported only for BusinessMetadata typedefs:
+     *                    If true, bypasses pre-delete validation checks and forcefully removes the type definition.
+     *                    For BusinessMetadata only:
      *                    - If isIndexable=true and force=false: performs normal graph scan validation
      *                    - If isIndexable=false and force=false: blocks deletion (requires force=true)
      *                    - If force=true: skips all validation and deletes the type

--- a/webapp/src/test/java/org/apache/atlas/web/adapters/TypeDefsRESTTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/adapters/TypeDefsRESTTest.java
@@ -108,7 +108,7 @@ public class TypeDefsRESTTest {
         AtlasErrorCode errorCode = null;
 
         try {
-            typesREST.deleteAtlasTypeByName(bmWithAllTypes);
+            typesREST.deleteAtlasTypeByName(bmWithAllTypes, false);
         } catch (AtlasBaseException e) {
             errorCode = e.getAtlasErrorCode();
         }
@@ -124,7 +124,7 @@ public class TypeDefsRESTTest {
         errorCode = null;
 
         try {
-            typesREST.deleteAtlasTypeByName(bmWithAllTypes);
+            typesREST.deleteAtlasTypeByName(bmWithAllTypes, false);
         } catch (AtlasBaseException e) {
             errorCode = e.getAtlasErrorCode();
         }
@@ -135,7 +135,7 @@ public class TypeDefsRESTTest {
 
         entityREST.removeBusinessAttributes(dbEntity.getGuid(), bmWithAllTypes, objectMap);
 
-        typesREST.deleteAtlasTypeByName(bmWithAllTypes);
+        typesREST.deleteAtlasTypeByName(bmWithAllTypes, false);
     }
 
     @Test
@@ -155,7 +155,7 @@ public class TypeDefsRESTTest {
         AtlasErrorCode errorCode = null;
 
         try {
-            typesREST.deleteAtlasTypeByName(bmWithSuperType);
+            typesREST.deleteAtlasTypeByName(bmWithSuperType, false);
         } catch (AtlasBaseException e) {
             errorCode = e.getAtlasErrorCode();
         }
@@ -171,7 +171,7 @@ public class TypeDefsRESTTest {
         errorCode = null;
 
         try {
-            typesREST.deleteAtlasTypeByName(bmWithSuperType);
+            typesREST.deleteAtlasTypeByName(bmWithSuperType, false);
         } catch (AtlasBaseException e) {
             errorCode = e.getAtlasErrorCode();
         }
@@ -182,7 +182,7 @@ public class TypeDefsRESTTest {
 
         entityREST.removeBusinessAttributes(dbEntity.getGuid(), bmWithSuperType, objectMap);
 
-        typesREST.deleteAtlasTypeByName(bmWithSuperType);
+        typesREST.deleteAtlasTypeByName(bmWithSuperType, false);
     }
 
     @Test

--- a/webapp/src/test/java/org/apache/atlas/web/adapters/TypeDefsRESTTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/adapters/TypeDefsRESTTest.java
@@ -209,7 +209,7 @@ public class TypeDefsRESTTest {
         AtlasErrorCode errorCode = null;
 
         try {
-            typesREST.deleteAtlasTypeDefs(atlasTypesDef);
+            typesREST.deleteAtlasTypeDefs(atlasTypesDef, false);
         } catch (AtlasBaseException e) {
             errorCode = e.getAtlasErrorCode();
         }
@@ -227,7 +227,7 @@ public class TypeDefsRESTTest {
         errorCode = null;
 
         try {
-            typesREST.deleteAtlasTypeDefs(atlasTypesDef);
+            typesREST.deleteAtlasTypeDefs(atlasTypesDef, false);
         } catch (AtlasBaseException e) {
             errorCode = e.getAtlasErrorCode();
         }
@@ -243,7 +243,7 @@ public class TypeDefsRESTTest {
         errorCode = null;
 
         try {
-            typesREST.deleteAtlasTypeDefs(atlasTypesDef);
+            typesREST.deleteAtlasTypeDefs(atlasTypesDef, false);
         } catch (AtlasBaseException e) {
             errorCode = e.getAtlasErrorCode();
         }
@@ -254,7 +254,7 @@ public class TypeDefsRESTTest {
 
         entityREST.removeBusinessAttributes(dbEntity.getGuid(), bmWithAllTypesMV, objectMap);
 
-        typesREST.deleteAtlasTypeDefs(atlasTypesDef);
+        typesREST.deleteAtlasTypeDefs(atlasTypesDef, false);
     }
 
     private void createTestEntity() throws AtlasBaseException {

--- a/webapp/src/test/java/org/apache/atlas/web/rest/TypesRESTTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/rest/TypesRESTTest.java
@@ -593,16 +593,16 @@ public class TypesRESTTest {
     public void testDeleteAtlasTypeByName_Success() throws AtlasBaseException {
         // Setup
         String typeName = "test_type";
-        doNothing().when(typeDefStore).deleteTypeByName(typeName);
+        doNothing().when(typeDefStore).deleteTypeByName(typeName, false);
 
         try (MockedStatic<AtlasPerfTracer> mockedPerfTracer = mockStatic(AtlasPerfTracer.class)) {
             mockedPerfTracer.when(() -> AtlasPerfTracer.isPerfTraceEnabled(any())).thenReturn(false);
 
             // Execute
-            typesREST.deleteAtlasTypeByName(typeName);
+            typesREST.deleteAtlasTypeByName(typeName, false);
 
             // Verify
-            verify(typeDefStore).deleteTypeByName(typeName);
+            verify(typeDefStore).deleteTypeByName(typeName, false);
         }
     }
 
@@ -610,17 +610,17 @@ public class TypesRESTTest {
     public void testDeleteAtlasTypeByName_WithPerfTracerEnabled() throws AtlasBaseException {
         // Setup
         String typeName = "test_type_perf";
-        doNothing().when(typeDefStore).deleteTypeByName(typeName);
+        doNothing().when(typeDefStore).deleteTypeByName(typeName, false);
 
         try (MockedStatic<AtlasPerfTracer> mockedPerfTracer = mockStatic(AtlasPerfTracer.class)) {
             mockedPerfTracer.when(() -> AtlasPerfTracer.isPerfTraceEnabled(any())).thenReturn(true);
             mockedPerfTracer.when(() -> AtlasPerfTracer.getPerfTracer(any(), anyString())).thenReturn(null);
 
             // Execute
-            typesREST.deleteAtlasTypeByName(typeName);
+            typesREST.deleteAtlasTypeByName(typeName, false);
 
             // Verify
-            verify(typeDefStore).deleteTypeByName(typeName);
+            verify(typeDefStore).deleteTypeByName(typeName, false);
             mockedPerfTracer.verify(() -> AtlasPerfTracer.isPerfTraceEnabled(any()));
             mockedPerfTracer.verify(() -> AtlasPerfTracer.getPerfTracer(any(), anyString()));
         }
@@ -631,18 +631,35 @@ public class TypesRESTTest {
         // Setup
         String typeName = "test_type_error";
         AtlasBaseException exception = new AtlasBaseException("Delete by name failed");
-        doThrow(exception).when(typeDefStore).deleteTypeByName(typeName);
+        doThrow(exception).when(typeDefStore).deleteTypeByName(typeName, false);
 
         try (MockedStatic<AtlasPerfTracer> mockedPerfTracer = mockStatic(AtlasPerfTracer.class)) {
             mockedPerfTracer.when(() -> AtlasPerfTracer.isPerfTraceEnabled(any())).thenReturn(false);
 
             // Execute & Verify
             AtlasBaseException thrownException = expectThrows(AtlasBaseException.class, () -> {
-                typesREST.deleteAtlasTypeByName(typeName);
+                typesREST.deleteAtlasTypeByName(typeName, false);
             });
 
             assertEquals(thrownException.getMessage(), "Delete by name failed");
-            verify(typeDefStore).deleteTypeByName(typeName);
+            verify(typeDefStore).deleteTypeByName(typeName, false);
+        }
+    }
+
+    @Test
+    public void testDeleteAtlasTypeByName_WithForceDelete() throws AtlasBaseException {
+        // Setup
+        String typeName = "test_type_force";
+        doNothing().when(typeDefStore).deleteTypeByName(typeName, true);
+
+        try (MockedStatic<AtlasPerfTracer> mockedPerfTracer = mockStatic(AtlasPerfTracer.class)) {
+            mockedPerfTracer.when(() -> AtlasPerfTracer.isPerfTraceEnabled(any())).thenReturn(false);
+
+            // Execute with force=true
+            typesREST.deleteAtlasTypeByName(typeName, true);
+
+            // Verify
+            verify(typeDefStore).deleteTypeByName(typeName, true);
         }
     }
 

--- a/webapp/src/test/java/org/apache/atlas/web/rest/TypesRESTTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/rest/TypesRESTTest.java
@@ -540,7 +540,7 @@ public class TypesRESTTest {
             mockedAtlasTypeUtil.when(() -> AtlasTypeUtil.toDebugString(mockTypesDef)).thenReturn("debug_string");
 
             // Execute
-            typesREST.deleteAtlasTypeDefs(mockTypesDef);
+            typesREST.deleteAtlasTypeDefs(mockTypesDef, false);
 
             // Verify
             verify(typeDefStore).deleteTypesDef(mockTypesDef, false);
@@ -559,7 +559,7 @@ public class TypesRESTTest {
             mockedAtlasTypeUtil.when(() -> AtlasTypeUtil.toDebugString(mockTypesDef)).thenReturn("debug_string");
 
             // Execute
-            typesREST.deleteAtlasTypeDefs(mockTypesDef);
+            typesREST.deleteAtlasTypeDefs(mockTypesDef, false);
 
             // Verify
             verify(typeDefStore).deleteTypesDef(mockTypesDef, false);
@@ -581,7 +581,7 @@ public class TypesRESTTest {
 
             // Execute & Verify
             AtlasBaseException thrownException = expectThrows(AtlasBaseException.class, () -> {
-                typesREST.deleteAtlasTypeDefs(mockTypesDef);
+                typesREST.deleteAtlasTypeDefs(mockTypesDef, false);
             });
 
             assertEquals(thrownException.getMessage(), "Delete failed");

--- a/webapp/src/test/java/org/apache/atlas/web/rest/TypesRESTTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/rest/TypesRESTTest.java
@@ -532,7 +532,7 @@ public class TypesRESTTest {
     @Test
     public void testDeleteAtlasTypeDefs_Success() throws AtlasBaseException {
         // Setup
-        doNothing().when(typeDefStore).deleteTypesDef(mockTypesDef);
+        doNothing().when(typeDefStore).deleteTypesDef(mockTypesDef, false);
 
         try (MockedStatic<AtlasPerfTracer> mockedPerfTracer = mockStatic(AtlasPerfTracer.class);
                 MockedStatic<AtlasTypeUtil> mockedAtlasTypeUtil = mockStatic(AtlasTypeUtil.class)) {
@@ -543,14 +543,14 @@ public class TypesRESTTest {
             typesREST.deleteAtlasTypeDefs(mockTypesDef);
 
             // Verify
-            verify(typeDefStore).deleteTypesDef(mockTypesDef);
+            verify(typeDefStore).deleteTypesDef(mockTypesDef, false);
         }
     }
 
     @Test
     public void testDeleteAtlasTypeDefs_WithPerfTracerEnabled() throws AtlasBaseException {
         // Setup
-        doNothing().when(typeDefStore).deleteTypesDef(mockTypesDef);
+        doNothing().when(typeDefStore).deleteTypesDef(mockTypesDef, false);
 
         try (MockedStatic<AtlasPerfTracer> mockedPerfTracer = mockStatic(AtlasPerfTracer.class);
                 MockedStatic<AtlasTypeUtil> mockedAtlasTypeUtil = mockStatic(AtlasTypeUtil.class)) {
@@ -562,7 +562,7 @@ public class TypesRESTTest {
             typesREST.deleteAtlasTypeDefs(mockTypesDef);
 
             // Verify
-            verify(typeDefStore).deleteTypesDef(mockTypesDef);
+            verify(typeDefStore).deleteTypesDef(mockTypesDef, false);
             mockedPerfTracer.verify(() -> AtlasPerfTracer.isPerfTraceEnabled(any()));
             mockedPerfTracer.verify(() -> AtlasPerfTracer.getPerfTracer(any(), anyString()));
         }
@@ -572,7 +572,7 @@ public class TypesRESTTest {
     public void testDeleteAtlasTypeDefs_WithException() throws AtlasBaseException {
         // Setup
         AtlasBaseException exception = new AtlasBaseException("Delete failed");
-        doThrow(exception).when(typeDefStore).deleteTypesDef(mockTypesDef);
+        doThrow(exception).when(typeDefStore).deleteTypesDef(mockTypesDef, false);
 
         try (MockedStatic<AtlasPerfTracer> mockedPerfTracer = mockStatic(AtlasPerfTracer.class);
                 MockedStatic<AtlasTypeUtil> mockedAtlasTypeUtil = mockStatic(AtlasTypeUtil.class)) {
@@ -585,7 +585,25 @@ public class TypesRESTTest {
             });
 
             assertEquals(thrownException.getMessage(), "Delete failed");
-            verify(typeDefStore).deleteTypesDef(mockTypesDef);
+            verify(typeDefStore).deleteTypesDef(mockTypesDef, false);
+        }
+    }
+
+    @Test
+    public void testDeleteAtlasTypeDefs_WithForceDelete() throws AtlasBaseException {
+        // Setup
+        doNothing().when(typeDefStore).deleteTypesDef(mockTypesDef, true);
+
+        try (MockedStatic<AtlasPerfTracer> mockedPerfTracer = mockStatic(AtlasPerfTracer.class);
+                MockedStatic<AtlasTypeUtil> mockedAtlasTypeUtil = mockStatic(AtlasTypeUtil.class)) {
+            mockedPerfTracer.when(() -> AtlasPerfTracer.isPerfTraceEnabled(any())).thenReturn(false);
+            mockedAtlasTypeUtil.when(() -> AtlasTypeUtil.toDebugString(mockTypesDef)).thenReturn("debug_string");
+
+            // Execute
+            typesREST.deleteAtlasTypeDefs(mockTypesDef, true);
+
+            // Verify
+            verify(typeDefStore).deleteTypesDef(mockTypesDef, true);
         }
     }
 


### PR DESCRIPTION
**ATLAS-4988**
**What changes were proposed in this pull request?**
Background: In Apache Atlas, deleting a Business Metadata (BM) definition requires a pre-check to ensure no existing entities are assigned to those attributes. For attributes with a data type of Array (multi-valued), the deletion process was taking an exceptionally long time (e.g., over 55 minutes for -1,18,300 entities), even when the BM was not assigned to any entity.

**Root Cause:**

1. Array attributes are not Solr-indexed
ARRAY BM attributes are not indexed in Solr.
Solr therefore performs a full collection scan when queried with NOT_EMPTY, causing severe latency.
2. Single-path Solr validation
The previous logic forced all BM attributes (STRING + ARRAY) through Solr.
This was efficient for STRING attributes but pathological for ARRAY attributes.
3. Historical entities ignored
The earlier implementation excluded deleted entities.
This allowed historical BM references to be missed, leading to potential integrity violations.
4. Unnecessary data retrieval
The Solr query requested attribute payloads, increasing I/O cost even though only existence was required.


**Changes Proposed:**

1. Check BM usage in the graph, not in Solr
Before removing a Business Metadata (BM) type, we see if any entity vertex still has the BM property set. That is done with a JanusGraph query on the right vertex property name, instead of using the search index for an “is it used?” check.
2. One graph query instead of two
The “is this BM attribute used?” check used to run two graph queries (direct type match, then supertype match). It now uses one query with an OR: match the entity’s type or any of its super types. We stop after one matching vertex.
3. Honor subtypes when deciding which entity types count
We still expand the configured “applicable entity types” to include subtypes, so a delete does not miss usage on child types. The expansion logic was tightened to go through AtlasEntityType from the type registry.
4. Cache work on the BM type object
AtlasBusinessMetadataType now remembers whether the definition has any non-indexable attribute, and (in a later resolution phase) caches each attribute’s applicable type names including subtypes. Delete uses that cache when present, and falls back to computing from the attribute definition when the cache is empty.
5. force delete for BM only
typedef delete APIs accept force (bulk and delete-by-name). For BM, force=true skips the reference checks and deletes the type anyway (with a warning that orphaned values may stay on entities). The bulk path passes force only into the BM delete loop, other typedef kinds are not supposed to bypass their usual rules because of this flag.
6. Block non-indexable BM unless force is true
If any BM attribute is non-indexable and force is false, delete is rejected with a new error code that tells the user they must use force=true if they accept skipping validation. The rules for treating “indexable” were fixed so null/false on the flag is handled consistently.
7. Plumbing in the typedef store
AtlasDefStore and AtlasAbstractDefStoreV2 gained overloads that carry forceDelete through pre-delete and delete. Non-BM stores keep the old behavior via default methods. deleteByName / deleteByGuid without force now simply call the overload with force=false so there is a single code path.
8. Tests and fixtures
Added and updated tests for BM delete (including mixed indexable / non-indexable and force), REST, client, and graph store.


**Impact**:

Performance Gain: BM typedef delete no longer relies on search for the “is this attribute still used?” step. It uses a small JanusGraph lookup (property present, type or supertype match, stop at one vertex) and reuses cached type lists from AtlasBusinessMetadataType. On large deployments this typically means much shorter and more predictable delete times than the old search-heavy path, especially where attributes were not usefully indexed for that check. 

**API and compatibility**:
Other typedef categories do not get a new “force bypass” through bulk delete; only the BM path uses force as described. Existing clients that omit force keep previous behavior for non-BM deletes.

**Scalability**:
Faster, more predictable BM deletes on big catalogs by using graph existence checks and cached subtype-aware type sets.

**How was this patch tested?**
Maven Build:
Build Successful.

**Manual API tests (curl) BM & Non-BM :**

1. Creation & deletion (no assignment): Created BM with string and array-of-string attributes (indexable), then deleted via DELETE /api/atlas/v2/types/typedefs and DELETE /api/atlas/v2/types/typedef/name/{typeName} with force=false. Expected 204; delete completed.
2. Deletion blocked (with assignment --> indexable BM): Assigned BM to a hive_table (and custom entity types), then tried to remove the BM typedef without force. Deletion was blocked with 409 and TYPE_HAS_REFERENCES.
3. Force delete (Bypass): With BM still assigned, called the same DELETEs with ?force=true. Got 204 and saw the force-delete log path (validation skipped; possible orphaned values on entities).
4. Non-indexable BM: Created BM with isIndexable: false; without force, delete returned 400 / NON_INDEXABLE_BM_DELETE_NOT_ALLOWED; with force=true, delete returned 204.
5. Non-BM typedefs (classifications and other categories): Used bulk DELETE /api/atlas/v2/types/typedefs for non-BM typedefs with force=false vs force=true. No instances --> 204 in both cases; instances still present --> 409 in both cases
 --> force does not bypass reference checks outside BM.
 
 
**API Usage Note: force on typedef delete (ATLAS-4988)**
**Supported Endpoints**
**Bulk delete**
DELETE /api/atlas/v2/types/typedefs?force=true|false
**Delete by name**
DELETE /api/atlas/v2/types/typedef/name/{typeName}?force=true|false
force is optional and defaults to false.

**Important: force only affects Business Metadata typedefs**
The force parameter is meaningful only for deleting Business Metadata (businessMetadataDefs) typedefs.
When deleting a Business Metadata type:
force=false (default)
Performs the standard pre-delete reference validation.
If the BM is still assigned to entities, deletion fails with reference-related errors.
force=true
Skips the pre-delete reference validation and deletes the Business Metadata typedef even if references still exist.
This may leave orphaned BM values on entities.
**Non-Business Metadata typedefs**
For all other typedef categories (enum, struct, classification, entity, relationship, etc.), the force parameter does not bypass existing validation or reference checks.
Behavior for these typedefs remains unchanged from previous releases:
Types without references can still be deleted successfully.
Types with existing references or instances continue to fail with errors such as:
409 / TYPE_HAS_REFERENCES
This behavior is consistent regardless of whether force=true or force=false is supplied.
