### PR TITLE
ATLAS-4071: Use remove() instead of rename loop when deleting property keys

### DIFF
--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphManagement.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphManagement.java
@@ -195,14 +195,7 @@ public class AtlasJanusGraphManagement implements AtlasGraphManagement {
             return;
         }
 
-        for (int i = 0; ; i++) {
-            String deletedKeyName = janusPropertyKey + "_deleted_" + i;
-
-            if (null == management.getPropertyKey(deletedKeyName)) {
-                management.changeName(janusPropertyKey, deletedKeyName);
-                break;
-            }
-        }
+        janusPropertyKey.remove();
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes the issue where after deleting a type, new insertions fail when using Elasticsearch as the index backend.

Previously, the code attempted to delete property keys by renaming them with a "_deleted_N" suffix in a loop. This approach left the property keys in the graph, causing schema conflicts with ES and preventing subsequent insertions. This change uses the remove() method to properly delete the property key, resolving the conflict.

## How was this patch tested?

Create a type and delete it. You can recreate it again successfully.