### PR TITLE
ATLAS-5301: Atlas React UI: Nested Subcategories not visible in Gloss…

### DIFF
--- a/dashboard/src/views/SideBar/SideBarTree/CustomFiltersTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/CustomFiltersTree.tsx
@@ -19,7 +19,6 @@ import { useState, useEffect, useMemo } from "react";
 import SideBarTree from "../../SideBar/SideBarTree/SideBarTree.tsx";
 import {
   customSortBy,
-  customSortByObjectKeys,
   groupBy,
   isArray,
   isEmpty
@@ -29,7 +28,6 @@ import type { Props } from "@models/treeStructureType.ts";
 import {
   ChildrenInterface,
   ChildrenInterfaces,
-  ServiceTypeFlatInterface,
   ServiceTypeInterface
 } from "@models/entityTreeType.ts";
 import {
@@ -47,9 +45,8 @@ const CustomFiltersTree = ({ sideBarOpen, searchTerm }: Props) => {
   );
   const { relationshipSearch = {} } = globalSessionData || {};
 
-  const [savedSearchType, setsavedSearchType] = useState<boolean>(true);
   const [savedSearchTypeData, setSavedSearchTypeData] = useState<
-    SavedSearchArrType<typeof savedSearchType>
+    SavedSearchArrType<true>
   >([]);
   const [customFilterLoader, setCustomFilterLoader] = useState<boolean>(false);
 
@@ -76,9 +73,7 @@ const CustomFiltersTree = ({ sideBarOpen, searchTerm }: Props) => {
     ];
 
     let searchTypes = !isEmpty(savedSearchData)
-      ? savedSearchType
-        ? groupBy(savedSearchData, "searchType")
-        : savedSearchData
+      ? groupBy(savedSearchData, "searchType")
       : groupBy(emptySearchTypes, "searchType");
     for (let type in searchTypes) {
       const getType = (type: string) => {
@@ -101,21 +96,20 @@ const CustomFiltersTree = ({ sideBarOpen, searchTerm }: Props) => {
           parent: type
         }));
       };
-      let name = savedSearchType ? getType(type) : searchTypes[type].name;
+      let name = getType(type);
       let children =
-        savedSearchType && !isEmpty(savedSearchData)
+        !isEmpty(savedSearchData)
           ? getChildren(searchTypes[type] as SavedSearchDataType[], type)
           : [];
       savedSearchTypeArr.push({
         name,
         children,
         types: "parent",
-        parent: savedSearchType ? type : searchTypes[type].searchType
+        parent: type
       });
     }
 
     const existingSearchTypes = savedSearchTypeArr.map((child) => child.parent);
