### PR TITLE
ATLAS-5333: Atlas React UI: Clearing a Classification search filter triggers 400 Bad Request on empty parameters

### DIFF
--- a/dashboard/src/utils/dashboardSearchUtils.ts
+++ b/dashboard/src/utils/dashboardSearchUtils.ts
@@ -43,7 +43,6 @@ const buildSearchParams = (
 
 	if (type === "all_classifications") {
 		params.set("tag", extra?.tag ?? "_ALL_CLASSIFICATION_TYPES");
-		params.set("type", "");
 	} else {
 		params.set("type", extra?.type ?? "_ALL_ENTITY_TYPES");
 	}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR fixes an issue where clearing a Classification search filter triggered a 400 Bad Request error.

*Root Cause:*
When navigating to classification searches from the Dashboard (e.g., Overview Card, Classification Types in Use), `dashboardSearchUtils.ts` was explicitly appending an empty `type=""` parameter to the search URL. When a user subsequently cleared the classification filter via the "X" button, `FilterQuery.tsx` incorrectly detected the dangling `type=` parameter as a "meaningful" filter. This caused the UI to fire an empty search request to the backend instead of safely resetting the search state.

*Fix:*
Removed the explicit injection of `params.set("type", "");` in `src/utils/dashboardSearchUtils.ts` when building classification URLs. By preventing the empty `type` parameter from being added, `FilterQuery` now correctly identifies when zero meaningful filters remain, safely navigating the user back to the default `/search` page without throwing a 400 error.

## How was this patch tested?

*Manual testing performed:*
1. Navigated to the Dashboard / Overview page.
2. Clicked on the `Classifications` count link inside the Overview card.
3. On the resulting Search Results page, clicked the "X" to clear the Classification filter.
4. Verified that the UI safely routed back to the default `/search` page without throwing a `400 Bad Request` backend error.
5. Repeated the above steps for the "Classification Types In Use" links to ensure coverage.
6. Verified that `npm run build` completes successfully with no regressions.
