### PR TITLE
ATLAS-5189: Decrypt postgres password

### DIFF
--- a/graphdb/janusgraph-rdbms/pom.xml
+++ b/graphdb/janusgraph-rdbms/pom.xml
@@ -39,6 +39,10 @@
             <version>${HikariCP.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>atlas-intg</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>
             <version>${eclipse.jpa.version}</version>

--- a/intg/src/main/java/org/apache/atlas/ApplicationProperties.java
+++ b/intg/src/main/java/org/apache/atlas/ApplicationProperties.java
@@ -67,7 +67,7 @@ public final class ApplicationProperties extends PropertiesConfiguration {
     public static final String       AD                               = "AD";
     public static final String       LDAP_AD_BIND_PASSWORD            = "atlas.authentication.method.ldap.ad.bind.password";
     public static final String       LDAP_BIND_PASSWORD               = "atlas.authentication.method.ldap.bind.password";
-    public static final String       MASK_LDAP_PASSWORD               = "********";
+    public static final String       MASK_PASSWORD                    = "********";
     public static final String       DEFAULT_GRAPHDB_BACKEND          = GRAPHBD_BACKEND_JANUS;
     public static final boolean      DEFAULT_SOLR_WAIT_SEARCHER       = false;
     public static final boolean      DEFAULT_INDEX_MAP_NAME           = false;
@@ -342,7 +342,7 @@ public final class ApplicationProperties extends PropertiesConfiguration {
                 if (ldapType.equalsIgnoreCase(LDAP)) {
                     String maskPasssword = configuration.getString(LDAP_BIND_PASSWORD);
 
-                    if (MASK_LDAP_PASSWORD.equals(maskPasssword)) {
+                    if (MASK_PASSWORD.equals(maskPasssword)) {
                         String password = SecurityUtil.getPassword(configuration, LDAP_BIND_PASSWORD, HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH);
 
                         configuration.clearProperty(LDAP_BIND_PASSWORD);
@@ -351,7 +351,7 @@ public final class ApplicationProperties extends PropertiesConfiguration {
                 } else if (ldapType.equalsIgnoreCase(AD)) {
                     String maskPasssword = configuration.getString(LDAP_AD_BIND_PASSWORD);
 
-                    if (MASK_LDAP_PASSWORD.equals(maskPasssword)) {
+                    if (MASK_PASSWORD.equals(maskPasssword)) {
                         String password = SecurityUtil.getPassword(configuration, LDAP_AD_BIND_PASSWORD, HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH);
 
                         configuration.clearProperty(LDAP_AD_BIND_PASSWORD);
@@ -362,6 +362,20 @@ public final class ApplicationProperties extends PropertiesConfiguration {
                 LOG.error("Error in getting secure password ", e);
             }
         }
+    }
+
+    public static String getDecryptedPassword(Configuration configuration, String propertyKey) {
+        String configuredValue = configuration != null ? configuration.getString(propertyKey) : null;
+
+        if (configuredValue != null && MASK_PASSWORD.equals(configuredValue)) {
+            try {
+                return SecurityUtil.getPassword(configuration, propertyKey, HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH);
+            } catch (Exception e) {
+                LOG.error("Error in getting secure password ", e);
+            }
+        }
+
+        return configuredValue;
     }
 
     private void setDefaults() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Approach:-:
Encryption: 
Use cputil.py   tool to encrypt password for key "atlas.graph.storage.rdbms.jpa.hikari.password" which will be then stored in jceks file along with password and Atlas will decrypt using new method added as getDecryptedPassword and set it in hikari data source

Expectation:-:
Encrypt password for rdbms db
atlas.graph.storage.rdbms.jpa.hikari.username=atlas
atlas.graph.storage.rdbms.jpa.hikari.password=password(we should set it as ********)
1.When a user will add password property in application.properties manually we should encrypt the password and send it to postgres
we should avoid plaintext password

## How was this patch tested?

**Created jceks file using below command** 
-k is for key
-p password to encrypt
-f jceks file path 

Enter path for jceks file in atlas-application.properties to this key **hadoop.security.credential.provider.path**=jceks://file/home/chaitali/project/forkbranch/atlas/rdbms.jceks

 ./cputil.py  -k atlas.graph.storage.rdbms.jpa.hikari.password -p  password -f jceks://file/home/project/forkbranch/atlas/rdbms.jceks

Check in the file path your jceks file should be created now

**Assign your provider path like below in atlas-application.properties file** 
hadoop.security.credential.provider.path=jceks://file/home/chaitali/project/forkbranch/atlas/rdbms.jceks

**Assign password in * format to this hikari password property**
atlas.graph.storage.rdbms.jpa.hikari.password=********

Please note it should be 8 * specifically