### PR TITLE
ATLAS-5298: Atlas-React UI: Fix Critical XSS Vulnerability in sanitiz…

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "dashboard",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@dnd-kit/core": "6.1.0",
         "@dnd-kit/modifiers": "7.0.0",
@@ -40,7 +41,7 @@
         "react-router-dom": "6.30.3",
         "react-toastify": "10.0.5",
         "redux": "5.0.1",
-        "sanitize-html": "2.13.0"
+        "sanitize-html": "^2.17.4"
       },
       "devDependencies": {
         "@types/autosuggest-highlight": "3.2.3",
@@ -3952,6 +3953,12 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -5107,6 +5114,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6157,17 +6173,49 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
-      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
+        "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/sass": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -44,7 +44,7 @@
     "react-router-dom": "6.30.3",
     "react-toastify": "10.0.5",
     "redux": "5.0.1",
-    "sanitize-html": "2.13.0"
+    "sanitize-html": "2.17.4"
   },
   "devDependencies": {
     "@types/autosuggest-highlight": "3.2.3",


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Upgraded sanitize-html dependency from 2.13.0 to 2.17.4
Fixed critical XSS vulnerability reported in npm audit
Addressed security issue related to unsafe raw-text passthrough handling (xmp tag)
Verified compatibility with existing rich text rendering and sanitization flows
No functional business logic changes were introduced

**Related vulnerability:**

GHSA-rpr9-rxv7-x643
How was this patch tested?
Manual Testing

**Validated rich text editor and HTML rendering flows across the application:**

Classification form
Glossary form
Business Metadata form
BM Attributes fields
HTML renderer components
Show more text components
Security Validation

**Tested sanitization against malicious HTML payloads:**

<script>alert('xss')</script>
<img src=x onerror=alert('xss')>
<xmp><script>alert('xss')</script></xmp>

**Verified:**

scripts are removed/sanitized correctly
no JavaScript execution occurs
formatting and existing rich text rendering continue to work as expected
Additional Validation
Executed npm audit after dependency upgrade
Verified application builds successfully
Performed regression testing for ReactQuill editor content rendering and display flows