### PR TITLE
ATLAS-5323: Atlas React UI: Upgrade and stabilize core frontend build  dependencies

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -71,7 +71,7 @@
         "semver": "7.5.4",
         "ts-jest": "29.4.6",
         "typescript": "5.2.2",
-        "vite": "6.4.2"
+        "vite": "6.4.3"
       },
       "optionalDependencies": {
         "@rollup/rollup-darwin-arm64": "4.59.0",
@@ -6262,14 +6262,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6519,7 +6521,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8763,11 +8767,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -10080,17 +10086,6 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "dev": true,
@@ -10466,9 +10461,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmmirror.com/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10554,17 +10549,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/walker": {
@@ -10671,7 +10655,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -87,7 +87,7 @@
     "semver": "7.5.4",
     "ts-jest": "29.4.6",
     "typescript": "5.2.2",
-    "vite": "6.4.2"
+    "vite": "6.4.3"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "4.59.0",
@@ -115,6 +115,9 @@
     "immutable": "4.3.8",
     "handlebars": "4.7.9",
     "axios": "1.16.0",
-    "@babel/plugin-transform-modules-systemjs": "7.29.4"
+    "@babel/plugin-transform-modules-systemjs": "7.29.4",
+    "form-data": "4.0.6",
+    "picomatch": "4.0.4",
+    "ws": "8.21.0"
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of ongoing maintenance to keep the Atlas Dashboard UI healthy, modern, and reliable, this PR upgrades several key frontend build and tooling dependencies to their latest stable releases. This ensures the project benefits from the latest performance improvements, stability enhancements, and upstream bug fixes.

The following core packages (and their sub-dependencies) have been bumped:
* `vite`
* `ws`
* `picomatch`
* `form-data`

## How was this patch tested?

This patch was tested by verifying the acceptance criteria outlined in the JIRA issue:
* Ensured the project builds successfully (`npm run build`) without any regressions or breaking changes.
* Verified that the local development server starts properly and serves the dashboard UI correctly (`npm run dev`).
* Ensured all existing test suites pass successfully after the dependency bump (`npm run test`).
