### PR TITLE
ATLAS-5310: Export/Import API : When tag attributes types get modified between the exports

### DIFF
--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -152,6 +152,7 @@ public final class Constants {
     public static final String INDEX_SEARCH_MAX_RESULT_SET_SIZE        = "atlas.graph.index.search.max-result-set-size";
     public static final String INDEX_SEARCH_TYPES_MAX_QUERY_STR_LENGTH = "atlas.graph.index.search.types.max-query-str-length";
     public static final String INDEX_SEARCH_TAGS_MAX_QUERY_STR_LENGTH  = "atlas.graph.index.search.tags.max-query-str-length";
+    public static final String INDEX_SEARCH_SOLR_MAX_TOKEN_LENGTH      = "atlas.graph.solr.index.search.max-token-length";
     public static final String INDEX_SEARCH_VERTEX_PREFIX_PROPERTY     = "atlas.graph.index.search.vertex.prefix";
     public static final String INDEX_SEARCH_VERTEX_PREFIX_DEFAULT      = "$v$";
     public static final String MAX_FULLTEXT_QUERY_STR_LENGTH = "atlas.graph.fulltext-max-query-str-length";

--- a/common/src/main/java/org/apache/atlas/repository/Constants.java
+++ b/common/src/main/java/org/apache/atlas/repository/Constants.java
@@ -152,7 +152,7 @@ public final class Constants {
     public static final String INDEX_SEARCH_MAX_RESULT_SET_SIZE        = "atlas.graph.index.search.max-result-set-size";
     public static final String INDEX_SEARCH_TYPES_MAX_QUERY_STR_LENGTH = "atlas.graph.index.search.types.max-query-str-length";
     public static final String INDEX_SEARCH_TAGS_MAX_QUERY_STR_LENGTH  = "atlas.graph.index.search.tags.max-query-str-length";
-    public static final String INDEX_SEARCH_SOLR_MAX_TOKEN_LENGTH      = "atlas.graph.solr.index.search.max-token-length";
+    public static final String INDEX_SEARCH_MAX_TOKEN_LENGTH           = "atlas.graph.index.search.max-token-length";
     public static final String INDEX_SEARCH_VERTEX_PREFIX_PROPERTY     = "atlas.graph.index.search.vertex.prefix";
     public static final String INDEX_SEARCH_VERTEX_PREFIX_DEFAULT      = "$v$";
     public static final String MAX_FULLTEXT_QUERY_STR_LENGTH = "atlas.graph.fulltext-max-query-str-length";

--- a/repository/src/main/java/org/apache/atlas/discovery/SearchProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/SearchProcessor.java
@@ -112,7 +112,7 @@ public abstract class SearchProcessor {
     public static final  int     MAX_RESULT_SIZE                 = getApplicationProperty(Constants.INDEX_SEARCH_MAX_RESULT_SET_SIZE, 150);
     public static final  int     MAX_QUERY_STR_LENGTH_TYPES      = getApplicationProperty(Constants.INDEX_SEARCH_TYPES_MAX_QUERY_STR_LENGTH, 512);
     public static final  int     MAX_QUERY_STR_LENGTH_TAGS       = getApplicationProperty(Constants.INDEX_SEARCH_TAGS_MAX_QUERY_STR_LENGTH, 512);
-    public static final  int     SOLR_MAX_TOKEN_STR_LENGTH       = getApplicationProperty(Constants.INDEX_SEARCH_SOLR_MAX_TOKEN_LENGTH, 255);
+    public static final  int     INDEX_SEARCH_MAX_TOKEN_STR_LENGTH = getApplicationProperty(Constants.INDEX_SEARCH_MAX_TOKEN_LENGTH, 255);
     public static final  String  INDEX_SEARCH_PREFIX             = AtlasGraphUtilsV2.getIndexSearchPrefix();
     public static final  String  AND_STR                         = " AND ";
     public static final  String  EMPTY_STRING                    = "";
@@ -868,12 +868,16 @@ public abstract class SearchProcessor {
                     LOG.debug("{} operator found for string attribute {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName);
 
                     ret = false;
-                } else if (operator == SearchParameters.Operator.CONTAINS && AtlasAttribute.hastokenizeChar(attributeValue) && indexType == null) { // indexType = TEXT
-                    LOG.debug("{} operator found for string (TEXT) attribute {} and special characters found in filter value {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName, attributeValue);
+                } else if (operator == SearchParameters.Operator.CONTAINS) {
+                    if (StringUtils.length(attributeValue) > INDEX_SEARCH_MAX_TOKEN_STR_LENGTH
+                            || (indexType == null && AtlasAttribute.hastokenizeChar(attributeValue))) {
+                        LOG.debug("{} operator found for string attribute {} and filter value {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName, attributeValue);
 
-                    ret = false;
-                } else if ((operator == SearchParameters.Operator.STARTS_WITH || operator == SearchParameters.Operator.ENDS_WITH || operator == SearchParameters.Operator.CONTAINS)  && attributeValue.length() > SOLR_MAX_TOKEN_STR_LENGTH) {
-                    LOG.debug("{} operator found for string attribute {} (SOLR MAX TOKEN STR LENGTH:{}) and filter value {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName, SOLR_MAX_TOKEN_STR_LENGTH, attributeValue);
+                        ret = false;
+                    }
+                } else if ((operator == SearchParameters.Operator.STARTS_WITH || operator == SearchParameters.Operator.ENDS_WITH)
+                        && StringUtils.length(attributeValue) > INDEX_SEARCH_MAX_TOKEN_STR_LENGTH) {
+                    LOG.debug("{} operator found for string attribute {} (max token length:{}) and filter value {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName, INDEX_SEARCH_MAX_TOKEN_STR_LENGTH, attributeValue);
 
                     ret = false;
                 }

--- a/repository/src/test/java/org/apache/atlas/discovery/EntitySearchProcessorTest.java
+++ b/repository/src/test/java/org/apache/atlas/discovery/EntitySearchProcessorTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.atlas.discovery;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.apache.atlas.AtlasClient;
 import org.apache.atlas.BasicTestSetup;
@@ -26,6 +27,7 @@ import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.discovery.SearchParameters;
 import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.EntityMutationResponse;
 import org.apache.atlas.repository.Constants;
@@ -35,6 +37,7 @@ import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasEntityStream;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
+import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +67,14 @@ import static org.testng.Assert.fail;
 public class EntitySearchProcessorTest extends BasicTestSetup {
     private static final Logger LOG = LoggerFactory.getLogger(EntitySearchProcessorTest.class);
 
+    private static final String HIVE_COLUMN_TYPE = "hive_column";
+
+    private static final String LONG_TABLE_NAME =
+            "rltdvhrxhocivajyqojaxulwzhgzgzpkfolziacfnndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjorziwhogwnjvsdrwksvrbxcxjlcrcmrvvmbdmenafmvgrqzcaqbgpnhxiqbvxcbnudafsmjzvlzzzzpqmjkngbximmbjbijrqfb";
+
+    private static final String LONG_TOKENIZED_TABLE_NAME =
+            "rrrrtokenizeeeeivajaxulwzhgzgzpkfoianndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjogrqzcaqbgpnhxiqbvxcbnudafsmaajzvlzzzzpqmjkngbximmbjbijrq1";
+
     private static final SimpleDateFormat FORMATTED_DATE       = new SimpleDateFormat("dd-MMM-yyyy");
     private static final String           EXPECTED_ENTITY_NAME = "hive_Table_Null_tableType";
     private static final TimeZone         TIME_ZONE_UTC        = TimeZone.getTimeZone("UTC");
@@ -88,6 +99,7 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         super.initialize();
 
         setupTestData();
+        createLongQualifiedNameTestEntities();
         createJapaneseEntityWithDescription();
         createChineseEntityWithDescription();
         FORMATTED_DATE.setTimeZone(TIME_ZONE_UTC);
@@ -200,7 +212,7 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         EntitySearchProcessor processor = new EntitySearchProcessor(context);
         List<AtlasVertex>     vertices  = processor.execute();
 
-        assertEquals(vertices.size(), 7);
+        assertEquals(vertices.size(), 10);
 
         List<String> nameList = new ArrayList<>();
         for (AtlasVertex vertex : vertices) {
@@ -278,7 +290,7 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         SearchContext context = new SearchContext(params, typeRegistry, graph, Collections.emptySet());
 
         EntitySearchProcessor processor = new EntitySearchProcessor(context);
-        assertEquals(processor.execute().size(), 14);
+        assertEquals(processor.execute().size(), 17);
     }
 
     @Test(expectedExceptions = AtlasBaseException.class, expectedExceptionsMessageRegExp = "Not_Exists: Unknown/invalid typename")
@@ -377,7 +389,7 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         EntitySearchProcessor processor = new EntitySearchProcessor(context);
         List<AtlasVertex>     vertices  = processor.execute();
 
-        assertEquals(vertices.size(), 7);
+        assertEquals(vertices.size(), 10);
 
         List<String> nameList = new ArrayList<>();
         for (AtlasVertex vertex : vertices) {
@@ -792,6 +804,131 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         assertTrue(guids.contains(cjkGuid2));
     }
 
+    @Test
+    public void searchTablesByQualifiedNameBeginswithAndEndswith() throws AtlasBaseException {
+        SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
+        List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
+
+        filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
+
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.STARTS_WITH, "Sales.sample_table"));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
+        filterCriteria.setCriterion(lstCriterion);
+
+        SearchParameters      params    = getSearchParameters(HIVE_TABLE_TYPE, filterCriteria, 20);
+        SearchContext         context   = new SearchContext(params, typeRegistry, graph, indexer.getVertexIndexKeys());
+        EntitySearchProcessor processor = new EntitySearchProcessor(context);
+        List<AtlasVertex>     vertices  = processor.execute();
+
+        assertEquals(vertices.size(), 1);
+    }
+
+    @Test
+    public void searchTablesByLongQualifiedNameBeginswithAndEndswith() throws AtlasBaseException {
+        SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
+        filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
+        List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.STARTS_WITH, "Sales.rltdvhrxhocivajyqojaxulwzhgzgzpkfolziacfnndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjorziwhogwnjvsdrwksvrbxcxjlcrcmrvvmbdmenafmvgrqzcaqbgpnhxiqbvxcbnudafsmjzvlzzzzpqmjkngbximmbjbijrqfb"));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
+        filterCriteria.setCriterion(lstCriterion);
+
+        SearchParameters      params    = getSearchParameters(HIVE_TABLE_TYPE, filterCriteria, 20);
+        SearchContext         context   = new SearchContext(params, typeRegistry, graph, indexer.getVertexIndexKeys());
+        EntitySearchProcessor processor = new EntitySearchProcessor(context);
+        List<AtlasVertex>     vertices  = processor.execute();
+
+        assertEquals(vertices.size(), 1);
+    }
+
+    @Test
+    public void searchColumnsByQualifiedNameBeginswithAndEndswith() throws AtlasBaseException {
+        SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
+        filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
+        List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.STARTS_WITH, "Sales.sample_table."));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
+        filterCriteria.setCriterion(lstCriterion);
+
+        SearchParameters      params    = getSearchParameters(HIVE_COLUMN_TYPE, filterCriteria, 20);
+        SearchContext         context   = new SearchContext(params, typeRegistry, graph, indexer.getVertexIndexKeys());
+        EntitySearchProcessor processor = new EntitySearchProcessor(context);
+        List<AtlasVertex>     vertices  = processor.execute();
+
+        assertEquals(vertices.size(), 6);
+    }
+
+    @Test
+    public void searchColumnsByLongQualifiedNameBeginswithAndEndswith() throws AtlasBaseException {
+        SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
+        filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
+        List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.STARTS_WITH, "Sales.rltdvhrxhocivajyqojaxulwzhgzgzpkfolziacfnndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjorziwhogwnjvsdrwksvrbxcxjlcrcmrvvmbdmenafmvgrqzcaqbgpnhxiqbvxcbnudafsmjzvlzzzzpqmjkngbximmbjbijrqfb."));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
+        filterCriteria.setCriterion(lstCriterion);
+
+        SearchParameters      params    = getSearchParameters(HIVE_COLUMN_TYPE, filterCriteria, 20);
+        SearchContext         context   = new SearchContext(params, typeRegistry, graph, indexer.getVertexIndexKeys());
+        EntitySearchProcessor processor = new EntitySearchProcessor(context);
+        List<AtlasVertex>     vertices  = processor.execute();
+
+        assertEquals(vertices.size(), 5);
+    }
+
+    @Test
+    public void searchTablesByLongTokenizedQualifiedNameBeginswithAndEndswith() throws AtlasBaseException {
+        SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
+        filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
+        List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.STARTS_WITH, "Sales.rrrrtokenizeeeeivajaxulwzhgzgzpkfoianndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjogrqzcaqbgpnhxiqbvxcbnudafsmaajzvlzzzzpqmjkngbximmbjbijrq1"));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
+        filterCriteria.setCriterion(lstCriterion);
+
+        SearchParameters      params    = getSearchParameters(HIVE_TABLE_TYPE, filterCriteria, 20);
+        SearchContext         context   = new SearchContext(params, typeRegistry, graph, indexer.getVertexIndexKeys());
+        EntitySearchProcessor processor = new EntitySearchProcessor(context);
+        List<AtlasVertex>     vertices  = processor.execute();
+
+        assertEquals(vertices.size(), 1);
+    }
+
+    @Test
+    public void searchTablesByQualifiedNameContainsAndEndswith() throws AtlasBaseException {
+        SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
+        List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
+
+        filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
+
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.CONTAINS, ".sample_table"));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
+        filterCriteria.setCriterion(lstCriterion);
+
+        SearchParameters      params    = getSearchParameters(HIVE_TABLE_TYPE, filterCriteria, 20);
+        SearchContext         context   = new SearchContext(params, typeRegistry, graph, indexer.getVertexIndexKeys());
+        EntitySearchProcessor processor = new EntitySearchProcessor(context);
+        List<AtlasVertex>     vertices  = processor.execute();
+
+        assertEquals(vertices.size(), 1);
+    }
+
+    @Test
+    public void searchTableByLongQualifiedNameContainsAndEndswith() throws AtlasBaseException {
+        SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
+        List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
+
+        filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
+
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.CONTAINS, ".rltdvhrxhocivajyqojaxulwzhgzgzpkfolziacfnndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjorziwhogwnjvsdrwksvrbxcxjlcrcmrvvmbdmenafmvgrqzcaqbgpnhxiqbvxcbnudafsmjzvlzzzzpqmjkngbximmbjbijrqfb"));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
+        filterCriteria.setCriterion(lstCriterion);
+
+        SearchParameters      params    = getSearchParameters(HIVE_TABLE_TYPE, filterCriteria, 20);
+        SearchContext         context   = new SearchContext(params, typeRegistry, graph, indexer.getVertexIndexKeys());
+        EntitySearchProcessor processor = new EntitySearchProcessor(context);
+        List<AtlasVertex>     vertices  = processor.execute();
+
+        assertEquals(vertices.size(), 1);
+    }
+
     private static SearchParameters.FilterCriteria filtercriteriaDateRange(String attributeValue, AtlasTypeRegistry typeRegistry, AtlasGraph graph) throws AtlasBaseException {
         SearchParameters.FilterCriteria filterCriteria = new SearchParameters.FilterCriteria();
         SearchParameters                params         = new SearchParameters();
@@ -857,6 +994,78 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         SearchContext context = new SearchContext(params, typeRegistry, graph, Collections.emptySet());
         EntitySearchProcessor processor = new EntitySearchProcessor(context);
 
-        assertEquals(processor.getResultCount(), 11);
+        assertEquals(processor.getResultCount(), 14);
+    }
+
+    private void createLongQualifiedNameTestEntities() throws AtlasBaseException {
+        AtlasEntityType entityType = typeRegistry.getEntityTypeByName(DATABASE_TYPE);
+        AtlasEntity     salesDB    = entityStore.getByUniqueAttributes(entityType,
+                Collections.singletonMap(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, "qualified:Sales")).getEntity();
+
+        AtlasEntity sd = storageDescriptor("hdfs://host:8000/apps/warehouse/sales", "TextInputFormat", "TextOutputFormat", true,
+                ImmutableList.of(column("time_id", "int", "time id")));
+
+        List<AtlasEntity> entities = new ArrayList<>();
+        entities.add(sd);
+
+        List<AtlasEntity> sampleColumns = ImmutableList.of(column("sm_time_id", "int", "time id"),
+                column("sm_product_id", "int", "product id"),
+                column("sm_customer_id", "int", "customer id"),
+                column("sm_sales", "double", "product id"),
+                column("sm_test", "int", "test 1"),
+                column("sm_test_limit", "int", "test limit 1"));
+
+        entities.addAll(sampleColumns);
+        entities.add(createTableWithClusterQualifiedName("sample_table", "sample table", salesDB, sd, "Dev 1", "Managed", sampleColumns));
+
+        List<AtlasEntity> longTableNameColumns = ImmutableList.of(column("l_id", "int", "time id"),
+                column("l_product_id", "int", "product id"),
+                column("l_customer_id", "int", "customer id"),
+                column("l_sales", "double", "product id"),
+                column("l_test", "int", "test 1"));
+
+        entities.addAll(longTableNameColumns);
+        entities.add(createTableWithClusterQualifiedName(LONG_TABLE_NAME, "table name length 300", salesDB, sd, "Dev 2", "Managed", longTableNameColumns));
+
+        List<AtlasEntity> longTokenizeTableNameColumns = ImmutableList.of(column("l_tknz_id", "int", "time id"),
+                column("l_tknz_product_id", "int", "product id"),
+                column("l_tknz_sales", "double", "product id"),
+                column("l_tknz_test", "int", "test 1"));
+
+        entities.addAll(longTokenizeTableNameColumns);
+        entities.add(createTableWithClusterQualifiedName(LONG_TOKENIZED_TABLE_NAME, "table name length 300, Tokenized", salesDB, sd, "Dev 3", "Managed", longTokenizeTableNameColumns));
+
+        entityStore.createOrUpdate(new AtlasEntityStream(new AtlasEntitiesWithExtInfo(entities)), false);
+    }
+
+    private AtlasEntity createTableWithClusterQualifiedName(String name, String description, AtlasEntity db, AtlasEntity sd,
+            String owner, String tableType, List<AtlasEntity> columns, String... traitNames) {
+        AtlasEntity table = table(name, description, db, sd, owner, tableType, columns, traitNames);
+        String      dbName      = db.getAttribute(AtlasClient.NAME).toString();
+        String      clusterName = db.getAttribute("clusterName").toString();
+
+        table.setAttribute(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, dbName + "." + name + "@" + clusterName);
+
+        return table;
+    }
+
+    private SearchParameters.FilterCriteria getSingleFilterCriteria(String attName, SearchParameters.Operator op, String attrValue) {
+        SearchParameters.FilterCriteria filterCriteria = new SearchParameters.FilterCriteria();
+        filterCriteria.setAttributeName(attName);
+        filterCriteria.setOperator(op);
+        filterCriteria.setAttributeValue(attrValue);
+
+        return filterCriteria;
+    }
+
+    private SearchParameters getSearchParameters(String typeName, SearchParameters.FilterCriteria entityFilter, int limit) {
+        SearchParameters params = new SearchParameters();
+        params.setTypeName(typeName);
+        if (entityFilter != null) {
+            params.setEntityFilters(entityFilter);
+        }
+        params.setLimit(limit);
+
+        return params;
     }
 }

