### PR TITLE
ATLAS-5242: Bump GitHub action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
       - name: Cache for maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository/*/*/*
@@ -57,7 +57,7 @@ jobs:
           chmod -R 777 ./
       
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -88,14 +88,14 @@ jobs:
           mv -f target/coverage dev-support/atlas-docker/dist/
 
       - name: Upload Code Coverage Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: dev-support/atlas-docker/dist/coverage/*
 
       - name: Cache downloaded archives
         if: success()
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: dev-support/atlas-docker/downloads
           key: ${{ runner.os }}-atlas-downloads-${{ hashFiles('dev-support/atlas-docker/.env') }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Node.js 20 is [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) in GitHub runners. Bump GitHub actions versions to the latest ones for Node.js 24 support.

https://issues.apache.org/jira/browse/ATLAS-5242


## How was this patch tested?

No warnings observed in CI run: https://github.com/kumaab/atlas/actions/runs/23176419841/job/67339482471