### PR TITLE
ATLAS-5299: Atlas React UI: Create Subcategory API Fails Due to Missi…

### DIFF
--- a/dashboard/src/views/Glossary/AddUpdateCategoryForm.tsx
+++ b/dashboard/src/views/Glossary/AddUpdateCategoryForm.tsx
@@ -39,7 +39,7 @@ const AddUpdateCategoryForm = (props: {
   dataObj: any;
 }) => {
   const { open, onClose, isAdd, node, dataObj } = props;
-  const { id, parent, types } = node || {};
+  const { id, parent, types, cGuid } = node || {};
   const { guid: glossaryTypeGuid }: any = useParams();
   const dispatchApi = useAppDispatch();
   const toastId: any = useRef(null);
@@ -103,7 +103,7 @@ const AddUpdateCategoryForm = (props: {
     }
     data["name"] = name;
     if (types == "child") {
-      data["parentCategory"] = { ["categoryGuid"]: glossaryTypeGuid };
+      data["parentCategory"] = { ["categoryGuid"]: cGuid || glossaryTypeGuid };
     }
     data["shortDescription"] = !isEmpty(shortDescription)
       ? shortDescription


### PR DESCRIPTION
**ATLAS-5299: Atlas React UI: Create Subcategory API Fails Due to Missing parentCategoryId in UI Payload**

**What changes were proposed in this pull request?**
Currently in the Atlas React UI, creating a child category (subcategory) under an existing category fails because the API payload is missing the correct parentCategoryId. The UI was previously hardcoding the categoryGuid to the root glossaryTypeGuid rather than the specific parent category the user had selected.

This patch fixes the issue by updating AddUpdateCategoryForm.tsx:

It extracts the cGuid (Category GUID) from the node props.
When the form is generating the payload for a "child" type category, it assigns categoryGuid to cGuid if it exists, gracefully falling back to glossaryTypeGuid if it does not.
This ensures that the correct parent ID is successfully passed to the backend API during subcategory creation.

**How was this patch tested?**
Manual testing in the UI:

Navigated to the Glossary page in the Atlas React UI.
Selected an existing Glossary category and clicked to add a child Category.
Filled out the Category creation form and submitted.
Verified via browser network tools that the POST request payload now correctly contains the parentCategory: { categoryGuid: "<correct-parent-guid>" }.
Confirmed that the API returns a success status and the subcategory successfully renders in the Glossary tree UI without crashing.