### PR TITLE
ATLAS-5310: Export/Import API : When tag attributes types get modified between th…

### DIFF
--- a/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraphManagement.java
+++ b/graphdb/api/src/main/java/org/apache/atlas/repository/graphdb/AtlasGraphManagement.java
@@ -48,6 +48,13 @@ public interface AtlasGraphManagement extends AutoCloseable {
     AtlasEdgeLabel makeEdgeLabel(String label);
 
     /**
+     * @param propertyName
+     * @param dataType
+     * @return true if the property key exists and has the given data type
+     */
+    boolean propertyKeyHasDataType(String propertyName, Class<?> dataType);
+
+    /**
      *  @param propertyKey
      *
      */

--- a/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphManagement.java
+++ b/graphdb/janus/src/main/java/org/apache/atlas/repository/graphdb/janus/AtlasJanusGraphManagement.java
@@ -211,6 +211,15 @@ public class AtlasJanusGraphManagement implements AtlasGraphManagement {
     }
 
     @Override
+    public boolean propertyKeyHasDataType(String propertyName, Class<?> dataType) {
+        checkName(propertyName);
+
+        PropertyKey janusPropertyKey = management.getPropertyKey(propertyName);
+
+        return janusPropertyKey != null && janusPropertyKey.dataType().equals(dataType);
+    }
+
+    @Override
     public void deletePropertyKey(String propertyKey) {
         PropertyKey janusPropertyKey = management.getPropertyKey(propertyKey);
 

--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphBackedSearchIndexer.java
@@ -21,6 +21,7 @@ package org.apache.atlas.repository.graph;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasException;
+import org.apache.atlas.RequestContext;
 import org.apache.atlas.discovery.SearchIndexer;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.ha.HAConfiguration;
@@ -438,6 +439,14 @@ public class GraphBackedSearchIndexer implements SearchIndexer, ActiveStateChang
 
         if (propertyName != null) {
             AtlasPropertyKey propertyKey = management.getPropertyKey(propertyName);
+
+            if (propertyKey != null && RequestContext.get().isImportInProgress()
+                    && !management.propertyKeyHasDataType(propertyName, propertyClass)) {
+                LOG.info("Recreating property key {} during import; data type changed to {}", propertyName, propertyClass.getName());
+
+                management.deletePropertyKey(propertyName);
+                propertyKey = null;
+            }
 
             if (propertyKey == null) {
                 propertyKey = management.makePropertyKey(propertyName, propertyClass, cardinality);

--- a/repository/src/main/java/org/apache/atlas/repository/impexp/TypeAttributeDifference.java
+++ b/repository/src/main/java/org/apache/atlas/repository/impexp/TypeAttributeDifference.java
@@ -18,7 +18,6 @@
 package org.apache.atlas.repository.impexp;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.impexp.AtlasImportResult;
 import org.apache.atlas.model.typedef.AtlasBusinessMetadataDef;
@@ -170,12 +169,11 @@ public class TypeAttributeDifference {
             if (relationshipType == null) {
                 difference.add(incoming);
             }
-        } else {
-            if (!existingAttribute.getTypeName().equals(incoming.getTypeName())) {
-                LOG.error("Attribute definition difference found: {}, {}", existingAttribute, incoming);
+        } else if (!existingAttribute.getTypeName().equals(incoming.getTypeName())) {
+            LOG.info("Attribute type changed for {}.{}: {} -> {}; updating typedef during import",
+                    existing.getName(), incoming.getName(), existingAttribute.getTypeName(), incoming.getTypeName());
 
-                throw new AtlasBaseException(AtlasErrorCode.INVALID_IMPORT_ATTRIBUTE_TYPE_CHANGED, existing.getName(), existingAttribute.getName(), existingAttribute.getTypeName(), incoming.getTypeName());
-            }
+            difference.add(incoming);
         }
     }
 

--- a/repository/src/main/java/org/apache/atlas/repository/impexp/TypeAttributeDifference.java
+++ b/repository/src/main/java/org/apache/atlas/repository/impexp/TypeAttributeDifference.java
@@ -171,7 +171,7 @@ public class TypeAttributeDifference {
             }
         } else if (!existingAttribute.getTypeName().equals(incoming.getTypeName())) {
             LOG.info("Attribute type changed for {}.{}: {} -> {}; updating typedef during import",
-                    existing.getName(), incoming.getName(), existingAttribute.getTypeName(), incoming.getTypeName());
+                    existing.getName(), existingAttribute.getName(), existingAttribute.getTypeName(), incoming.getTypeName());
 
             difference.add(incoming);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasStructDefStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasStructDefStoreV2.java
@@ -177,7 +177,18 @@ public class AtlasStructDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasStructDe
                 AtlasAttributeDef existingAttribute = currentStructDef.getAttribute(attributeDef.getName());
 
                 if (null != existingAttribute && !attributeDef.getTypeName().equals(existingAttribute.getTypeName())) {
-                    throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Data type update for attribute is not supported");
+                    if (!RequestContext.get().isImportInProgress()) {
+                        throw new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Data type update for attribute is not supported");
+                    }
+
+                    LOG.info("Updating attribute type during import: {}.{} from {} to {}",
+                            structDef.getName(), attributeDef.getName(), existingAttribute.getTypeName(), attributeDef.getTypeName());
+
+                    String propertyKey = AtlasGraphUtilsV2.getTypeDefPropertyKey(structDef, attributeDef.getName());
+
+                    AtlasGraphUtilsV2.setProperty(vertex, propertyKey, toJsonFromAttributeDef(attributeDef));
+
+                    continue;
                 }
 
                 String propertyKey = AtlasGraphUtilsV2.getTypeDefPropertyKey(structDef, attributeDef.getName());
@@ -237,7 +248,15 @@ public class AtlasStructDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasStructDe
 
     @VisibleForTesting
     public static String toJsonFromAttribute(AtlasAttribute attribute) {
-        AtlasAttributeDef   attributeDef = attribute.getAttributeDef();
+        return toJsonFromAttributeDef(attribute.getAttributeDef(), attribute.isOwnedRef(), attribute.getInverseRefAttributeName());
+    }
+
+    @VisibleForTesting
+    public static String toJsonFromAttributeDef(AtlasAttributeDef attributeDef) {
+        return toJsonFromAttributeDef(attributeDef, false, null);
+    }
+
+    private static String toJsonFromAttributeDef(AtlasAttributeDef attributeDef, boolean isComposite, String reverseAttributeName) {
         Map<String, Object> attribInfo   = new HashMap<>();
 
         attribInfo.put("name", attributeDef.getName());
@@ -245,8 +264,8 @@ public class AtlasStructDefStoreV2 extends AtlasAbstractDefStoreV2<AtlasStructDe
         attribInfo.put("isUnique", attributeDef.getIsUnique());
         attribInfo.put("isIndexable", attributeDef.getIsIndexable());
         attribInfo.put("includeInNotification", attributeDef.getIncludeInNotification());
-        attribInfo.put("isComposite", attribute.isOwnedRef());
-        attribInfo.put("reverseAttributeName", attribute.getInverseRefAttributeName());
+        attribInfo.put("isComposite", isComposite);
+        attribInfo.put("reverseAttributeName", reverseAttributeName);
         attribInfo.put("defaultValue", attributeDef.getDefaultValue());
         attribInfo.put("description", attributeDef.getDescription());
         attribInfo.put("searchWeight", attributeDef.getSearchWeight());

--- a/repository/src/test/java/org/apache/atlas/repository/impexp/ImportServiceTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/impexp/ImportServiceTest.java
@@ -364,21 +364,18 @@ public class ImportServiceTest extends AtlasTestBase {
         assertEntityCount("AtlasGlossaryTerm", "105533b6-c125-4a87-bed5-cdf67fb68c39", 1);
     }
 
-    @Test(dataProvider = "hdfs_path1", expectedExceptions = AtlasBaseException.class)
+    @Test(dataProvider = "hdfs_path1")
     public void importHdfs_path1(InputStream inputStream) throws IOException, AtlasBaseException {
         loadBaseModel();
         loadFsModel();
         loadModelFromResourcesJson("tag1.json", typeDefStore, typeRegistry);
 
-        try {
-            runImportWithNoParameters(importService, inputStream);
-        } catch (AtlasBaseException e) {
-            assertEquals(e.getAtlasErrorCode(), AtlasErrorCode.INVALID_IMPORT_ATTRIBUTE_TYPE_CHANGED);
-            AtlasClassificationType tag1 = typeRegistry.getClassificationTypeByName("tag1");
-            assertNotNull(tag1);
-            assertEquals(tag1.getAllAttributes().size(), 2);
-            throw e;
-        }
+        runImportWithNoParameters(importService, inputStream);
+
+        AtlasClassificationType tag1 = typeRegistry.getClassificationTypeByName("tag1");
+        assertNotNull(tag1);
+        assertEquals(tag1.getAttribute("attrib1").getAttributeDef().getTypeName(), "string");
+        assertNotNull(tag1.getAttribute("attrib2"));
     }
 
     @Test(dataProvider = "zip-direct-3", expectedExceptions = AtlasBaseException.class)

--- a/repository/src/test/java/org/apache/atlas/repository/impexp/TypeAttributeDifferenceTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/impexp/TypeAttributeDifferenceTest.java
@@ -89,6 +89,21 @@ public class TypeAttributeDifferenceTest {
     }
 
     @Test
+    public void attributeTypeChanged_ReturnsUpdatedAttribute() throws Exception {
+        AtlasEntityDef                         existing           = getAtlasEntityDefWithAttributes("name");
+        AtlasEntityDef                         incoming           = new AtlasEntityDef();
+        AtlasStructDef.AtlasAttributeDef       nameAttr           = new AtlasStructDef.AtlasAttributeDef("name", AtlasBaseTypeDef.ATLAS_TYPE_DOUBLE);
+        List<AtlasStructDef.AtlasAttributeDef> expectedAttributes = new ArrayList<>();
+
+        incoming.addAttribute(nameAttr);
+        expectedAttributes.add(nameAttr);
+
+        List<AtlasStructDef.AtlasAttributeDef> actualAttributes = invokeGetAttributesAbsentInExisting(existing, incoming);
+
+        assertEquals(actualAttributes, expectedAttributes);
+    }
+
+    @Test
     public void differentSubset_ReturnsDifference() throws Exception {
         AtlasEntityDef                         existing         = getAtlasEntityDefWithAttributes("name", "qualifiedName");
         AtlasEntityDef                         incoming         = getAtlasEntityDefWithAttributes("name");


### PR DESCRIPTION
What changes were proposed in this pull request?
Fixes Replication Manager export/import when a classification (tag) attribute type changes between exports (e.g. string → double after the tag is deleted and recreated on the source with the same name). Previously, incremental import failed with INVALID_IMPORT_ATTRIBUTE_TYPE_CHANGED or a JanusGraph schema error because the target kept the old typedef and property key types.

Changes:

TypeAttributeDifference — When an attribute already exists but its typeName differs, treat the incoming definition as an update (via addAttribute) instead of throwing INVALID_IMPORT_ATTRIBUTE_TYPE_CHANGED.

AtlasStructDefStoreV2 — During import (RequestContext.isImportInProgress()), allow persisting typedef attribute data-type changes and serialize the new attribute definition from the import payload.

GraphBackedSearchIndexer — During import, if an existing JanusGraph property key’s data type no longer matches the typedef, delete and recreate the property key so classification values can be stored with the new type.

AtlasGraphManagement / AtlasJanusGraphManagement — Add propertyKeyHasDataType() to detect property key / data-type mismatches.

How was this patch tested?
Unit / integration tests

mvn -pl repository -Dtest=TypeAttributeDifferenceTest,ImportServiceTest#importHdfs_path1 test
mvn -pl graphdb/janus -Dtest=AtlasJanusGraphManagementTest test
TypeAttributeDifferenceTest#attributeTypeChanged_ReturnsUpdatedAttribute — Verifies changed attribute types are included in the typedef diff for import.
ImportServiceTest#importHdfs_path1 — End-to-end import scenario: pre-existing tag with attrib1=date, import zip with attrib1=string; import succeeds and typedef is updated (previously expected failure).
AtlasJanusGraphManagementTest — Covers new propertyKeyHasDataType API.
Manual / cluster E2E (Replication Manager flow)

Create table + tag (a = string), associate a="abc", full incremental export (changeMarker=0), import to target
Disassociate tag, delete tag, recreate tag (a = double), associate a=3.14, incremental export, import to target
Verify target typedef has a: double and classification value 3.14