### PR TITLE
ATLAS-5309 : Allow unauthenticated access to Swagger apidocs static a…

### DIFF
--- a/build-tools/src/main/resources/ui-dist/index.js
+++ b/build-tools/src/main/resources/ui-dist/index.js
@@ -128,6 +128,11 @@
     };
     function fetchCsrfHeader() {
         var response = getSessionDetails();
+
+        if (!response) {
+            return;
+        }
+
         if (!csrfEnabled && response['atlas.rest-csrf.enabled']) {
             var str = "" + response['atlas.rest-csrf.enabled'];
             csrfEnabled = (str.toLowerCase() == 'true');

--- a/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
+++ b/webapp/src/main/java/org/apache/atlas/web/security/AtlasSecurityConfig.java
@@ -190,7 +190,8 @@ public class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
                 "/libs/**", "/n/libs/**",
                 "/js/**", "/n/js/**",
                 "/ieerror.html", "/migration-status.html",
-                "/api/atlas/admin/status"));
+                "/api/atlas/admin/status",
+                "/apidocs/**"));
 
         if (!keycloakEnabled) {
             matchers.add("/login.jsp");

--- a/webapp/src/main/resources/spring-security.xml
+++ b/webapp/src/main/resources/spring-security.xml
@@ -28,6 +28,7 @@
     <security:http pattern="/ieerror.html" security="none" />
     <security:http pattern="/api/atlas/admin/status" security="none" />
     <security:http pattern="/api/atlas/admin/metrics" security="none" />
+    <security:http pattern="/apidocs/**" security="none" />
 
     <security:http create-session="always"
                    entry-point-ref="entryPoint">


### PR DESCRIPTION
…ssets

## What changes were proposed in this pull request?

Added /apidocs/** to security exclusions in AtlasSecurityConfig.java and spring-security.xml to allow anonymous access to Swagger UI assets and OpenAPI documentation.
Updated index.js to handle anonymous users and prevent CSRF-related JavaScript errors when no session is available.


## How was this patch tested?

Verified Swagger UI and openapi.json are accessible without authentication.
Confirmed Swagger UI loads successfully for anonymous users.
Verified existing authenticated Atlas APIs works.