### PR TITLE
ATLAS-5318: Configure GitHub workflows to use concurrency cancel-in-progress for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ on:
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   docker-build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION

## What changes were proposed in this pull request?

ATLAS-5318: Configure GitHub workflows to use concurrency cancel-in-progress for pull requests

see recommended best practices at Apache
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices

## How was this patch tested?

similar changes tested on several other Apache repositories