--- a/repository/src/test/java/org/apache/atlas/discovery/EntitySearchProcessorTest.java
+++ b/repository/src/test/java/org/apache/atlas/discovery/EntitySearchProcessorTest.java
@@ -73,7 +73,7 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
             "rltdvhrxhocivajyqojaxulwzhgzgzpkfolziacfnndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjorziwhogwnjvsdrwksvrbxcxjlcrcmrvvmbdmenafmvgrqzcaqbgpnhxiqbvxcbnudafsmjzvlzzzzpqmjkngbximmbjbijrqfb";
 
     private static final String LONG_TOKENIZED_TABLE_NAME =
-            "rrrrtokenizeeeeivajaxulwzhgzgzpkfoianndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjogrqzcaqbgpnhxiqbvxcbnudafsmaajzvlzzzzpqmjkngbximmbjbijrq1";
+            "rrrr.tokenize:eeeivajaxulwzhgzgzpkfoianndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjogrqzcaqbgpnhxiqbvxcbnudafsmaajzvlzzzzpqmjkngbximmbjbijrq1";
 
     private static final SimpleDateFormat FORMATTED_DATE       = new SimpleDateFormat("dd-MMM-yyyy");
     private static final String           EXPECTED_ENTITY_NAME = "hive_Table_Null_tableType";