-    if (savedSearchType) {
       emptySearchTypes.forEach((typeObj) => {
         if (!existingSearchTypes.includes(typeObj.searchType)) {
           savedSearchTypeArr.push({
@@ -126,9 +120,8 @@ const CustomFiltersTree = ({ sideBarOpen, searchTerm }: Props) => {
           });
         }
       });
-    }
     setSavedSearchTypeData(savedSearchTypeArr as any);
-  }, [savedSearchData, savedSearchType]);
+  }, [savedSearchData]);
 
   const generateChildrenData = useMemo(() => {
     const child = (childs: any) => {
@@ -157,35 +150,26 @@ const CustomFiltersTree = ({ sideBarOpen, searchTerm }: Props) => {
       serviceTypeData.map((type: any) => ({
         id: type.name,
         label: type.name,
-        children: savedSearchType
-          ? child(type.children as ChildrenInterfaces[])
-          : [],
+        children: child(type.children as ChildrenInterfaces[]),
         types: type.types,
         parent: type.parent
       }));
-  }, [savedSearchType]);
+  }, []);
 
   const treeData = useMemo(() => {
-    return savedSearchType
-      ? customSortBy(
+    return customSortBy(
           generateChildrenData(
             savedSearchTypeData as unknown as SavedSearchArrInterface[]
           ),
           ["label"]
-        )
-      : generateChildrenData(
-          customSortByObjectKeys(
-            savedSearchTypeData as ServiceTypeFlatInterface[]
-          )
         );
-  }, [savedSearchType, savedSearchTypeData]);
+  }, [savedSearchTypeData]);
 
   return (
     <SideBarTree
       treeData={treeData}
       treeName={"CustomFilters"}
-      setisEmptyServicetype={setsavedSearchType}
-      isEmptyServicetype={savedSearchType}
+      isEmptyServicetype={true}
       refreshData={fetchInitialData}
       sideBarOpen={sideBarOpen}
       loader={customFilterLoader}

--- a/dashboard/src/views/SideBar/SideBarTree/GlossaryTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/GlossaryTree.tsx
@@ -61,92 +61,93 @@ const GlossaryTree = ({ sideBarOpen, searchTerm }: Props) => {
     newServiceTypeArr =
       glossaryData != null
         ? glossaryData.map(
-            (glossary: {
-              name: string;
-              subTypes: [];
-              guid: string;
-              superTypes: string[];
-              categories: EnumCategoryRelation[];
-              terms: EnumCategoryRelation[];
+          (glossary: {
+            name: string;
+            subTypes: [];
+            guid: string;
+            superTypes: string[];
+            categories: EnumCategoryRelation[];
+            terms: EnumCategoryRelation[];
+          }) => {
+            let categoryRelation: EnumCategoryRelation[] = [];
+
+            glossary?.categories?.map((obj: EnumCategoryRelations) => {
+              if (obj.parentCategoryGuid != undefined) {
+                categoryRelation.push(obj as EnumCategoryRelations);
+              }
+            });
+
+            const getChildren = (glossaries: {
+              children: EnumCategoryRelation[];
+              parent: string;
             }) => {
-              let categoryRelation: EnumCategoryRelation[] = [];
+              return !isEmpty(glossaries.children)
+                ? glossaries.children
+                  .map((glossariesType: any) => {
+                    const getChild = (parentGuid: string | undefined): any => {
+                      if (!parentGuid) return [];
+                      return categoryRelation
+                        .map((obj: EnumCategoryRelations) => {
+                          if (
+                            obj.parentCategoryGuid ==
+                            parentGuid
+                          ) {
+                            return {
+                              ["name"]: obj.displayText,
+                              id: obj.displayText,
+                              ["children"]: getChild(obj.categoryGuid),
+                              types: "child",
+                              parent: glossaries.parent,
+                              cGuid: glossaryType
+                                ? obj.termGuid
+                                : obj.categoryGuid,
+                              guid: glossary.guid
+                            };
+                          }
+                        })
+                        .filter(Boolean);
+                    };
+                    if (glossariesType.parentCategoryGuid == undefined) {
+                      return {
+                        ["name"]: glossariesType.displayText,
+                        id: glossariesType.displayText,
+                        ["children"]: getChild(glossariesType.categoryGuid),
+                        types: "child",
+                        parent: glossaries.parent,
+                        cGuid: glossaryType
+                          ? glossariesType.termGuid
+                          : glossariesType.categoryGuid,
+                        guid: glossary.guid
+                      };
+                    }
+                  })
+                  .filter(Boolean)
+                : [];
+            };
 
-              glossary?.categories?.map((obj: EnumCategoryRelations) => {
-                if (obj.parentCategoryGuid != undefined) {
-                  categoryRelation.push(obj as EnumCategoryRelations);
-                }
-              });
+            let name: string = glossary.name,
+              children: any = glossaryType
+                ? getChildren({
+                  children: glossary?.terms,
+                  parent: glossary.name
+                })
+                : getChildren({
+                  children: glossary?.categories,
+                  parent: glossary.name
+                });
 
-              const getChildren = (glossaries: {
-                children: EnumCategoryRelation[];
-                parent: string;
-              }) => {
-                return !isEmpty(glossaries.children)
-                  ? glossaries.children
-                      .map((glossariesType: any) => {
-                        const getChild = () => {
-                          return categoryRelation
-                            .map((obj: EnumCategoryRelations) => {
-                              if (
-                                obj.parentCategoryGuid ==
-                                glossariesType.categoryGuid
-                              ) {
-                                return {
-                                  ["name"]: obj.displayText,
-                                  id: obj.displayText,
-                                  ["children"]: [],
-                                  types: "child",
-                                  parent: glossaries.parent,
-                                  cGuid: glossaryType
-                                    ? obj.termGuid
-                                    : obj.categoryGuid,
-                                  guid: glossary.guid
-                                };
-                              }
-                            })
-                            .filter(Boolean);
-                        };
-                        if (glossariesType.parentCategoryGuid == undefined) {
-                          return {
-                            ["name"]: glossariesType.displayText,
-                            id: glossariesType.displayText,
-                            ["children"]: getChild(),
-                            types: "child",
-                            parent: glossaries.parent,
-                            cGuid: glossaryType
-                              ? glossariesType.termGuid
-                              : glossariesType.categoryGuid,
-                            guid: glossary.guid
-                          };
-                        }
-                      })
-                      .filter(Boolean)
-                  : [];
-              };
-
-              let name: string = glossary.name,
-                children: any = glossaryType
-                  ? getChildren({
-                      children: glossary?.terms,
-                      parent: glossary.name
-                    })
-                  : getChildren({
-                      children: glossary?.categories,
-                      parent: glossary.name
-                    });
-
-              return {
-                [name]: {
-                  ["name"]: name,
-                  ["children"]: children || [],
-                  id: glossary.guid,
-                  types: "parent",
-                  parent: name,
-                  guid: glossary.guid
-                }
-              };
-            }
-          )
+            return {
+              [name]: {
+                ["name"]: name,
+                ["children"]: children || [],
+                id: glossary.guid,
+                types: "parent",
+                parent: name,
+                guid: glossary.guid
+              }
+            };
+          }
+        )
         : [];
 
     setGlossaryData(newServiceTypeArr);
@@ -162,10 +163,10 @@ const GlossaryTree = ({ sideBarOpen, searchTerm }: Props) => {
             children:
               obj?.children != undefined
                 ? child(
-                    obj.children.filter(
-                      Boolean
-                    ) as unknown as ChildrenInterfaces[]
-                  )
+                  obj.children.filter(
+                    Boolean
+                  ) as unknown as ChildrenInterfaces[]
+                )
                 : [],
             types: obj?.types,
             parent: obj?.parent,
@@ -193,8 +194,8 @@ const GlossaryTree = ({ sideBarOpen, searchTerm }: Props) => {
   const treeData = useMemo(() => {
     return !isEmpty(glossaryData)
       ? generateChildrenData(
-          customSortByObjectKeys(glossaryTypeData as ServiceTypeInterface[])
-        )
+        customSortByObjectKeys(glossaryTypeData as ServiceTypeInterface[])
+      )
       : noTreeData();
   }, [glossaryType, glossaryTypeData]);
 

--- a/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
@@ -1042,23 +1042,6 @@ const BarTreeView: FC<{
                     </IconButton>
                   </LightTooltip>
 
-                  {treeName == "CustomFilters" && (
-                    <LightTooltip title={getEmptyTypesTitle()}>
-                      <AccountTreeIcon
-                        sx={{
-                          color: !isEmptyServicetype ? "#999 !important" : "",
-                        }}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          if (setisEmptyServicetype) {
-                            setisEmptyServicetype(!isEmptyServicetype);
-                          }
-                        }}
-                        fontSize="small"
-                        className="menuitem-icon"
-                      />
-                    </LightTooltip>
-                  )}
 
                   {(treeName == "Entities" ||
                     treeName == "Classifications" ||


### PR DESCRIPTION
Resolved the issue where nested/child subcategories were missing or not expandable in the Glossary Tree Structure view by implementing a recursive child mapping lookup.

**Key Changes**
Recursive Category Mapping: Updated the getChild function in GlossaryTree.tsx
 to recursively fetch nested child subcategories using the child category's identifier (getChild(obj.categoryGuid)).

**Custom Filters Tree Cleanup**: Removed the unused flat-view toggle logic (the savedSearchType state and toggle AccountTreeIcon button) from CustomFiltersTree.tsx and SideBarTree.tsx, defaulting custom filters to tree-only view mode.
