### PR TITLE
ATLAS-5032: Updated CONTAINS so we only defer to JanusGraph when inde…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/SearchProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/SearchProcessor.java
@@ -877,8 +877,8 @@ public abstract class SearchProcessor {
                         ret = false;
                     }
                 } else if ((operator == SearchParameters.Operator.STARTS_WITH || operator == SearchParameters.Operator.ENDS_WITH)
-                        && StringUtils.length(attributeValue) > INDEX_SEARCH_MAX_TOKEN_STR_LENGTH) {
-                    LOG.debug("{} operator found for string attribute {} (max token length:{}) and filter value {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName, INDEX_SEARCH_MAX_TOKEN_STR_LENGTH, attributeValue);
+                        && indexType == null && StringUtils.length(attributeValue) > INDEX_SEARCH_MAX_TOKEN_STR_LENGTH) {
+                    LOG.debug("{} operator found for string (TEXT) attribute {} (max token length:{}) and filter value {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName, INDEX_SEARCH_MAX_TOKEN_STR_LENGTH, attributeValue);
 
                     ret = false;
                 }

--- a/repository/src/main/java/org/apache/atlas/discovery/SearchProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/SearchProcessor.java
@@ -869,9 +869,10 @@ public abstract class SearchProcessor {
 
                     ret = false;
                 } else if (operator == SearchParameters.Operator.CONTAINS) {
-                    if (StringUtils.length(attributeValue) > INDEX_SEARCH_MAX_TOKEN_STR_LENGTH
-                            || (indexType == null && AtlasAttribute.hastokenizeChar(attributeValue))) {
-                        LOG.debug("{} operator found for string attribute {} and filter value {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName, attributeValue);
+                    // TEXT attributes (indexType == null) use Solr tokenization; STRING attributes (Mapping.STRING) do not
+                    if (indexType == null && (StringUtils.length(attributeValue) > INDEX_SEARCH_MAX_TOKEN_STR_LENGTH
+                            || AtlasAttribute.hastokenizeChar(attributeValue))) {
+                        LOG.debug("{} operator found for string (TEXT) attribute {} and filter value {}, deferring to in-memory or graph query (might cause poor performance)", operator, qualifiedName, attributeValue);
 
                         ret = false;
                     }

--- a/repository/src/test/java/org/apache/atlas/discovery/SearchProcessorTest.java
+++ b/repository/src/test/java/org/apache/atlas/discovery/SearchProcessorTest.java
@@ -23,6 +23,8 @@ import org.apache.atlas.model.discovery.SearchParameters;
 import org.apache.atlas.model.discovery.SearchParameters.FilterCriteria;
 import org.apache.atlas.model.discovery.SearchParameters.FilterCriteria.Condition;
 import org.apache.atlas.model.discovery.SearchParameters.Operator;
+import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
+import org.apache.atlas.model.typedef.AtlasStructDef;
 import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.graphdb.AtlasEdge;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
@@ -32,7 +34,9 @@ import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.type.AtlasClassificationType;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasRelationshipType;
+import org.apache.atlas.type.AtlasStructType;
 import org.apache.atlas.type.AtlasStructType.AtlasAttribute;
+import org.apache.atlas.type.AtlasType;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.commons.collections.Predicate;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
@@ -47,6 +51,7 @@ import org.testng.annotations.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -533,6 +538,83 @@ public class SearchProcessorTest {
             // Expected with minimal setup - but exercises real code paths
             assertTrue(true);
         }
+    }
+
+    private static final String LONG_FILTER_VALUE;
+
+    static {
+        char[] chars = new char[300];
+        Arrays.fill(chars, 'x');
+        LONG_FILTER_VALUE = new String(chars);
+    }
+
+    @Test
+    public void testContainsLongValueTextIndexTypeNotIndexSearchable() throws Exception {
+        assertFalse(isIndexSearchableForAttribute("qualifiedName", "qualifiedName", Operator.CONTAINS,
+                LONG_FILTER_VALUE, null));
+    }
+
+    @Test
+    public void testContainsLongValueStringIndexTypeIsIndexSearchable() throws Exception {
+        assertTrue(isIndexSearchableForAttribute("owner", "__s_owner", Operator.CONTAINS,
+                LONG_FILTER_VALUE, AtlasStructDef.AtlasAttributeDef.IndexType.STRING));
+    }
+
+    @Test
+    public void testContainsShortValueTextIndexTypeIsIndexSearchable() throws Exception {
+        assertTrue(isIndexSearchableForAttribute("qualifiedName", "qualifiedName", Operator.CONTAINS,
+                "default.table", null));
+    }
+
+    @Test
+    public void testStartsWithLongValueTextIndexTypeNotIndexSearchable() throws Exception {
+        assertFalse(isIndexSearchableForAttribute("qualifiedName", "qualifiedName", Operator.STARTS_WITH,
+                LONG_FILTER_VALUE, null));
+    }
+
+    @Test
+    public void testStartsWithLongValueStringIndexTypeIsIndexSearchable() throws Exception {
+        assertTrue(isIndexSearchableForAttribute("owner", "__s_owner", Operator.STARTS_WITH,
+                LONG_FILTER_VALUE, AtlasStructDef.AtlasAttributeDef.IndexType.STRING));
+    }
+
+    @Test
+    public void testEndsWithLongValueTextIndexTypeNotIndexSearchable() throws Exception {
+        assertFalse(isIndexSearchableForAttribute("qualifiedName", "qualifiedName", Operator.ENDS_WITH,
+                LONG_FILTER_VALUE, null));
+    }
+
+    @Test
+    public void testEndsWithLongValueStringIndexTypeIsIndexSearchable() throws Exception {
+        assertTrue(isIndexSearchableForAttribute("owner", "__s_owner", Operator.ENDS_WITH,
+                LONG_FILTER_VALUE, AtlasStructDef.AtlasAttributeDef.IndexType.STRING));
+    }
+
+    private boolean isIndexSearchableForAttribute(String attributeName, String vertexPropertyName,
+                                                 Operator operator, String attributeValue,
+                                                 AtlasStructDef.AtlasAttributeDef.IndexType indexType) throws Exception {
+        FilterCriteria filterCriteria = new FilterCriteria();
+        filterCriteria.setAttributeName(attributeName);
+        filterCriteria.setOperator(operator);
+        filterCriteria.setAttributeValue(attributeValue);
+
+        AtlasStructType structType = mock(AtlasStructType.class);
+        AtlasType         attrType = mock(AtlasType.class);
+        AtlasStructDef.AtlasAttributeDef attributeDef = mock(AtlasStructDef.AtlasAttributeDef.class);
+
+        when(structType.getAttributeType(attributeName)).thenReturn(attrType);
+        when(attrType.getTypeName()).thenReturn(AtlasBaseTypeDef.ATLAS_TYPE_STRING);
+        when(structType.getVertexPropertyName(attributeName)).thenReturn(vertexPropertyName);
+        when(structType.getAttributeDef(attributeName)).thenReturn(attributeDef);
+        when(attributeDef.getIndexType()).thenReturn(indexType);
+
+        Set<String> indexedKeys = new HashSet<>(Collections.singletonList(vertexPropertyName));
+        when(context.getIndexedKeys()).thenReturn(indexedKeys);
+        when(context.getEdgeIndexKeys()).thenReturn(Collections.emptySet());
+
+        Method method = SearchProcessor.class.getDeclaredMethod("isIndexSearchable", FilterCriteria.class, AtlasStructType.class);
+        method.setAccessible(true);
+        return (Boolean) method.invoke(searchProcessor, filterCriteria, structType);
     }
 
     @Test


### PR DESCRIPTION
What changes were proposed in this pull request?

indexType STRING fields are indexed without tokenization (Mapping.STRING), so that issue applies to TEXT attributes (indexType == null), not STRING.
qualifiedName uses default TEXT indexing and attributes with indexType: STRING (e.g. name, owner) don't have this tokenization problem.
 Update the CONTAINS check so we only fall back to Janus graph when indexType == null and either the filter value exceeds max token length or contains tokenize characters. STRING indexType attributes will keep using index search for long CONTAINS values.

[ATLAS-5032](https://issues.apache.org/jira/browse/ATLAS-5032): Fix basic search for long qualifiedName with startsWith / endsWith / contains

Problem
Basic search with attribute filters on qualifiedName returns no results when filter values exceed Solr’s default max token length (255). This affects startsWith, endsWith, and contains, especially when multiple criteria on the same attribute are combined with AND (e.g. qualifiedName starts with a long prefix and ends with @primary).

Root cause: Solr ignores tokens longer than maxTokenLength, so index-based search does not match even though the entity exists and can be retrieved by GUID.

Solution (Approach 2 from [ATLAS-5032](https://issues.apache.org/jira/browse/ATLAS-5032))
For indexed string attributes, when the filter value length exceeds the configured Solr token limit, do not use the Solr index for STARTS_WITH, ENDS_WITH, or CONTAINS. Search falls back to JanusGraph instead.

Also ensure index and graph query paths stay consistent when the same attribute appears in multiple AND criteria:

Skip graph filter construction when the criterion is still index-searchable.
Skip index query construction when the criterion is not index-searchable.

How was this patch tested?
Unit / module tests
EntitySearchProcessorTest — 48 tests, including 6 new [ATLAS-5032](https://issues.apache.org/jira/browse/ATLAS-5032) scenarios (short and long qualifiedName, hive_table and hive_column, tokenized name, CONTAINS + ENDS_WITH).
Full repository module: mvn -pl repository test — 2391 tests, 0 failures.
mvn -pl common,repository -DskipTests install — build success.
Manual / REST (local Docker Atlas)
Reproduced the JIRA flow against http://localhost:21000/:

Created a hive_table with a ~370-character name and qualifiedName default.@primary.
Basic search with AND:
qualifiedName startsWith default.<370-char-name>
qualifiedName endsWith @primary
Result: 1 matching entity (previously empty).