### PR TITLE
ATLAS-5229: TypeDef patches to update unnecessary indexed attributes …

### DIFF
--- a/addons/models/0000-Area0/patches/008-base_model_update_ddl_querytext_attribute.json
+++ b/addons/models/0000-Area0/patches/008-base_model_update_ddl_querytext_attribute.json
@@ -1,0 +1,14 @@
+{
+  "patches": [
+    {
+      "id": "TYPEDEF_PATCH_0008_001",
+      "description": "Update isIndexable to False for ddl.queryText attribute in BaseModel",
+      "action": "UPDATE_ATTRIBUTE_METADATA",
+      "typeName": "ddl",
+      "applyToVersion": "1.0",
+      "updateToVersion": "1.1",
+      "attributeName":   "queryText",
+      "params": { "isIndexable": false }
+    }
+  ]
+}


### PR DESCRIPTION
…to false

## What changes were proposed in this pull request?

This patch handles the typeDef patches to disable the unnecessary attribute indexes

## How was this patch tested?

This patch was tested along with ATLAS-5227