@@ -879,7 +879,7 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
         filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
         List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
-        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.STARTS_WITH, "Sales.rrrrtokenizeeeeivajaxulwzhgzgzpkfoianndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjogrqzcaqbgpnhxiqbvxcbnudafsmaajzvlzzzzpqmjkngbximmbjbijrq1"));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.STARTS_WITH, "Sales.rrrr.tokenize:eeeivajaxulwzhgzgzpkfoianndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjogrqzcaqbgpnhxiqbvxcbnudafsmaajzvlzzzzpqmjkngbximmbjbijrq1"));
         lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
         filterCriteria.setCriterion(lstCriterion);
 
@@ -899,6 +899,25 @@ public class EntitySearchProcessorTest extends BasicTestSetup {
         filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
 
         lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.CONTAINS, ".sample_table"));
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
+        filterCriteria.setCriterion(lstCriterion);
+
+        SearchParameters      params    = getSearchParameters(HIVE_TABLE_TYPE, filterCriteria, 20);
+        SearchContext         context   = new SearchContext(params, typeRegistry, graph, indexer.getVertexIndexKeys());
+        EntitySearchProcessor processor = new EntitySearchProcessor(context);
+        List<AtlasVertex>     vertices  = processor.execute();
+
+        assertEquals(vertices.size(), 1);
+    }
+
+    @Test
+    public void searchTableByLongTokenizedQualifiedNameContainsAndEndswith() throws AtlasBaseException {
+        SearchParameters.FilterCriteria filterCriteria          = new SearchParameters.FilterCriteria();
+        List<SearchParameters.FilterCriteria> lstCriterion      = new ArrayList<>();
+
+        filterCriteria.setCondition(SearchParameters.FilterCriteria.Condition.AND);
+
+        lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.CONTAINS, ".rrrr.tokenize:eeeivajaxulwzhgzgzpkfoianndzncjkthzeaeykdhhrjqdeibhdgiepwqkinvqzqxevushydtwjaabzgbfjmzvcbsoxewruhyhciyjefzsnokxvbeiiowzbhlkmujcnwilslgeswobzwwvkugyupsemqxsbdcmgrlpxmeuljvxyddvpccvcloupjogrqzcaqbgpnhxiqbvxcbnudafsmaajzvlzzzzpqmjkngbximmbjbijrq1"));
         lstCriterion.add(getSingleFilterCriteria(AtlasClient.REFERENCEABLE_ATTRIBUTE_NAME, SearchParameters.Operator.ENDS_WITH, "@cl1"));
         filterCriteria.setCriterion(lstCriterion);
 


