### PR TITLE
ATLAS-5351: Add required ASF policy links to LegalFooter component

### DIFF
--- a/docs/theme/components/shared/LegalFooter/index.js
+++ b/docs/theme/components/shared/LegalFooter/index.js
@@ -69,18 +69,27 @@ export const LegalFooter = props => {
 								width="10"
 							/>
 						</LinkStyled>
-						Copyright © 2011-2018 The Apache Software Foundation.
+						Copyright © 2011-2026 The Apache Software Foundation.
 						Licensed under the{" "}
 						<LinkStyled href="https://www.apache.org/licenses/LICENSE-2.0">
 							Apache License, Version 2.0
 						</LinkStyled>
-						.Apache Atlas, Atlas, Apache, the Apache feather logo
+						. Apache Atlas, Atlas, Apache, the Apache logo
 						are trademarks of the{" "}
 						<LinkStyled href="https://www.apache.org">
 							Apache Software Foundation
 						</LinkStyled>
 						.All other marks mentioned may be trademarks or
 						registered trademarks of their respective owners.
+					</ParagraphFooter>
+					<ParagraphFooter>
+						<LinkStyled href="https://www.apache.org/">Foundation</LinkStyled>{" | "}
+						<LinkStyled href="https://www.apache.org/events/current-event.html">Events</LinkStyled>{" | "}
+						<LinkStyled href="https://www.apache.org/licenses/">License</LinkStyled>{" | "}
+						<LinkStyled href="https://www.apache.org/security/">Security</LinkStyled>{" | "}
+						<LinkStyled href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</LinkStyled>{" | "}
+						<LinkStyled href="https://www.apache.org/foundation/thanks.html">Thanks</LinkStyled>{" | "}
+						<LinkStyled href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</LinkStyled>
 					</ParagraphFooter>
 				</div>
 			</div>


### PR DESCRIPTION
The Atlas website is failing all 9 ASF website policy checks (https://whimsy.apache.org/site/) because the site is rendered entirely via JavaScript and the compliance scanner cannot execute JS.

This adds the missing ASF policy links (Foundation, Events, License, Security, Sponsorship, Thanks, Privacy) to the LegalFooter React component, updates the copyright year to 2026, and fixes the trademark text ("Apache feather logo" → "Apache logo").

Note: The underlying issue is that the Whimsy scanner cannot parse JS-rendered content. Even with these links present, the scanner may still report failures until it gains JS rendering capability. However, the links should be present regardless for site visitors.

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/