### PR TITLE
ATLAS-5148: Atlas DSL GROUP BY fails for non-String attributes (DATE/Long)

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphTraversal.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphTraversal.java
@@ -114,9 +114,9 @@ public class AtlasJanusGraphTraversal extends AtlasGraphTraversal<AtlasJanusVert
             ret = new HashMap<>(map.size());
 
             for (Object key : map.keySet()) {
-                if (!(key instanceof String)) {
-                    continue;
-                }
+                LOG.info("Printing Key DataType: {}", key.getClass());
+
+                String keyStr = (key instanceof String) ? (String) key : String.valueOf(key);
 
                 Object value = map.get(key);
 
@@ -131,7 +131,7 @@ public class AtlasJanusGraphTraversal extends AtlasGraphTraversal<AtlasJanusVert
                         }
                     }
 
-                    ret.put((String) key, values);
+                    ret.put(keyStr, values);
                 }
             }
         } else {

--- a/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphTraversalTest.java
+++ b/graphdb/janus/src/test/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphTraversalTest.java
@@ -225,7 +225,7 @@ public class AtlasJanusGraphTraversalTest {
         List<Vertex> vertexList = new ArrayList<>();
         vertexList.add(mock(Vertex.class));
 
-        mapResult.put(123, vertexList); // Non-string key
+        mapResult.put(123, vertexList); // Non-string key (Integer)
         mapResult.put("validKey", vertexList);
         resultList.add(mapResult);
 
@@ -234,8 +234,9 @@ public class AtlasJanusGraphTraversalTest {
 
         Map<String, Collection<AtlasJanusVertex>> vertexMap = traversal.getAtlasVertexMap();
         assertNotNull(vertexMap);
-        assertEquals(vertexMap.size(), 1); // Only string keys should be included
+        assertEquals(vertexMap.size(), 2);
         assertNotNull(vertexMap.get("validKey"));
+        assertNotNull(vertexMap.get("123")); // Integer key converted to String
     }
 
     @Test
@@ -269,6 +270,44 @@ public class AtlasJanusGraphTraversalTest {
         Map<String, Collection<AtlasJanusVertex>> vertexMap = traversal.getAtlasVertexMap();
         assertNotNull(vertexMap);
         assertTrue(vertexMap.isEmpty());
+    }
+
+    @Test
+    public void testGetAtlasVertexMapWithLongKeysForDSLGroupByCreateTime() throws Exception {
+        List<Object> resultList = new ArrayList<>();
+        Map<Object, Object> mapResult = new HashMap<>();
+
+        // Create mock vertices for different timestamp groups
+        List<Vertex> group1Vertices = new ArrayList<>();
+        group1Vertices.add(mock(Vertex.class));
+        group1Vertices.add(mock(Vertex.class));
+
+        List<Vertex> group2Vertices = new ArrayList<>();
+        group2Vertices.add(mock(Vertex.class));
+
+        List<Vertex> group3Vertices = new ArrayList<>();
+        group3Vertices.add(mock(Vertex.class));
+        group3Vertices.add(mock(Vertex.class));
+        group3Vertices.add(mock(Vertex.class));
+
+        // Add groups with Long keys (simulating createTime timestamps)
+        mapResult.put(1700000000000L, group1Vertices); // Timestamp 1
+        mapResult.put(1710000000000L, group2Vertices); // Timestamp 2
+        mapResult.put(1720000000000L, group3Vertices); // Timestamp 3
+
+        resultList.add(mapResult);
+        setResultList(traversal, resultList);
+
+        Map<String, Collection<AtlasJanusVertex>> vertexMap = traversal.getAtlasVertexMap();
+        // Verify results
+        assertNotNull(vertexMap);
+        assertEquals(vertexMap.size(), 3); // All Long keys converted to String
+        assertNotNull(vertexMap.get("1700000000000")); // Verify Long converted to String
+        assertNotNull(vertexMap.get("1710000000000"));
+        assertNotNull(vertexMap.get("1720000000000"));
+        assertEquals(vertexMap.get("1700000000000").size(), 2); // 2 vertices in group1
+        assertEquals(vertexMap.get("1710000000000").size(), 1); // 1 vertex in group2
+        assertEquals(vertexMap.get("1720000000000").size(), 3); // 3 vertices in group3
     }
 
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Problem Description (Before Fix)**
1. GROUP BY works only for String attributes

Query:
Table groupby(owner)
Conclusion: Works

Query:
Table groupby(createTime)
Conclusion: Returns no records

Both owner (String) and createTime (Date/Long) attributes exist on the same hive_table entities.

2. GROUP BY with SELECT fails for DATE attributes

Query:
Table groupby(createTime) select owner, name, max(createTime)
Conclusion: Returns no records

Similar query using a String attribute works as expected:
Table groupby(owner) select owner, count()
Conclusion: Works

3. Root Cause
GROUP BY keys were handled only for String data types
When grouping by non-String attributes (Date/Long), valid group keys were dropped during result processing
This resulted in empty results even though grouping succeeded internally


**Fix Description (After Fix)**
1. Handle GROUP BY keys of any data type

Updated method:
AtlasJanusGraphTraversal.getAtlasVertexMap()

Logic change:
String keyStr = (key instanceof String) ? (String) key : String.valueOf(key);

This converts GROUP BY keys of type Long, Date, Integer, etc. into String. Prevents valid GROUP BY results from being dropped

2. GROUP BY on DATE attributes now works correctly

Query:
Table groupby(createTime)
Conclusion: Returns grouped results

3. DSL queries now behave as documented

The following queries now return valid results:
Table groupby(createTime) select owner, name, min(createTime)
Table groupby(createTime) select owner, name, max(createTime)


## How was this patch tested?

. UI testing
. Local Build (jdk8/17)
. PC: https://ci-builds.apache.org/job/Atlas/job/PreCommit-ATLAS-Build-Test/2029/
. CI workflow