### PR TITLE
ATLAS-5274: [Impala Hook] Self-referencing INSERT OVERWRITE produces …

### DIFF
--- a/addons/impala-bridge/src/main/java/org/apache/atlas/impala/hook/events/CreateImpalaProcess.java
+++ b/addons/impala-bridge/src/main/java/org/apache/atlas/impala/hook/events/CreateImpalaProcess.java
@@ -89,6 +89,10 @@ public class CreateImpalaProcess extends BaseImpalaEvent {
 
                 if (entity != null) {
                     inputs.add(entity);
+                    if (outputNodes.contains(input)) {
+                        // Include self-referencing entities in outputs to preserve circular lineage; otherwise they’re skipped as already processed inputs.
+                        outputs.add(entity);
+                    }
                 }
             }
         }


### PR DESCRIPTION
…impala_process with empty outputs[], breaking lineage

## What changes were proposed in this pull request?

earlier for impala insert overwrite (DML QUERY) shows the wrong lineage graph :
<img width="556" height="204" alt="image" src="https://github.com/user-attachments/assets/22d9397e-ae37-4ac9-9258-dc0577a95d8d" />

now after these changes lineage will look like this :
<img width="532" height="204" alt="image" src="https://github.com/user-attachments/assets/19c69c40-6e54-4abf-9417-7344f92fcdb7" />

explanation :
getEntities() walks inputNodes and outputNodes and fills the process’s inputs and outputs lists, using a single processedNames set to avoid duplicates. When the same table is both read and written (e.g. self-lineage / INSERT OVERWRITE into the table you read from), its qualified name appears in both node lists. The input loop runs first and registers that name in processedNames. The output loop then treats the name as “already processed” and skips adding that table to outputs, even though it is a real write target. The fix is to dedupe per side (separate sets for inputs vs outputs) so the same qualified name can appear in both inputs and outputs when the lineage says so.

## How was this patch tested?

unit testing , mvn build 