### PR TITLE
ATLAS-5297: Atlas React UI: Topbar alignment and spacing issue in hea…

### DIFF
--- a/dashboard/src/components/GlobalSearch/QuickSearch.tsx
+++ b/dashboard/src/components/GlobalSearch/QuickSearch.tsx
@@ -388,6 +388,7 @@ const QuickSearch = () => {
 				className="global-search-stack"
 				alignItems="center"
 				gap="0.5rem"
+				sx={{ minWidth: 0, flexShrink: 1 }}
 			>
 				<FormControl
 					size="small"
@@ -436,8 +437,8 @@ const QuickSearch = () => {
 						disablePortal
 						className="global-search-autocomplete"
 						sx={{
-							minWidth: 280,
-							flex: 1,
+							minWidth: 150,
+							flex: "1 1 280px",
 							"& + .MuiAutocomplete-popper .MuiAutocomplete-option": {
 								backgroundColor: "white"
 							},

--- a/dashboard/src/views/Layout/Header.tsx
+++ b/dashboard/src/views/Layout/Header.tsx
@@ -182,14 +182,14 @@ const Header: React.FC<Header> = ({
       )}
       {location.pathname !== "/" &&
         location.pathname !== "/search" && (
-          <div style={{ display: "flex", justifyContent: "center", flex: "1" }}>
+          <div style={{ display: "flex", justifyContent: "center", flex: "1", minWidth: 0, padding: "0 16px" }}>
             <QuickSearch />
           </div>
         )}
       {(location.pathname === "/" || location.pathname === "/search") && (
         <div style={{ flex: "1" }} />
       )}
-      <div className="header-menu" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <div className="header-menu" style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
         <CreateDropdown />
         <LightTooltip title="Downloads">
           <IconButton


### PR DESCRIPTION
Resolved layout and spacing alignment issues in the header section by making the QuickSearch search bar responsive. The search bar now shrinks dynamically down to 150px on smaller screen widths, and the header icons are prevented from shrinking or breaking layout.

**Key Changes**
**QuickSearch.tsx:**
Added minWidth: 0 and flexShrink: 1 to the search stack wrapper.
Adjusted autocomplete styling to set minWidth: 150 (down from 280) and updated flex basis to 1 1 280px for smooth scaling.
**Header.tsx:**
Set minWidth: 0 and added padding (padding: "0 16px") around the search bar container to prevent overflow.
Added flexShrink: 0 to the header menu/action buttons container so they remain visible and un-truncated on smaller viewport widths.