### PR TITLE
ATLAS-5270: Import scripts fails to create log file

### DIFF
--- a/addons/hbase-bridge/pom.xml
+++ b/addons/hbase-bridge/pom.xml
@@ -596,6 +596,16 @@
                                             <artifactId>logback-classic</artifactId>
                                             <version>${logback.version}</version>
                                         </artifactItem>
+                                        <artifactItem>
+                                            <groupId>ch.qos.logback</groupId>
+                                            <artifactId>logback-core</artifactId>
+                                            <version>${logback.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.slf4j</groupId>
+                                            <artifactId>slf4j-api</artifactId>
+                                            <version>${slf4j.version}</version>
+                                        </artifactItem>
                                     </artifactItems>
                                 </configuration>
                             </execution>

--- a/addons/hbase-bridge/src/bin/import-hbase.sh
+++ b/addons/hbase-bridge/src/bin/import-hbase.sh
@@ -125,9 +125,9 @@ else
 fi
 
 if [ ! -z "$HADOOP_CP" ]; then
-  CP="${HBASE_CP}:${HADOOP_CP}:${ATLASCPPATH}"
+  CP="${ATLASCPPATH}:${HBASE_CP}:${HADOOP_CP}"
 else
-  CP="${HBASE_CP}:${ATLASCPPATH}"
+  CP="${ATLASCPPATH}:${HBASE_CP}"
 fi
 
 # If running in cygwin, convert pathnames and classpath to Windows format.
@@ -141,7 +141,7 @@ then
 fi
 
 JAVA_PROPERTIES="$ATLAS_OPTS -Datlas.log.dir=$ATLAS_LOG_DIR -Datlas.log.file=import-hbase.log
--Dlog4j.configuration=atlas-hbase-import-log4j.xml"
+-Dlogback.configurationFile=atlas-hbase-import-logback.xml"
 
 IMPORT_ARGS=
 JVM_ARGS=

--- a/addons/hive-bridge/pom.xml
+++ b/addons/hive-bridge/pom.xml
@@ -530,6 +530,16 @@
                                             <artifactId>logback-classic</artifactId>
                                             <version>${logback.version}</version>
                                         </artifactItem>
+                                        <artifactItem>
+                                            <groupId>ch.qos.logback</groupId>
+                                            <artifactId>logback-core</artifactId>
+                                            <version>${logback.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.slf4j</groupId>
+                                            <artifactId>slf4j-api</artifactId>
+                                            <version>${slf4j.version}</version>
+                                        </artifactItem>
                                     </artifactItems>
                                 </configuration>
                             </execution>

--- a/addons/hive-bridge/src/bin/import-hive.sh
+++ b/addons/hive-bridge/src/bin/import-hive.sh
@@ -131,7 +131,7 @@ then
 fi
 
 JAVA_PROPERTIES="$ATLAS_OPTS -Datlas.log.dir=$ATLAS_LOG_DIR -Datlas.log.file=import-hive.log
--Dlog4j.configuration=atlas-hive-import-log4j.xml"
+-Dlogback.configurationFile=atlas-hive-import-logback.xml"
 
 IMPORT_ARGS=
 JVM_ARGS=

--- a/addons/kafka-bridge/pom.xml
+++ b/addons/kafka-bridge/pom.xml
@@ -509,6 +509,21 @@
                                             <artifactId>hadoop-common</artifactId>
                                             <version>${hadoop.version}</version>
                                         </artifactItem>
+                                        <artifactItem>
+                                            <groupId>ch.qos.logback</groupId>
+                                            <artifactId>logback-classic</artifactId>
+                                            <version>${logback.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>ch.qos.logback</groupId>
+                                            <artifactId>logback-core</artifactId>
+                                            <version>${logback.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.slf4j</groupId>
+                                            <artifactId>slf4j-api</artifactId>
+                                            <version>${slf4j.version}</version>
+                                        </artifactItem>
                                     </artifactItems>
                                 </configuration>
                             </execution>

--- a/addons/kafka-bridge/src/bin/import-kafka.sh
+++ b/addons/kafka-bridge/src/bin/import-kafka.sh
@@ -121,7 +121,7 @@ then
 fi
 
 JAVA_PROPERTIES="$ATLAS_OPTS -Datlas.log.dir=$ATLAS_LOG_DIR -Datlas.log.file=import-kafka.log
--Dlog4j.configuration=atlas-kafka-import-log4j.xml"
+-Dlogback.configurationFile=atlas-kafka-import-logback.xml"
 shift
 
 while [[ ${1} =~ ^\-D ]]; do


### PR DESCRIPTION
## What changes were proposed in this pull request?

Issue: import scripts don't get created in the path: /var/log/atlas.


## How was this patch tested?

- Tested and verified import scripts for (hbase, hive, kafka) ran successfully and created log file in path: /var/log/atlas
- mvn build