### PR TITLE
ATLAS-5219: Docker setup update to keep containers immutable

### DIFF
--- a/dev-support/atlas-docker/Dockerfile.atlas
+++ b/dev-support/atlas-docker/Dockerfile.atlas
@@ -34,6 +34,10 @@ RUN tar xfz /home/atlas/dist/apache-atlas-${ATLAS_VERSION}-server.tar.gz --direc
     rm -rf ${ATLAS_HOME}/logs && \
     ln -s /var/log/atlas ${ATLAS_HOME}/logs && \
     ln -s /home/atlas/data ${ATLAS_HOME}/data && \
+    mkdir -p ${ATLAS_HOME}/server/webapp/atlas && \
+    cd ${ATLAS_HOME}/server/webapp/atlas && \
+    jar -xf ../atlas.war && \
+    rm -f ../atlas.war && \
     chown -R atlas:atlas ${ATLAS_HOME}/ /var/run/atlas/ /var/log/atlas/
 
 COPY ./scripts/hbase-site.xml ${ATLAS_HOME}/hbase/conf/

--- a/dev-support/atlas-docker/README.md
+++ b/dev-support/atlas-docker/README.md
@@ -81,6 +81,6 @@ Docker files in this folder create docker images and run them to build Apache At
       docker compose -f docker-compose.atlas.yml -f docker-compose.atlas-hadoop.yml up -d --wait
       ```
 
-   Apache Atlas will be installed at /opt/atlas/, and logs are at /var/logs/atlas directory.
+   Apache Atlas will be installed at /opt/atlas/, and logs are at /var/log/atlas directory.
 
 7. Atlas Admin can be accessed at http://localhost:21000 (admin/atlasR0cks!)

--- a/dev-support/atlas-docker/README.md
+++ b/dev-support/atlas-docker/README.md
@@ -31,35 +31,55 @@ Docker files in this folder create docker images and run them to build Apache At
 3. Update environment variables in .env file, if necessary
 
 4. Execute following command to download necessary archives to setup Atlas/HDFS/HBase/Kafka services:
-   ~~~
+
+   ```shell
    chmod +x download-archives.sh
    ./download-archives.sh
-   ~~~
+   ```
 
-5.  Execute following commands to set environment variables to build Apache Atlas docker containers:
-   ~~~
+5. Execute following commands to set environment variables to build Apache Atlas docker containers:
+
+   ```shell
    export DOCKER_BUILDKIT=1
    export COMPOSE_DOCKER_CLI_BUILD=1
