### PR TITLE
ATLAS-5339: Atlas React UI: Clicking  Create Entity while on an Entity Detail Page opens the Edit Form instead of Create Form

### DIFF
--- a/dashboard/src/components/CreateDropdown/CreateDropdown.tsx
+++ b/dashboard/src/components/CreateDropdown/CreateDropdown.tsx
@@ -152,6 +152,7 @@ const CreateDropdown = () => {
 				<EntityForm
 					open={entityModal}
 					onClose={() => setEntityModal(false)}
+					isAdd={true}
 				/>
 			)}
 			{classificationModal && (

--- a/dashboard/src/components/CreateDropdown/__tests__/CreateDropdown.test.tsx
+++ b/dashboard/src/components/CreateDropdown/__tests__/CreateDropdown.test.tsx
@@ -29,9 +29,9 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('@views/Entity/EntityForm', () => ({
 	__esModule: true,
-	default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+	default: ({ open, onClose, isAdd }: { open: boolean; onClose: () => void; isAdd?: boolean }) =>
 		open ? (
-			<div data-testid="entity-form">
+			<div data-testid="entity-form" data-isadd={isAdd ? 'true' : 'false'}>
 				<button type="button" onClick={onClose}>
 					Close entity
 				</button>
@@ -84,6 +84,7 @@ describe('CreateDropdown (header Create menu)', () => {
 
 		fireEvent.click(screen.getByText('Entity'))
 		expect(await screen.findByTestId('entity-form')).toBeInTheDocument()
+		expect(screen.getByTestId('entity-form')).toHaveAttribute('data-isadd', 'true')
 
 		fireEvent.click(screen.getByText('Close entity'))
 		await waitFor(() => {

--- a/dashboard/src/views/Entity/EntityForm.tsx
+++ b/dashboard/src/views/Entity/EntityForm.tsx
@@ -78,15 +78,18 @@ export function reducer(state: State, action: Action): State {
 
 const EntityForm = ({
   open,
-  onClose
+  onClose,
+  isAdd = false
 }: {
   open: boolean;
   onClose: () => void;
+  isAdd?: boolean;
 }) => {
   const key = "atlas.ui.editable.entity.types";
   const dispatchApi = useAppDispatch();
   const navigate = useNavigate();
-  const { guid }: any = useParams();
+  const { guid: urlGuid }: any = useParams();
+  const guid = isAdd ? undefined : urlGuid;
   const [_searchParams, setSearchParams] = useSearchParams();
 
   const { entityData = {} }: any = useAppSelector((state: any) => state.entity);

--- a/dashboard/src/views/__tests__/EntityForm.test.tsx
+++ b/dashboard/src/views/__tests__/EntityForm.test.tsx
@@ -266,6 +266,20 @@ describe('EntityForm - 100% Coverage', () => {
 			expect(screen.getByTestId('modal-title')).toHaveTextContent('Create entity');
 		});
 
+		test('opens in create mode when isAdd=true even if URL has guid', async () => {
+			mockGuid = 'existing-guid-123';
+			const store = createStore(mockEntityData, mockSessionData, mockTypeHeaderData);
+			render(
+				<Provider store={store}>
+					<MemoryRouter>
+						<EntityForm open={true} onClose={jest.fn()} isAdd={true} />
+					</MemoryRouter>
+				</Provider>
+			);
+			expect(screen.getByTestId('modal-title')).toHaveTextContent('Create entity');
+			expect(mockGetEntity).not.toHaveBeenCalled();
+		});
+
 		test('does not render when open is false', () => {
 			const store = createStore(mockEntityData, mockSessionData, mockTypeHeaderData);
 			render(

--- a/dashboard/src/views/__tests__/EntityForm.test.tsx
+++ b/dashboard/src/views/__tests__/EntityForm.test.tsx
@@ -266,18 +266,52 @@ describe('EntityForm - 100% Coverage', () => {
 			expect(screen.getByTestId('modal-title')).toHaveTextContent('Create entity');
 		});
 
-		test('opens in create mode when isAdd=true even if URL has guid', async () => {
-			mockGuid = 'existing-guid-123';
+		test('opens in Create mode when isAdd=true even if URL has guid', async () => {
+			mockGuid = 'detail-page-guid-123';
 			const store = createStore(mockEntityData, mockSessionData, mockTypeHeaderData);
 			render(
 				<Provider store={store}>
-					<MemoryRouter>
+					<MemoryRouter initialEntries={['/detailPage/detail-page-guid-123']}>
 						<EntityForm open={true} onClose={jest.fn()} isAdd={true} />
 					</MemoryRouter>
 				</Provider>
 			);
 			expect(screen.getByTestId('modal-title')).toHaveTextContent('Create entity');
 			expect(mockGetEntity).not.toHaveBeenCalled();
+		});
+
+		test('opens in Edit mode when isAdd=false and URL has guid (ensures edit behavior is unchanged)', async () => {
+			mockGuid = 'detail-page-guid-123';
+			
+			// Mock successful API response for Edit mode
+			mockGetEntity.mockResolvedValue({
+				data: {
+					entity: {
+						guid: 'detail-page-guid-123',
+						typeName: 'DataSet',
+						attributes: { name: 'Test Entity' }
+					}
+				}
+			});
+			mockGetTypedef.mockResolvedValue({
+				data: { attributeDefs: [], relationshipAttributeDefs: [] }
+			});
+
+			const store = createStore(mockEntityData, mockSessionData, mockTypeHeaderData);
+			render(
+				<Provider store={store}>
+					<MemoryRouter initialEntries={['/detailPage/detail-page-guid-123']}>
+						<EntityForm open={true} onClose={jest.fn()} isAdd={false} />
+					</MemoryRouter>
+				</Provider>
+			);
+
+			await waitFor(() => {
+				expect(mockGetEntity).toHaveBeenCalledWith('detail-page-guid-123', 'GET', {});
+			});
+			await waitFor(() => {
+				expect(screen.getByTestId('modal-title')).toHaveTextContent('Edit entity');
+			});
 		});
 
 		test('does not render when open is false', () => {


### PR DESCRIPTION
**What changes were proposed in this pull request?**
ATLAS-5339: Fix issue where clicking "Create Entity" from the header dropdown while on an Entity Detail page incorrectly opens the Edit form instead of the Create form.

**Root Cause:**
When a user is on an Entity Detail page, the URL contains a `guid` parameter. The `EntityForm` component automatically reads this `guid` from the URL parameters (`useParams`) and assumes the user wants to edit that specific entity. 

**Fix:**
- Added an `isAdd` boolean prop to the `EntityForm` component.
- Updated the `CreateDropdown` component to explicitly pass `isAdd={true}` when opening the entity form.
- Modified `EntityForm` to check for `isAdd`. If `isAdd` is true, it explicitly ignores the `guid` from the URL parameters (`const guid = isAdd ? undefined : urlGuid;`), forcing the form to open in Create mode instead of Edit mode.
- Added unit tests in `CreateDropdown.test.tsx` to verify the `isAdd` prop is passed correctly.

**How was this patch tested?**
- **Unit Tests:** Added unit tests to `CreateDropdown.test.tsx` to verify the `isAdd` state is accurately passed to the `EntityForm`. 
- **Test Suite:** Ran the full Jest test suite (`npm run test:coverage`). Verified that all 4,630 tests pass successfully with 0 failures and overall coverage is well above the 50% threshold.
- **Manual UI Testing:** Navigated to an existing Entity Detail page (where the URL contains a `guid`), clicked the "Create Entity" button from the header, and verified that a blank Create Form opens instead of the pre-filled Edit Form for the current entity.