### PR DESCRIPTION
What changes were proposed in this pull request?
CDPD-69317: Export/Import API — handle tag attribute type changes between exports

When a tag/classification attribute’s type changed between two exports (e.g. attrib1 was date in the target Atlas instance but string in the import bundle), import previously failed with INVALID_IMPORT_ATTRIBUTE_TYPE_CHANGED.

This patch allows import to succeed in that scenario by:

TypeAttributeDifference — Treat attribute type mismatches as updatable differences instead of throwing INVALID_IMPORT_ATTRIBUTE_TYPE_CHANGED.
AtlasStructDefStoreV2 — Skip the “Data type update for attribute is not supported” guard when an import is in progress.
GraphBackedSearchIndexer — During import, if a graph property key already exists with a different Java type, delete and recreate it (JanusGraph does not support in-place type changes).
AtlasGraphManagement / AtlasJanusGraphManagement — Add getPropertyKeyDataType() to read the registered type of an existing property key.
Example: Import bundle defines tag1 with attrib1=string, attrib2=int, attrib3=int, while the target has tag1 with attrib1=date, attrib3=int. Import now completes and updates attrib1 to string, adds attrib2, and keeps attrib3.

How was this patch tested?
Unit tests
TypeAttributeDifferenceTest.attributeTypeChange_ReturnsUpdatedAttribute — verifies a changed attribute type is returned as a difference to apply.
ImportServiceTest.importHdfs_path1 — updated from expecting INVALID_IMPORT_ATTRIBUTE_TYPE_CHANGED to asserting successful import with updated tag attributes (attrib1=string, attrib2=int, attrib3=int) using hdfs_path1.zip and tag1.json.