-   ~~~
+   ```
 
 6. Build and deploy Apache Atlas in containers using docker compose
 
-   6.1. Build atlas-base image with the following command:
-        docker compose -f docker-compose.atlas-base.yml build
+   Atlas server configuration is mounted from `config/atlas/${ATLAS_BACKEND}/atlas-application.properties`.
+   The file authentication credentials are mounted from `config/atlas/users-credentials.properties`.
 
-   6.2. Ensure that the `${HOME}/.m2` directory exists and execute following command to build Apache Atlas:
-        mkdir -p ${HOME}/.m2
-        docker compose -f docker-compose.atlas-build.yml up
+   1. Build atlas-base image with the following command:
+
+      ```shell
+      docker compose -f docker-compose.atlas-base.yml build
+      ```
+
+   2. Ensure that the `${HOME}/.m2` directory exists and execute following command to build Apache Atlas:
+
+      ```shell
+      mkdir -p ${HOME}/.m2
+      docker compose -f docker-compose.atlas-build.yml up
+      ```
 
    Time taken to complete the build might vary (upto an hour), depending on status of ${HOME}/.m2 directory cache.
 
-   6.3. To install and start Atlas using Postgres as backend store, execute following commands:
-        export ATLAS_BACKEND=postgres
-        docker compose -f docker-compose.atlas.yml up -d --wait
+   3. To install and start Atlas using Postgres as backend store, execute following commands:
 
-   6.4. To install and start Atlas using HBase as backend store, execute following commands:
-        export ATLAS_BACKEND=hbase
-        docker compose -f docker-compose.atlas.yml -f docker-compose.atlas-hadoop.yml up -d --wait
+      ```shell
+      export ATLAS_BACKEND=postgres
+      docker compose -f docker-compose.atlas.yml -f docker-compose.atlas-postgres.yml up -d --wait
+      ```
+
+      The Postgres overlay runs `config/init_postgres.sh` as a one-shot initialization service before Atlas starts.
+      This creates the required roles, databases, and Atlas RDBMS schema.
+
+   4. To install and start Atlas using HBase as backend store, execute following commands:
+
+      ```shell
+      export ATLAS_BACKEND=hbase
+      docker compose -f docker-compose.atlas.yml -f docker-compose.atlas-hadoop.yml up -d --wait
+      ```
 
    Apache Atlas will be installed at /opt/atlas/, and logs are at /var/logs/atlas directory.
 

--- a/dev-support/atlas-docker/config/atlas/hbase/atlas-application.properties
+++ b/dev-support/atlas-docker/config/atlas/hbase/atlas-application.properties
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#########  Graph Database Configs  #########
+
+atlas.graph.storage.backend=hbase2
+atlas.graph.storage.hbase.table=apache_atlas_janus
+atlas.graph.storage.hostname=atlas-zk.example.com:2181
+atlas.graph.storage.hbase.regions-per-server=1
+atlas.graph.storage.hbase.compression-algorithm=NONE
+atlas.graph.graph.replace-instance-if-exists=true
+
+atlas.EntityAuditRepository.impl=org.apache.atlas.repository.audit.HBaseBasedAuditRepository
+atlas.audit.hbase.tablename=apache_atlas_entity_audit
+atlas.audit.zookeeper.session.timeout.ms=1000
+atlas.audit.hbase.zookeeper.quorum=atlas-zk.example.com:2181
+
+#########  Graph Search Index  #########
+
+atlas.graph.index.search.backend=solr
+atlas.graph.index.search.solr.mode=http
+atlas.graph.index.search.solr.http-urls=http://atlas-solr.example.com:8983/solr
+atlas.graph.index.search.solr.zookeeper-connect-timeout=60000
+atlas.graph.index.search.solr.zookeeper-session-timeout=60000
+atlas.graph.index.search.solr.wait-searcher=false
+atlas.graph.index.search.max-result-set-size=150
+
+#########  Notification Configs  #########
+
+atlas.notification.embedded=false
+atlas.kafka.data=${sys:atlas.home}/data/kafka
+atlas.kafka.zookeeper.connect=atlas-zk.example.com:2181
+atlas.kafka.bootstrap.servers=atlas-kafka.example.com:9092
+atlas.kafka.zookeeper.session.timeout.ms=400
+atlas.kafka.zookeeper.connection.timeout.ms=200
+atlas.kafka.zookeeper.sync.time.ms=20
+atlas.kafka.auto.commit.interval.ms=1000
+atlas.kafka.hook.group.id=atlas
+atlas.kafka.enable.auto.commit=false
+atlas.kafka.auto.offset.reset=earliest
+atlas.kafka.session.timeout.ms=30000
+atlas.kafka.offsets.topic.replication.factor=1
+atlas.kafka.poll.timeout.ms=1000
+atlas.notification.create.topics=true
+atlas.notification.replicas=1
+atlas.notification.topics=ATLAS_HOOK,ATLAS_ENTITIES
+atlas.notification.log.failed.messages=true
+atlas.notification.consumer.retry.interval=500
+atlas.notification.hook.retry.interval=1000
+
+#########  Security Properties  #########
+
+atlas.enableTLS=false
+atlas.authentication.method.kerberos=false
+atlas.authentication.method.file=true
+atlas.authentication.method.ldap.type=none
+atlas.authentication.method.file.filename=${sys:atlas.home}/conf/users-credentials.properties
+
+#########  Server Properties  #########
+
+atlas.rest.address=http://localhost:21000
+atlas.server.ha.enabled=false
+
+######### Atlas Authorization #########
+
+atlas.authorizer.impl=simple
+atlas.authorizer.simple.authz.policy.file=atlas-simple-authz-policy.json
+
+#########  CSRF Configs  #########
+
+atlas.rest-csrf.enabled=true
+atlas.rest-csrf.browser-useragents-regex=^Mozilla.*,^Opera.*,^Chrome.*
+atlas.rest-csrf.methods-to-ignore=GET,OPTIONS,HEAD,TRACE
+atlas.rest-csrf.custom-header=X-XSRF-HEADER
+
+######### Atlas Metric/Stats configs #########
+
+atlas.metric.query.cache.ttlInSecs=900

--- a/dev-support/atlas-docker/config/atlas/postgres/atlas-application.properties
+++ b/dev-support/atlas-docker/config/atlas/postgres/atlas-application.properties
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#########  Graph Database Configs  #########
+
+atlas.graph.storage.backend=rdbms
+atlas.graph.storage.hbase.table=apache_atlas_janus
+atlas.graph.storage.hbase.compression-algorithm=NONE
+atlas.graph.graph.replace-instance-if-exists=true
+
+atlas.graph.storage.rdbms.jpa.hikari.driverClassName=org.postgresql.Driver
+atlas.graph.storage.rdbms.jpa.hikari.jdbcUrl=jdbc:postgresql://atlas-db/atlas
+atlas.graph.storage.rdbms.jpa.hikari.username=atlas
+atlas.graph.storage.rdbms.jpa.hikari.password=atlasR0cks!
+atlas.graph.storage.rdbms.jpa.hikari.maximumPoolSize=40
+atlas.graph.storage.rdbms.jpa.hikari.minimumIdle=5
+atlas.graph.storage.rdbms.jpa.hikari.idleTimeout=300000
+atlas.graph.storage.rdbms.jpa.hikari.connectionTestQuery=select 1
+atlas.graph.storage.rdbms.jpa.hikari.maxLifetime=1800000
+atlas.graph.storage.rdbms.jpa.hikari.connectionTimeout=30000
+atlas.graph.storage.rdbms.jpa.javax.persistence.jdbc.dialect=org.eclipse.persistence.platform.database.PostgreSQLPlatform
+
+atlas.EntityAuditRepository.impl=org.apache.atlas.repository.audit.rdbms.RdbmsBasedAuditRepository
+atlas.audit.hbase.tablename=apache_atlas_entity_audit
+atlas.audit.zookeeper.session.timeout.ms=1000
+atlas.audit.hbase.zookeeper.quorum=atlas-zk.example.com:2181
+
+#########  Graph Search Index  #########
+
+atlas.graph.index.search.backend=solr
+atlas.graph.index.search.solr.mode=http
+atlas.graph.index.search.solr.http-urls=http://atlas-solr.example.com:8983/solr
+atlas.graph.index.search.solr.zookeeper-connect-timeout=60000
+atlas.graph.index.search.solr.zookeeper-session-timeout=60000
+atlas.graph.index.search.solr.wait-searcher=false
+atlas.graph.index.search.max-result-set-size=150
+
+#########  Notification Configs  #########
+
+atlas.notification.embedded=false
+atlas.kafka.data=${sys:atlas.home}/data/kafka
+atlas.kafka.zookeeper.connect=atlas-zk.example.com:2181
+atlas.kafka.bootstrap.servers=atlas-kafka.example.com:9092
+atlas.kafka.zookeeper.session.timeout.ms=400
+atlas.kafka.zookeeper.connection.timeout.ms=200
+atlas.kafka.zookeeper.sync.time.ms=20
+atlas.kafka.auto.commit.interval.ms=1000
+atlas.kafka.hook.group.id=atlas
+atlas.kafka.enable.auto.commit=false
+atlas.kafka.auto.offset.reset=earliest
+atlas.kafka.session.timeout.ms=30000
+atlas.kafka.offsets.topic.replication.factor=1
+atlas.kafka.poll.timeout.ms=1000
+atlas.notification.create.topics=true
+atlas.notification.replicas=1
+atlas.notification.topics=ATLAS_HOOK,ATLAS_ENTITIES
+atlas.notification.log.failed.messages=true
+atlas.notification.consumer.retry.interval=500
+atlas.notification.hook.retry.interval=1000
+
+#########  Security Properties  #########
+
+atlas.enableTLS=false
+atlas.authentication.method.kerberos=false
+atlas.authentication.method.file=true
+atlas.authentication.method.ldap.type=none
+atlas.authentication.method.file.filename=${sys:atlas.home}/conf/users-credentials.properties
+
+#########  Server Properties  #########
+
+atlas.rest.address=http://localhost:21000
+atlas.server.ha.enabled=false
+
+######### Atlas Authorization #########
+
+atlas.authorizer.impl=simple
+atlas.authorizer.simple.authz.policy.file=atlas-simple-authz-policy.json
+
+#########  CSRF Configs  #########
+
+atlas.rest-csrf.enabled=true
+atlas.rest-csrf.browser-useragents-regex=^Mozilla.*,^Opera.*,^Chrome.*
+atlas.rest-csrf.methods-to-ignore=GET,OPTIONS,HEAD,TRACE
+atlas.rest-csrf.custom-header=X-XSRF-HEADER
+
+######### Atlas Metric/Stats configs #########
+
+atlas.metric.query.cache.ttlInSecs=900

--- a/dev-support/atlas-docker/config/atlas/users-credentials.properties
+++ b/dev-support/atlas-docker/config/atlas/users-credentials.properties
@@ -15,5 +15,4 @@
 # limitations under the License.
 
 # username=group::sha256-password
-# Password: atlasR0cks!
 admin=ADMIN::bad2e629a8d93dddfd6cf4c6e04f02035e0ec146f22a8ba1f6b8252a2634107a

--- a/dev-support/atlas-docker/config/atlas/users-credentials.properties
+++ b/dev-support/atlas-docker/config/atlas/users-credentials.properties
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM postgres:13.21
-
-# Copy DB init script
-USER 0
-RUN  mkdir -p /docker-entrypoint-initdb.d
-COPY config/init_postgres.sh /docker-entrypoint-initdb.d/
-RUN chown -R postgres:postgres /docker-entrypoint-initdb.d/
-ENV POSTGRES_PASSWORD=atlasR0cks!
+# username=group::sha256-password
+# Password: atlasR0cks!
+admin=ADMIN::bad2e629a8d93dddfd6cf4c6e04f02035e0ec146f22a8ba1f6b8252a2634107a

--- a/dev-support/atlas-docker/config/init_postgres.sh
+++ b/dev-support/atlas-docker/config/init_postgres.sh
@@ -50,33 +50,56 @@ atlas_psql_cmd=(
 create_role() {
   local role_name=$1
   local role_password=$2
+  local role_exists
+  local role_sql
 
-  "${psql_cmd[@]}" <<EOSQL
-DO \$\$
-BEGIN
-  IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${role_name}') THEN
-    CREATE ROLE ${role_name} WITH LOGIN PASSWORD '${role_password}';
-  ELSE
-    ALTER ROLE ${role_name} WITH LOGIN PASSWORD '${role_password}';
-  END IF;
-END
-\$\$;
+  role_exists=$("${psql_cmd[@]}" --set=role_name="${role_name}" -At <<'EOSQL'
+SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = :'role_name';
 EOSQL
+)
+
+  if [ "${role_exists}" != "1" ]
+  then
+    role_sql=$("${psql_cmd[@]}" --set=role_name="${role_name}" --set=role_password="${role_password}" -At <<'EOSQL'
+SELECT format('CREATE ROLE %I WITH LOGIN PASSWORD %L', :'role_name', :'role_password');
+EOSQL
+)
+  else
+    role_sql=$("${psql_cmd[@]}" --set=role_name="${role_name}" --set=role_password="${role_password}" -At <<'EOSQL'
+SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'role_name', :'role_password');
+EOSQL
+)
+  fi
+
+  "${psql_cmd[@]}" -c "${role_sql}"
 }
 
 create_database() {
   local database_name=$1
   local owner_name=$2
   local database_exists
+  local database_sql
+  local grant_sql
 
-  database_exists=$("${psql_cmd[@]}" -Atc "SELECT 1 FROM pg_database WHERE datname = '${database_name}'")
+  database_exists=$("${psql_cmd[@]}" --set=database_name="${database_name}" -At <<'EOSQL'
+SELECT 1 FROM pg_database WHERE datname = :'database_name';
+EOSQL
+)
 
   if [ "${database_exists}" != "1" ]
   then
-    "${psql_cmd[@]}" -c "CREATE DATABASE ${database_name} OWNER ${owner_name};"
+    database_sql=$("${psql_cmd[@]}" --set=database_name="${database_name}" --set=owner_name="${owner_name}" -At <<'EOSQL'
+SELECT format('CREATE DATABASE %I OWNER %I', :'database_name', :'owner_name');
+EOSQL
+)
+    "${psql_cmd[@]}" -c "${database_sql}"
   fi
 
-  "${psql_cmd[@]}" -c "GRANT ALL PRIVILEGES ON DATABASE ${database_name} TO ${owner_name};"
+  grant_sql=$("${psql_cmd[@]}" --set=database_name="${database_name}" --set=owner_name="${owner_name}" -At <<'EOSQL'
+SELECT format('GRANT ALL PRIVILEGES ON DATABASE %I TO %I', :'database_name', :'owner_name');
+EOSQL
+)
+  "${psql_cmd[@]}" -c "${grant_sql}"
   "${psql_cmd[@]}" --dbname "${database_name}" -c "GRANT ALL ON SCHEMA public TO public;"
 }
 

--- a/dev-support/atlas-docker/config/init_postgres.sh
+++ b/dev-support/atlas-docker/config/init_postgres.sh
@@ -16,21 +16,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
 
-set -e
+: "${POSTGRES_HOST:=atlas-db}"
+: "${POSTGRES_PORT:=5432}"
+: "${POSTGRES_USER:=postgres}"
+: "${POSTGRES_DB:=postgres}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+: "${HIVE_DB_PASSWORD:?HIVE_DB_PASSWORD must be set}"
+: "${ATLAS_DB_PASSWORD:?ATLAS_DB_PASSWORD must be set}"
+: "${ATLAS_SCHEMA_FILE:?ATLAS_SCHEMA_FILE must be set}"
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    CREATE USER hive WITH PASSWORD 'atlasR0cks!';
-    CREATE DATABASE hive;
-    GRANT ALL PRIVILEGES ON DATABASE hive TO hive;
+export PGPASSWORD="${POSTGRES_PASSWORD}"
 
-    CREATE USER atlas WITH PASSWORD 'atlasR0cks!';
-    CREATE DATABASE atlas;
-    GRANT ALL PRIVILEGES ON DATABASE atlas TO atlas;
+psql_cmd=(
+  psql
+  -v ON_ERROR_STOP=1
+  --host "${POSTGRES_HOST}"
+  --port "${POSTGRES_PORT}"
+  --username "${POSTGRES_USER}"
+  --dbname "${POSTGRES_DB}"
+)
 
-    \c hive
-    GRANT ALL ON SCHEMA public TO public;
+atlas_psql_cmd=(
+  psql
+  -v ON_ERROR_STOP=1
+  --host "${POSTGRES_HOST}"
+  --port "${POSTGRES_PORT}"
+  --username atlas
+  --dbname atlas
+)
 
-    \c atlas
-    GRANT ALL ON SCHEMA public TO public;
+create_role() {
+  local role_name=$1
+  local role_password=$2
+
+  "${psql_cmd[@]}" <<EOSQL
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${role_name}') THEN
+    CREATE ROLE ${role_name} WITH LOGIN PASSWORD '${role_password}';
+  ELSE
+    ALTER ROLE ${role_name} WITH LOGIN PASSWORD '${role_password}';
+  END IF;
+END
+\$\$;
 EOSQL
+}
+
+create_database() {
+  local database_name=$1
+  local owner_name=$2
+  local database_exists
+
+  database_exists=$("${psql_cmd[@]}" -Atc "SELECT 1 FROM pg_database WHERE datname = '${database_name}'")
+
+  if [ "${database_exists}" != "1" ]
+  then
+    "${psql_cmd[@]}" -c "CREATE DATABASE ${database_name} OWNER ${owner_name};"
+  fi
+
+  "${psql_cmd[@]}" -c "GRANT ALL PRIVILEGES ON DATABASE ${database_name} TO ${owner_name};"
+  "${psql_cmd[@]}" --dbname "${database_name}" -c "GRANT ALL ON SCHEMA public TO public;"
+}
+
+create_role hive "${HIVE_DB_PASSWORD}"
+create_database hive hive
+
+create_role atlas "${ATLAS_DB_PASSWORD}"
+create_database atlas atlas
+
+PGPASSWORD="${ATLAS_DB_PASSWORD}" "${atlas_psql_cmd[@]}" --file "${ATLAS_SCHEMA_FILE}"

--- a/dev-support/atlas-docker/docker-compose.atlas-common.yml
+++ b/dev-support/atlas-docker/docker-compose.atlas-common.yml
@@ -47,14 +47,13 @@ services:
       - "2181:2181"
 
   atlas-db:
-    build:
-      context: .
-      dockerfile: Dockerfile.atlas-db
-    image: atlas-db
+    image: postgres:13.21
     container_name: atlas-db
     hostname: atlas-db.example.com
     networks:
       - atlas
+    environment:
+      POSTGRES_PASSWORD: atlasR0cks!
     healthcheck:
       test: 'su -c "pg_isready -q" postgres'
       interval: 30s

--- a/dev-support/atlas-docker/docker-compose.atlas-postgres.yml
+++ b/dev-support/atlas-docker/docker-compose.atlas-postgres.yml
@@ -21,13 +21,13 @@ services:
       POSTGRES_PASSWORD: atlasR0cks!
       HIVE_DB_PASSWORD: atlasR0cks!
       ATLAS_DB_PASSWORD: atlasR0cks!
-      ATLAS_SCHEMA_FILE: /home/atlas/create_schema.sql
+      ATLAS_SCHEMA_FILE: /tmp/create_schema.sql
     volumes:
-      - ./config/init_postgres.sh:/home/atlas/init_postgres.sh:ro
-      - ../../graphdb/janusgraph-rdbms/src/main/resources/META-INF/postgres/create_schema.sql:/home/atlas/create_schema.sql:ro
+      - ./config/init_postgres.sh:/tmp/init_postgres.sh:ro
+      - ../../graphdb/janusgraph-rdbms/src/main/resources/META-INF/postgres/create_schema.sql:/tmp/create_schema.sql:ro
     command:
       - /bin/bash
-      - /home/atlas/init_postgres.sh
+      - /tmp/init_postgres.sh
 
 networks:
   atlas:

--- a/dev-support/atlas-docker/docker-compose.atlas-postgres.yml
+++ b/dev-support/atlas-docker/docker-compose.atlas-postgres.yml
@@ -1,0 +1,34 @@
+services:
+  atlas:
+    depends_on:
+      atlas-db-init:
+        condition: service_completed_successfully
+
+  atlas-db-init:
+    image: postgres:13.21
+    container_name: atlas-db-init
+    hostname: atlas-db-init.example.com
+    networks:
+      - atlas
+    depends_on:
+      atlas-backend:
+        condition: service_healthy
+    environment:
+      POSTGRES_HOST: atlas-db
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: atlasR0cks!
+      HIVE_DB_PASSWORD: atlasR0cks!
+      ATLAS_DB_PASSWORD: atlasR0cks!
+      ATLAS_SCHEMA_FILE: /home/atlas/create_schema.sql
+    volumes:
+      - ./config/init_postgres.sh:/home/atlas/init_postgres.sh:ro
+      - ../../graphdb/janusgraph-rdbms/src/main/resources/META-INF/postgres/create_schema.sql:/home/atlas/create_schema.sql:ro
+    command:
+      - /bin/bash
+      - /home/atlas/init_postgres.sh
+
+networks:
+  atlas:
+    name: atlasnw

--- a/dev-support/atlas-docker/docker-compose.atlas.yml
+++ b/dev-support/atlas-docker/docker-compose.atlas.yml
@@ -16,6 +16,8 @@ services:
       - atlas
     volumes:
       - ./data:/home/atlas/data
+      - ./config/atlas/${ATLAS_BACKEND}/atlas-application.properties:/opt/atlas/conf/atlas-application.properties:ro
+      - ./config/atlas/users-credentials.properties:/opt/atlas/conf/users-credentials.properties:ro
     ports:
       - "21000:21000"
     depends_on:

--- a/dev-support/atlas-docker/scripts/atlas.sh
+++ b/dev-support/atlas-docker/scripts/atlas.sh
@@ -16,67 +16,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
 set -x
 
-if [ ! -e ${ATLAS_HOME}/.setupDone ]
+ATLAS_APPLICATION_PROPERTIES=${ATLAS_HOME}/conf/atlas-application.properties
+ATLAS_USER_CREDENTIALS=${ATLAS_HOME}/conf/users-credentials.properties
+ATLAS_EXPANDED_WEBAPP=${ATLAS_HOME}/server/webapp/atlas/WEB-INF
+
+if [ ! -r "${ATLAS_APPLICATION_PROPERTIES}" ]
 then
-  SETUP_ATLAS=true
-else
-  SETUP_ATLAS=false
+  echo "Missing readable Atlas configuration: ${ATLAS_APPLICATION_PROPERTIES}" >&2
+  exit 1
 fi
 
-if [ "${SETUP_ATLAS}" == "true" ]
+if [ ! -r "${ATLAS_USER_CREDENTIALS}" ]
 then
-  encryptedPwd=$(${ATLAS_HOME}/bin/cputil.py -g -u admin -p atlasR0cks! -s | tail -1)
+  echo "Missing readable Atlas user credentials: ${ATLAS_USER_CREDENTIALS}" >&2
+  exit 1
+fi
 
-  echo "admin=ADMIN::${encryptedPwd}" > ${ATLAS_HOME}/conf/users-credentials.properties
-
-  sed -i "s/atlas.graph.storage.hostname=.*$/atlas.graph.storage.hostname=atlas-zk.example.com:2181/"             /opt/atlas/conf/atlas-application.properties
-  sed -i "s/atlas.audit.hbase.zookeeper.quorum=.*$/atlas.audit.hbase.zookeeper.quorum=atlas-zk.example.com:2181/" /opt/atlas/conf/atlas-application.properties
-
-  sed -i "s/^atlas.graph.index.search.solr.mode=cloud/# atlas.graph.index.search.solr.mode=cloud/"                                              /opt/atlas/conf/atlas-application.properties
-  sed -i "s/^# *atlas.graph.index.search.solr.mode=http/atlas.graph.index.search.solr.mode=http/"                                               /opt/atlas/conf/atlas-application.properties
-  sed -i "s/^.*atlas.graph.index.search.solr.http-urls=.*$/atlas.graph.index.search.solr.http-urls=http:\/\/atlas-solr.example.com:8983\/solr/" /opt/atlas/conf/atlas-application.properties
-
-  sed -i "s/atlas.notification.embedded=.*$/atlas.notification.embedded=false/"                            /opt/atlas/conf/atlas-application.properties
-  sed -i "s/atlas.kafka.zookeeper.connect=.*$/atlas.kafka.zookeeper.connect=atlas-zk.example.com:2181/"    /opt/atlas/conf/atlas-application.properties
-  sed -i "s/atlas.kafka.bootstrap.servers=.*$/atlas.kafka.bootstrap.servers=atlas-kafka.example.com:9092/" /opt/atlas/conf/atlas-application.properties
-
-  echo ""                                                     >> /opt/atlas/conf/atlas-application.properties
-  echo "atlas.graph.storage.hbase.compression-algorithm=NONE" >> /opt/atlas/conf/atlas-application.properties
-  echo "atlas.graph.graph.replace-instance-if-exists=true"    >> /opt/atlas/conf/atlas-application.properties
-
-  if [ "${ATLAS_BACKEND}" == "postgres" ]
-  then
-    # set RDBMS as backend and entity-audit store
-    sed -i "s/^atlas.graph.storage.backend=hbase2/# atlas.graph.storage.backend=hbase2/"                                                            /opt/atlas/conf/atlas-application.properties
-    sed -i "s/atlas.EntityAuditRepository.impl=.*$/# atlas.EntityAuditRepository.impl=org.apache.atlas.repository.audit.HBaseBasedAuditRepository/" /opt/atlas/conf/atlas-application.properties
-
-    cat <<EOF >> /opt/atlas/conf/atlas-application.properties
-
-atlas.graph.storage.backend=rdbms
-atlas.graph.storage.rdbms.jpa.hikari.driverClassName=org.postgresql.Driver
-atlas.graph.storage.rdbms.jpa.hikari.jdbcUrl=jdbc:postgresql://atlas-db/atlas
-atlas.graph.storage.rdbms.jpa.hikari.username=atlas
-atlas.graph.storage.rdbms.jpa.hikari.password=atlasR0cks!
-atlas.graph.storage.rdbms.jpa.hikari.maximumPoolSize=40
-atlas.graph.storage.rdbms.jpa.hikari.minimumIdle=5
-atlas.graph.storage.rdbms.jpa.hikari.idleTimeout=300000
-atlas.graph.storage.rdbms.jpa.hikari.connectionTestQuery=select 1
-atlas.graph.storage.rdbms.jpa.hikari.maxLifetime=1800000
-atlas.graph.storage.rdbms.jpa.hikari.connectionTimeout=30000
-atlas.graph.storage.rdbms.jpa.javax.persistence.jdbc.dialect=org.eclipse.persistence.platform.database.PostgreSQLPlatform
-atlas.graph.storage.rdbms.jpa.javax.persistence.schema-generation.database.action=create
-atlas.graph.storage.rdbms.jpa.javax.persistence.schema-generation.create-database-schemas=true
-atlas.graph.storage.rdbms.jpa.javax.persistence.schema-generation.create-source=script
-atlas.graph.storage.rdbms.jpa.javax.persistence.schema-generation.create-script-source=META-INF/postgres/create_schema.sql
-atlas.EntityAuditRepository.impl=org.apache.atlas.repository.audit.rdbms.RdbmsBasedAuditRepository
-EOF
-  fi
-
-  chown -R atlas:atlas ${ATLAS_HOME}/
-
-  touch ${ATLAS_HOME}/.setupDone
+if [ ! -d "${ATLAS_EXPANDED_WEBAPP}" ]
+then
+  echo "Missing expanded Atlas webapp: ${ATLAS_EXPANDED_WEBAPP}" >&2
+  exit 1
 fi
 
 su -c "cd ${ATLAS_HOME}/bin && ./atlas_start.py" atlas


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Appropriate `atlas-application.properties` is mounted read-only according to `${ATLAS_BACKEND}`
- `users-credentials.properties` is mounted read-only
- Significant reduction in atlas image size
- Postgres initialization is done via a separate container `atlas-db-init` driven from docker compose file: `dev-support/atlas-docker/docker-compose.atlas-postgres.yml`, thereafter `Dockerfile.atlas-db` is no longer required - postgres image is pulled directly.
- Updated the README with instructions


## How was this patch tested?
```
docker compose -f docker-compose.atlas-base.yml build

export ATLAS_BACKEND=postgres
docker compose -f docker-compose.atlas.yml -f docker-compose.atlas-postgres.yml up -d --wait
```

- All containers come up
- `atlas-db-init` comes up and sets up the database and quits thereafter
- Atlas UI is working, no errors seen in `/var/log/atlas/application.log`