### PR TITLE
ATLAS-5275, ATLAS-5273, ATLAS-5272:Atlas React UI redirects to Home page during tag/term assignment after Ranger policy change. REACT UI Uploaded file name is truncated in Business Metadata import modal in React UI. React UI incorrectly allows/removes Applicable Type chips in Business Metadata edit flow.

### DIFF
--- a/dashboard/src/api/apiMethods/fetchApi.ts
+++ b/dashboard/src/api/apiMethods/fetchApi.ts
@@ -20,6 +20,40 @@ import { globalSessionData } from "../../utils/Enum";
 import { toast } from "react-toastify";
 import { serverErrorHandler } from "@utils/Utils";
 
+/** Keep 403 toasts readable (Atlas authorization message). */
+const FORBIDDEN_ERROR_TOAST_MS = 5_000;
+/**
+ * Callers often `toast.dismiss(ref.current)` in catch when `ref.current` is null;
+ * react-toastify then clears all toasts and removes the 403 toast we just showed.
+ * Queue the toast as a macrotask so it runs after that dismiss.
+ */
+const FETCH_API_FORBIDDEN_TOAST_ID = "fetch-api-http-403";
+
+const showForbiddenToastLater = (
+  responseData: unknown,
+  defaultMessage: string
+) => {
+  setTimeout(() => {
+    let message = defaultMessage;
+    if (responseData && typeof responseData === "object") {
+      const d = responseData as {
+        errorMessage?: unknown;
+        message?: unknown;
+        error?: unknown;
+      };
+      message =
+        (d.errorMessage as string | undefined) ||
+        (d.message as string | undefined) ||
+        (d.error as string | undefined) ||
+        message;
+    }
+    toast.error(message, {
+      toastId: FETCH_API_FORBIDDEN_TOAST_ID,
+      autoClose: FORBIDDEN_ERROR_TOAST_MS
+    });
+  }, 0);
+};
+
 let prevNetworkErrorTime = 0;
 
 function errorHandelingForAbortAndStatus0() {
@@ -61,10 +95,12 @@ const fetchApi = async (url: string, config: AxiosRequestConfig) => {
             window.location.replace("login.jsp");
             break;
           case 403:
-            // Match classic UI (Utils.defaultErrorHandler): show API message via
-            // notify/toast only; do not redirect — user stays on current screen.
-            serverErrorHandler(
-              { responseJSON: error.response?.data },
+            // Match classic UI: toast only, no redirect. Defer toast so callers
+            // that dismiss all toasts in catch (e.g. toast.dismiss(null ref)) do
+            // not remove this notification before it is shown — see
+            // showForbiddenToastLater.
+            showForbiddenToastLater(
+              error.response?.data,
               "You are not authorized"
             );
             break;

--- a/dashboard/src/api/apiMethods/fetchApi.ts
+++ b/dashboard/src/api/apiMethods/fetchApi.ts
@@ -61,11 +61,12 @@ const fetchApi = async (url: string, config: AxiosRequestConfig) => {
             window.location.replace("login.jsp");
             break;
           case 403:
+            // Match classic UI (Utils.defaultErrorHandler): show API message via
+            // notify/toast only; do not redirect — user stays on current screen.
             serverErrorHandler(
               { responseJSON: error.response?.data },
               "You are not authorized"
             );
-            window.location.replace("login.jsp");
             break;
           case 404:
             serverErrorHandler(
@@ -99,7 +100,13 @@ const fetchApi = async (url: string, config: AxiosRequestConfig) => {
             break;
         }
       }
-      if (error.response?.statusText != "abort") {
+      // Only treat as offline / connection failure when there is no HTTP
+      // response (or status 0). Do not run this for 403/404/5xx — those are
+      // handled above and would wrongly show a network toast.
+      const res = error.response;
+      const isAbort =
+        error.code === "ERR_CANCELED" || res?.statusText === "abort";
+      if (!isAbort && (!res || Number(res.status) === 0)) {
         errorHandelingForAbortAndStatus0();
       }
     }

--- a/dashboard/src/utils/Utils.ts
+++ b/dashboard/src/utils/Utils.ts
@@ -340,6 +340,10 @@ const getEntityIconPath = (options: any) => {
 };
 
 const serverError = (error: any, toastId: any) => {
+  // fetchApi already surfaces 403 via serverErrorHandler (toast); avoid duplicate.
+  if (error?.response?.status === 403) {
+    return;
+  }
   if (
     error.response !== undefined &&
     error.response.data.errorMessage !== undefined

--- a/dashboard/src/views/BusinessMetadata/BusinessMetadataAtrributeForm.tsx
+++ b/dashboard/src/views/BusinessMetadata/BusinessMetadataAtrributeForm.tsx
@@ -33,6 +33,7 @@ import {
   FormControlLabel,
   Checkbox,
   Autocomplete,
+  Chip,
   Tooltip,
   tooltipClasses,
   TooltipProps,
@@ -235,6 +236,18 @@ const BusinessMetadataAttributeForm = ({
         : [];
 
       let enumTypeOptions = [...selectedEnumValues];
+      const isBmAttributeEdit = !isEmpty(editbmAttribute);
+      const nonRemovableApplicableTypes =
+        isBmAttributeEdit &&
+        Array.isArray(field?.options?.applicableEntityTypes)
+          ? new Set(
+              field.options.applicableEntityTypes.filter(
+                (t: unknown): t is string =>
+                  typeof t === "string" && t.length > 0
+              )
+            )
+          : null;
+
       return (
         <>
           <fieldset
@@ -832,6 +845,29 @@ const BusinessMetadataAttributeForm = ({
                               : []
                           }
                           className="advanced-search-autocomplete"
+                          renderTags={
+                            nonRemovableApplicableTypes
+                              ? (tagValue, getTagProps) =>
+                                  tagValue.map((option: string, tagIndex) => {
+                                    const tagProps = getTagProps({
+                                      index: tagIndex
+                                    });
+                                    const stripDelete =
+                                      nonRemovableApplicableTypes.has(option);
+                                    return (
+                                      <Chip
+                                        {...tagProps}
+                                        label={option}
+                                        onDelete={
+                                          stripDelete
+                                            ? undefined
+                                            : tagProps.onDelete
+                                        }
+                                      />
+                                    );
+                                  })
+                              : undefined
+                          }
                           renderInput={(params) => (
                             <TextField
                               {...params}

--- a/dashboard/src/views/SideBar/Import/ImportLayout.tsx
+++ b/dashboard/src/views/SideBar/Import/ImportLayout.tsx
@@ -19,7 +19,7 @@ import { useEffect, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { Typography, LinearProgress, Stack } from "@mui/material";
 import { toast } from "react-toastify";
-import { CustomButton } from "@components/muiComponents";
+import { CustomButton, LightTooltip } from "@components/muiComponents";
 
 const thumb = {
   position: "relative",
@@ -140,17 +140,21 @@ const ImportLayout = ({
             color="inherit"
             sx={progressCss}
           />
-          <Typography
-            sx={{
-              overflow: "hidden",
-              whiteSpace: "nowrap",
-              textOverflow: "ellipsis",
-              lineHeight: "2",
-              width: "100%"
-            }}
-          >
-            {file.name}
-          </Typography>
+          <LightTooltip title={file.name} placement="top" arrow>
+            <Typography
+              component="span"
+              sx={{
+                overflow: "hidden",
+                whiteSpace: "nowrap",
+                textOverflow: "ellipsis",
+                lineHeight: "2",
+                width: "100%",
+                display: "block"
+              }}
+            >
+              {file.name}
+            </Typography>
+          </LightTooltip>
         </Stack>
       </Stack>
       <CustomButton


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Added a proper error message for users attempting to create a classification without sufficient permissions.
- Enhanced the UI to display the full file name on hover for uploaded files. on import module.
- Updated the edit window to restrict the removal of existing types; the 'Remove' option has been disabled/removed.

## How was this patch tested?
Manually tested.
<img width="1835" height="1098" alt="Screenshot from 2026-04-26 13-45-58" src="https://github.com/user-attachments/assets/12dbd934-060b-41ea-8ecb-3c4040a37af1" />
<img width="1835" height="1098" alt="Screenshot from 2026-04-26 13-45-44" src="https://github.com/user-attachments/assets/e03d8917-9342-4f2c-8262-192fdcfc58f8" />
<img width="1849" height="1120" alt="Screenshot from 2026-04-28 14-37-04" src="https://github.com/user-attachments/assets/5a1177c7-776f-471c-9034-1dd64123973a" />

