### PR TITLE
ATLAS-5317: Resilient bulk purge with pre-validation, enriched responses, and worker batches

### DIFF
--- a/addons/models/0000-Area0/0010-base_model.json
+++ b/addons/models/0000-Area0/0010-base_model.json
@@ -15,7 +15,8 @@
         { "ordinal": 6, "value": "TYPE_DEF_UPDATE" },
         { "ordinal": 7, "value": "TYPE_DEF_DELETE" },
         { "ordinal": 8, "value": "SERVER_START" },
-        { "ordinal": 9, "value": "SERVER_STATE_ACTIVE" }
+        { "ordinal": 9, "value": "SERVER_STATE_ACTIVE" },
+        { "ordinal": 10, "value": "AUTO_PURGE" }
       ]
     }
   ],

--- a/client/client-v2/src/test/java/org/apache/atlas/AtlasClientV2Test.java
+++ b/client/client-v2/src/test/java/org/apache/atlas/AtlasClientV2Test.java
@@ -43,6 +43,9 @@ import org.apache.atlas.model.instance.AtlasRelatedObjectId;
 import org.apache.atlas.model.instance.AtlasRelationship;
 import org.apache.atlas.model.instance.ClassificationAssociateRequest;
 import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.EntityMutations.EntityOperation;
+import org.apache.atlas.model.instance.FailedEntity;
+import org.apache.atlas.model.instance.PurgeSummary;
 import org.apache.atlas.model.lineage.AtlasLineageInfo.LineageDirection;
 import org.apache.atlas.model.profile.AtlasUserSavedSearch;
 import org.apache.atlas.model.typedef.AtlasBusinessMetadataDef;
@@ -52,8 +55,10 @@ import org.apache.atlas.model.typedef.AtlasEnumDef;
 import org.apache.atlas.model.typedef.AtlasRelationshipDef;
 import org.apache.atlas.model.typedef.AtlasStructDef;
 import org.apache.atlas.model.typedef.AtlasTypesDef;
+import org.apache.atlas.utils.AtlasJson;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.http.HttpStatus;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -79,6 +84,7 @@ import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -2510,6 +2516,79 @@ public class AtlasClientV2Test {
 
         assertNotNull(result);
         assertEquals(result, mockResponse);
+    }
+
+    @Test
+    public void testPurgeEntitiesByGuidsAssignsToBaseType() throws Exception {
+        TestableAtlasClientV2 client = new TestableAtlasClientV2();
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        client.setMockResponse(mockResponse, EntityMutationResponse.class);
+
+        EntityMutationResponse result = client.purgeEntitiesByGuids(Collections.singleton("guid1"));
+
+        assertNotNull(result);
+        assertEquals(result, mockResponse);
+    }
+
+    @Test
+    public void testPurgeEntitiesByGuidsDeserializesPurgeFieldsOnHttp200() throws Exception {
+        EntityMutationResponse result = invokePurgeWithMockedHttpResponse(HttpStatus.SC_OK, buildSamplePurgeResponseJson());
+
+        assertPurgeResponseFields(result);
+    }
+
+    @Test
+    public void testPurgeEntitiesByGuidsDeserializedResponseAssignsToBaseType() throws Exception {
+        EntityMutationResponse result = invokePurgeWithMockedHttpResponse(HttpStatus.SC_OK, buildSamplePurgeResponseJson());
+
+        assertNotNull(result.getEntitiesByOperation(EntityOperation.PURGE));
+        assertEquals(result.getEntitiesByOperation(EntityOperation.PURGE).size(), 1);
+        assertEquals(result.getEntitiesByOperation(EntityOperation.PURGE).get(0).getGuid(), "purged-guid");
+    }
+
+    private EntityMutationResponse invokePurgeWithMockedHttpResponse(int httpStatus, String responseJson) throws Exception {
+        AtlasClientV2       atlasClient = new AtlasClientV2(service, configuration);
+        WebResource.Builder builder     = setupBuilder(AtlasClientV2.API_V2.PURGE_ENTITIES_BY_GUIDS, service);
+        ClientResponse      response    = mock(ClientResponse.class);
+
+        when(response.getStatus()).thenReturn(httpStatus);
+        when(response.getEntity(String.class)).thenReturn(responseJson);
+        when(builder.method(eq(javax.ws.rs.HttpMethod.PUT), eq(ClientResponse.class), any())).thenReturn(response);
+
+        return atlasClient.purgeEntitiesByGuids(Collections.singleton("purged-guid"));
+    }
+
+    private static String buildSamplePurgeResponseJson() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        Map<EntityOperation, List<AtlasEntityHeader>> mutatedEntities = new HashMap<>();
+        List<AtlasEntityHeader> purged = new ArrayList<>();
+        purged.add(new AtlasEntityHeader("Table", "purged-guid", null));
+        mutatedEntities.put(EntityOperation.PURGE, purged);
+        response.setMutatedEntities(mutatedEntities);
+
+        response.addFailedEntity(new FailedEntity("failed-guid", "ATLAS-404-00-006", "instance not found"));
+        response.setSummary(new PurgeSummary(2, 1, 0, 1, 0));
+
+        return AtlasJson.toJson(response);
+    }
+
+    private static void assertPurgeResponseFields(EntityMutationResponse result) {
+        assertNotNull(result);
+        assertNotNull(result.getPurgedEntities());
+        assertEquals(result.getPurgedEntities().size(), 1);
+        assertEquals(result.getPurgedEntities().get(0).getGuid(), "purged-guid");
+
+        assertNotNull(result.getFailedEntities());
+        assertEquals(result.getFailedEntities().size(), 1);
+        assertEquals(result.getFailedEntities().get(0).getGuid(), "failed-guid");
+        assertEquals(result.getFailedEntities().get(0).getErrorCode(), "ATLAS-404-00-006");
+        assertEquals(result.getFailedEntities().get(0).getErrorMessage(), "instance not found");
+
+        assertNotNull(result.getPurgeSummary());
+        assertEquals(result.getPurgeSummary().getRequestedCount(), 2);
+        assertEquals(result.getPurgeSummary().getPurgedCount(), 1);
+        assertEquals(result.getPurgeSummary().getFailedCount(), 1);
     }
 
     @Test

--- a/distro/src/conf/atlas-application.properties
+++ b/distro/src/conf/atlas-application.properties
@@ -272,6 +272,17 @@ atlas.search.gremlin.enable=false
 #atlas.headers.<headerName>=<headerValue>
 
 
+#########  Purge Configuration ########
+
+# Maximum number of GUIDs allowed per REST purge request (PUT /api/atlas/v2/admin/purge).
+#atlas.purge.api.max.request.size=1000
+
+# Number of worker threads for REST and scheduled bulk purge (WorkItemManager consumers).
+#atlas.purge.workers.count=2
+
+# Number of GUIDs committed per worker batch during bulk purge.
+#atlas.purge.worker.batch.size=100
+
 #########  UI Configuration ########
 
 #atlas.ui.default.version=v2

--- a/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasConfiguration.java
@@ -120,7 +120,8 @@ public enum AtlasConfiguration {
     ATLAS_ASYNC_IMPORT_MIN_DURATION_OVERRIDE_TEST_AUTOMATION("atlas.async.import.min.duration.override.test.automation", false),
     ASYNC_IMPORT_TOPIC_PREFIX("atlas.async.import.topic.prefix", "ATLAS_IMPORT_"),
     ASYNC_IMPORT_REQUEST_ID_PREFIX("atlas.async.import.request_id.prefix", "async_import_"),
-    REPLACE_HUGE_SPARK_PROCESS_ATTRIBUTES_PATCH("atlas.process.spark.attributes.update.patch", false);
+    REPLACE_HUGE_SPARK_PROCESS_ATTRIBUTES_PATCH("atlas.process.spark.attributes.update.patch", false),
+    PURGE_API_MAX_REQUEST_SIZE("atlas.purge.api.max.request.size", 1000);
     private static final Configuration APPLICATION_PROPERTIES;
 
     private final String propertyName;

--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -184,6 +184,9 @@ public enum AtlasErrorCode {
     BLANK_VALUE_ATTRIBUTE(400, "ATLAS-400-00-105", "Value Attribute can't be empty!"),
     INVALID_RELATIONSHIP_LABEL(400, "ATLAS-400-00-106", "Invalid relationship label {0}. The referenced entity type {1} could not be resolved from the type registry."),
     NON_INDEXABLE_BM_DELETE_NOT_ALLOWED(400, "ATLAS-400-00-107", "Deletion not allowed for non-indexable Business Metadata ''{0}'' without force=true. Non-indexable attributes cannot be validated efficiently for references; use force=true to skip validation and delete (warning: orphaned references may remain)."),
+    INVALID_GUID(400, "ATLAS-400-00-108", "guid {0} is not a valid UUID"),
+    PURGE_REQUEST_SIZE_EXCEEDS_LIMIT(400, "ATLAS-400-00-109", "purge request size {0} exceeds maximum limit {1}"),
+    NOT_IN_DELETED_STATE(400, "ATLAS-400-00-10A", "entity {0} is not in DELETED state"),
 
     UNAUTHORIZED_ACCESS(403, "ATLAS-403-00-001", "{0} is not authorized to perform {1}"),
 

--- a/intg/src/main/java/org/apache/atlas/model/instance/EntityMutationResponse.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/EntityMutationResponse.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.atlas.model.instance.EntityMutations.EntityOperation;
 import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -33,9 +33,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -50,13 +52,18 @@ public class EntityMutationResponse implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Map<EntityOperation, List<AtlasEntityHeader>> mutatedEntities;
+    @JsonIgnore
+    private transient Map<EntityOperation, Set<String>>   entityGuidsPerOp;
     private Map<String, String>                           guidAssignments;
+    private List<FailedEntity>                            failedEntities;
+    private MutationSummary                               summary;
 
     public EntityMutationResponse() {
     }
 
     public EntityMutationResponse(final Map<EntityOperation, List<AtlasEntityHeader>> mutatedEntities) {
         this.mutatedEntities = mutatedEntities;
+        rebuildEntityGuidsPerOp();
     }
 
     public Map<EntityOperation, List<AtlasEntityHeader>> getMutatedEntities() {
@@ -65,6 +72,7 @@ public class EntityMutationResponse implements Serializable {
 
     public void setMutatedEntities(final Map<EntityOperation, List<AtlasEntityHeader>> mutatedEntities) {
         this.mutatedEntities = mutatedEntities;
+        rebuildEntityGuidsPerOp();
     }
 
     public Map<String, String> getGuidAssignments() {
@@ -73,6 +81,40 @@ public class EntityMutationResponse implements Serializable {
 
     public void setGuidAssignments(Map<String, String> guidAssignments) {
         this.guidAssignments = guidAssignments;
+    }
+
+    public List<FailedEntity> getFailedEntities() {
+        return failedEntities;
+    }
+
+    public void setFailedEntities(List<FailedEntity> failedEntities) {
+        this.failedEntities = failedEntities;
+    }
+
+    public MutationSummary getSummary() {
+        return summary;
+    }
+
+    @JsonDeserialize(as = PurgeSummary.class)
+    public void setSummary(MutationSummary summary) {
+        this.summary = summary;
+    }
+
+    @JsonIgnore
+    public PurgeSummary getPurgeSummary() {
+        return summary instanceof PurgeSummary ? (PurgeSummary) summary : null;
+    }
+
+    public void addFailedEntity(FailedEntity failedEntity) {
+        if (failedEntity == null) {
+            return;
+        }
+
+        if (failedEntities == null) {
+            failedEntities = new ArrayList<>();
+        }
+
+        failedEntities.add(failedEntity);
     }
 
     @JsonIgnore
@@ -228,9 +270,14 @@ public class EntityMutationResponse implements Serializable {
 
     @JsonIgnore
     public void addEntity(EntityOperation op, AtlasEntityHeader header) {
-        // if an entity is already included in CREATE, update the header, to capture propagated classifications
+        if (header == null) {
+            return;
+        }
+
+        // Duplicate GUID under CREATE: keep the first header, ignore later additions
+        String guid = header.getGuid();
         if (op == EntityOperation.UPDATE || op == EntityOperation.PARTIAL_UPDATE) {
-            if (entityHeaderExists(getCreatedEntities(), header.getGuid())) {
+            if (entityHeaderExists(EntityOperation.CREATE, guid)) {
                 op = EntityOperation.CREATE;
             }
         }
@@ -241,7 +288,12 @@ public class EntityMutationResponse implements Serializable {
 
         List<AtlasEntityHeader> opEntities = mutatedEntities.computeIfAbsent(op, k -> new ArrayList<>());
 
-        if (!entityHeaderExists(opEntities, header.getGuid())) {
+        if (guid == null) {
+            opEntities.add(header);
+            return;
+        }
+
+        if (getGuidsForOperation(op).add(guid)) {
             opEntities.add(header);
         }
     }
@@ -258,7 +310,7 @@ public class EntityMutationResponse implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(mutatedEntities, guidAssignments);
+        return Objects.hash(mutatedEntities, guidAssignments, failedEntities, summary);
     }
 
     @Override
@@ -272,7 +324,9 @@ public class EntityMutationResponse implements Serializable {
         EntityMutationResponse that = (EntityMutationResponse) o;
 
         return Objects.equals(mutatedEntities, that.mutatedEntities) &&
-                Objects.equals(guidAssignments, that.guidAssignments);
+                Objects.equals(guidAssignments, that.guidAssignments) &&
+                Objects.equals(failedEntities, that.failedEntities) &&
+                Objects.equals(summary, that.summary);
     }
 
     @Override
@@ -280,19 +334,39 @@ public class EntityMutationResponse implements Serializable {
         return toString(new StringBuilder()).toString();
     }
 
-    private boolean entityHeaderExists(List<AtlasEntityHeader> entityHeaders, String guid) {
-        boolean ret = false;
-
-        if (CollectionUtils.isNotEmpty(entityHeaders) && guid != null) {
-            for (AtlasEntityHeader entityHeader : entityHeaders) {
-                if (StringUtils.equals(entityHeader.getGuid(), guid)) {
-                    ret = true;
-                    break;
-                }
-            }
+    private Set<String> getGuidsForOperation(EntityOperation op) {
+        if (entityGuidsPerOp == null) {
+            rebuildEntityGuidsPerOp();
         }
 
-        return ret;
+        return entityGuidsPerOp.computeIfAbsent(op, k -> new HashSet<>());
+    }
+
+    private void rebuildEntityGuidsPerOp() {
+        entityGuidsPerOp = new HashMap<>();
+
+        if (mutatedEntities == null) {
+            return;
+        }
+
+        for (Map.Entry<EntityOperation, List<AtlasEntityHeader>> entry : mutatedEntities.entrySet()) {
+            Set<String> guids = new HashSet<>();
+            List<AtlasEntityHeader> headers = entry.getValue();
+
+            if (headers != null) {
+                for (AtlasEntityHeader header : headers) {
+                    if (header.getGuid() != null) {
+                        guids.add(header.getGuid());
+                    }
+                }
+            }
+
+            entityGuidsPerOp.put(entry.getKey(), guids);
+        }
+    }
+
+    private boolean entityHeaderExists(EntityOperation op, String guid) {
+        return guid != null && getGuidsForOperation(op).contains(guid);
     }
 
     private AtlasEntityHeader getFirstEntityByType(List<AtlasEntityHeader> entitiesByOperation, String typeName) {

--- a/intg/src/main/java/org/apache/atlas/model/instance/FailedEntity.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/FailedEntity.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.model.instance;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
+
+/**
+ * Represents a single GUID that failed during a mutation operation, with error code and message.
+ */
+@JsonAutoDetect(getterVisibility = PUBLIC_ONLY, setterVisibility = PUBLIC_ONLY, fieldVisibility = NONE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FailedEntity implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String guid;
+    private String errorCode;
+    private String errorMessage;
+
+    public FailedEntity() {
+    }
+
+    public FailedEntity(String guid, String errorCode, String errorMessage) {
+        this.guid         = guid;
+        this.errorCode    = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public String getGuid() {
+        return guid;
+    }
+
+    public void setGuid(String guid) {
+        this.guid = guid;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("FailedEntity{");
+        sb.append("guid='").append(guid).append('\'');
+        sb.append(", errorCode='").append(errorCode).append('\'');
+        sb.append(", errorMessage='").append(errorMessage).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FailedEntity that = (FailedEntity) o;
+        return Objects.equals(guid, that.guid) &&
+               Objects.equals(errorCode, that.errorCode) &&
+               Objects.equals(errorMessage, that.errorMessage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(guid, errorCode, errorMessage);
+    }
+}

--- a/intg/src/main/java/org/apache/atlas/model/instance/MutationSummary.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/MutationSummary.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.model.instance;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.io.Serializable;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
+
+/**
+ * Base class for operation-specific mutation summary counts.
+ */
+@JsonAutoDetect(getterVisibility = PUBLIC_ONLY, setterVisibility = PUBLIC_ONLY, fieldVisibility = NONE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class MutationSummary implements Serializable {
+    private static final long serialVersionUID = 1L;
+}

--- a/intg/src/main/java/org/apache/atlas/model/instance/PurgeSummary.java
+++ b/intg/src/main/java/org/apache/atlas/model/instance/PurgeSummary.java
@@ -1,0 +1,224 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.model.instance;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
+
+/**
+ * Summary counts for purge operations.
+ */
+@JsonAutoDetect(getterVisibility = PUBLIC_ONLY, setterVisibility = PUBLIC_ONLY, fieldVisibility = NONE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PurgeSummary extends MutationSummary {
+    private static final long serialVersionUID = 1L;
+
+    private long requestedCount;
+    private long purgedCount;
+    private long purgedDependenciesCount;
+    private long failedCount;
+    private long failedDependenciesCount;
+    private long skippedCount;
+    private long validGuidCount;
+    private boolean executionFailed;
+    private long expandedEntityCount;
+    private long skippedRequestedCount;
+    private long skippedDependenciesCount;
+    private long unprocessedCount;
+    private long batchCount;
+
+    public PurgeSummary() {
+    }
+
+    public PurgeSummary(long requestedCount, long purgedCount, long purgedDependenciesCount, long failedCount, long skippedCount) {
+        this(requestedCount, purgedCount, purgedDependenciesCount, failedCount, 0, skippedCount);
+    }
+
+    public PurgeSummary(long requestedCount, long purgedCount, long purgedDependenciesCount, long failedCount,
+                        long failedDependenciesCount, long skippedCount) {
+        this.requestedCount            = requestedCount;
+        this.purgedCount               = purgedCount;
+        this.purgedDependenciesCount   = purgedDependenciesCount;
+        this.failedCount               = failedCount;
+        this.failedDependenciesCount   = failedDependenciesCount;
+        this.skippedCount              = skippedCount;
+    }
+
+    public long getRequestedCount() {
+        return requestedCount;
+    }
+
+    public void setRequestedCount(long requestedCount) {
+        this.requestedCount = requestedCount;
+    }
+
+    public long getPurgedCount() {
+        return purgedCount;
+    }
+
+    public void setPurgedCount(long purgedCount) {
+        this.purgedCount = purgedCount;
+    }
+
+    public long getPurgedDependenciesCount() {
+        return purgedDependenciesCount;
+    }
+
+    public void setPurgedDependenciesCount(long purgedDependenciesCount) {
+        this.purgedDependenciesCount = purgedDependenciesCount;
+    }
+
+    public long getFailedCount() {
+        return failedCount;
+    }
+
+    public void setFailedCount(long failedCount) {
+        this.failedCount = failedCount;
+    }
+
+    public long getFailedDependenciesCount() {
+        return failedDependenciesCount;
+    }
+
+    public void setFailedDependenciesCount(long failedDependenciesCount) {
+        this.failedDependenciesCount = failedDependenciesCount;
+    }
+
+    public long getSkippedCount() {
+        return skippedCount;
+    }
+
+    public void setSkippedCount(long skippedCount) {
+        this.skippedCount = skippedCount;
+    }
+
+    public long getValidGuidCount() {
+        return validGuidCount;
+    }
+
+    public void setValidGuidCount(long validGuidCount) {
+        this.validGuidCount = validGuidCount;
+    }
+
+    public boolean getExecutionFailed() {
+        return executionFailed;
+    }
+
+    public void setExecutionFailed(boolean executionFailed) {
+        this.executionFailed = executionFailed;
+    }
+
+    public long getExpandedEntityCount() {
+        return expandedEntityCount;
+    }
+
+    public void setExpandedEntityCount(long expandedEntityCount) {
+        this.expandedEntityCount = expandedEntityCount;
+    }
+
+    public long getSkippedRequestedCount() {
+        return skippedRequestedCount;
+    }
+
+    public void setSkippedRequestedCount(long skippedRequestedCount) {
+        this.skippedRequestedCount = skippedRequestedCount;
+    }
+
+    public long getSkippedDependenciesCount() {
+        return skippedDependenciesCount;
+    }
+
+    public void setSkippedDependenciesCount(long skippedDependenciesCount) {
+        this.skippedDependenciesCount = skippedDependenciesCount;
+    }
+
+    public long getUnprocessedCount() {
+        return unprocessedCount;
+    }
+
+    public void setUnprocessedCount(long unprocessedCount) {
+        this.unprocessedCount = unprocessedCount;
+    }
+
+    public long getBatchCount() {
+        return batchCount;
+    }
+
+    public void setBatchCount(long batchCount) {
+        this.batchCount = batchCount;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("PurgeSummary{");
+        sb.append("requestedCount=").append(requestedCount);
+        sb.append(", purgedCount=").append(purgedCount);
+        sb.append(", purgedDependenciesCount=").append(purgedDependenciesCount);
+        sb.append(", failedCount=").append(failedCount);
+        sb.append(", failedDependenciesCount=").append(failedDependenciesCount);
+        sb.append(", skippedCount=").append(skippedCount);
+        sb.append(", validGuidCount=").append(validGuidCount);
+        sb.append(", executionFailed=").append(executionFailed);
+        sb.append(", expandedEntityCount=").append(expandedEntityCount);
+        sb.append(", skippedRequestedCount=").append(skippedRequestedCount);
+        sb.append(", skippedDependenciesCount=").append(skippedDependenciesCount);
+        sb.append(", unprocessedCount=").append(unprocessedCount);
+        sb.append(", batchCount=").append(batchCount);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PurgeSummary that = (PurgeSummary) o;
+        return requestedCount == that.requestedCount &&
+               purgedCount == that.purgedCount &&
+               purgedDependenciesCount == that.purgedDependenciesCount &&
+               failedCount == that.failedCount &&
+               failedDependenciesCount == that.failedDependenciesCount &&
+               skippedCount == that.skippedCount &&
+               validGuidCount == that.validGuidCount &&
+               executionFailed == that.executionFailed &&
+               expandedEntityCount == that.expandedEntityCount &&
+               skippedRequestedCount == that.skippedRequestedCount &&
+               skippedDependenciesCount == that.skippedDependenciesCount &&
+               unprocessedCount == that.unprocessedCount &&
+               batchCount == that.batchCount;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(requestedCount, purgedCount, purgedDependenciesCount, failedCount, failedDependenciesCount,
+                skippedCount, validGuidCount, executionFailed, expandedEntityCount, skippedRequestedCount,
+                skippedDependenciesCount, unprocessedCount, batchCount);
+    }
+}

--- a/intg/src/main/python/apache_atlas/utils.py
+++ b/intg/src/main/python/apache_atlas/utils.py
@@ -112,12 +112,20 @@ def type_coerce_dict_list(obj, objType):
 
 
 class API:
-    def __init__(self, path, method, expected_status, consumes=APPLICATION_JSON, produces=APPLICATION_JSON):
+    def __init__(self, path, method, expected_status, consumes=APPLICATION_JSON, produces=APPLICATION_JSON,
+                 alternate_expected_statuses=None):
         self.path = path
         self.method = method
         self.expected_status = expected_status
         self.consumes = consumes
         self.produces = produces
+        self.alternate_expected_statuses = alternate_expected_statuses or []
+
+    def matches_expected_status(self, status_code):
+        if status_code == self.expected_status:
+            return True
+
+        return status_code in self.alternate_expected_statuses
 
     def multipart_urljoin(self, base_path, *path_elems):
         """Join a base path and multiple context path elements. Handle single
@@ -136,11 +144,13 @@ class API:
         return reduce(urljoin_pair, path_elems, base_path)
 
     def format_path(self, params):
-        return API(self.path.format(**params), self.method, self.expected_status, self.consumes, self.produces)
+        return API(self.path.format(**params), self.method, self.expected_status, self.consumes, self.produces,
+                   self.alternate_expected_statuses)
 
     def format_path_with_params(self, *params):
         request_path = self.multipart_urljoin(self.path, *params)
-        return API(request_path, self.method, self.expected_status, self.consumes, self.produces)
+        return API(request_path, self.method, self.expected_status, self.consumes, self.produces,
+                   self.alternate_expected_statuses)
 
 
 class HTTPMethod(enum.Enum):
@@ -152,5 +162,6 @@ class HTTPMethod(enum.Enum):
 
 class HTTPStatus:
     OK = 200
+    MULTI_STATUS = 207
     NO_CONTENT = 204
     SERVICE_UNAVAILABLE = 503

--- a/intg/src/test/java/org/apache/atlas/model/instance/TestEntityMutationResponse.java
+++ b/intg/src/test/java/org/apache/atlas/model/instance/TestEntityMutationResponse.java
@@ -586,4 +586,68 @@ public class TestEntityMutationResponse {
 
         assertEquals(guidAssignments, response.getGuidAssignments());
     }
+
+    @Test
+    public void testSetMutatedEntitiesThenAddEntity() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        Map<EntityOperation, List<AtlasEntityHeader>> mutatedEntities = new HashMap<>();
+        List<AtlasEntityHeader> purgedEntities = new ArrayList<>();
+        purgedEntities.add(new AtlasEntityHeader("type1", "guid1", null));
+        mutatedEntities.put(EntityOperation.PURGE, purgedEntities);
+
+        // Rebuilds the GUID index from the map; duplicate add must be ignored.
+        response.setMutatedEntities(mutatedEntities);
+
+        // Add the same entity again — must not duplicate.
+        AtlasEntityHeader duplicateEntity = new AtlasEntityHeader("type1", "guid1", null);
+        response.addEntity(EntityOperation.PURGE, duplicateEntity);
+
+        assertEquals(1, response.getPurgedEntities().size());
+        assertEquals("guid1", response.getPurgedEntities().get(0).getGuid());
+    }
+
+    @Test
+    public void testAddEntityThenSetMutatedEntitiesThenAddEntity() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        // 1. addEntity runs -> index has CREATE -> {guid1}
+        AtlasEntityHeader entity1 = new AtlasEntityHeader("type1", "guid1", null);
+        response.addEntity(EntityOperation.CREATE, entity1);
+
+        assertEquals(1, response.getCreatedEntities().size());
+
+        // 2. setMutatedEntities replaces lists
+        Map<EntityOperation, List<AtlasEntityHeader>> newMutatedEntities = new HashMap<>();
+        List<AtlasEntityHeader> newCreatedEntities = new ArrayList<>();
+        newCreatedEntities.add(new AtlasEntityHeader("type2", "guid2", null));
+        newMutatedEntities.put(EntityOperation.CREATE, newCreatedEntities);
+
+        // This must invalidate the cache!
+        response.setMutatedEntities(newMutatedEntities);
+
+        // 3. addEntity runs again for guid2 already in the new list
+        AtlasEntityHeader entity2 = new AtlasEntityHeader("type2", "guid2", null);
+        response.addEntity(EntityOperation.CREATE, entity2);
+        // If cache wasn't invalidated, entityHeaderExists might use stale cache {guid1}
+        // and add guid2 again, resulting in 2 entries for guid2 (actually size 2 in the list).
+        assertEquals(1, response.getCreatedEntities().size());
+        assertEquals("guid2", response.getCreatedEntities().get(0).getGuid());
+    }
+
+    @Test
+    public void testNullGuidBehavior() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        AtlasEntityHeader nullGuidEntity1 = new AtlasEntityHeader("type1", null, null);
+        AtlasEntityHeader nullGuidEntity2 = new AtlasEntityHeader("type2", null, null);
+
+        // Null GUIDs are not indexed, but they should still be added to the lists.
+        response.addEntity(EntityOperation.CREATE, nullGuidEntity1);
+        response.addEntity(EntityOperation.CREATE, nullGuidEntity2);
+
+        assertEquals(2, response.getCreatedEntities().size());
+        assertNull(response.getCreatedEntities().get(0).getGuid());
+        assertNull(response.getCreatedEntities().get(1).getGuid());
+    }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/purge/PurgeExecutionStats.java
+++ b/repository/src/main/java/org/apache/atlas/repository/purge/PurgeExecutionStats.java
@@ -1,0 +1,329 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.repository.purge;
+
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.FailedEntity;
+import org.apache.atlas.model.instance.PurgeSummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Mutable run-context for purge execution accounting. Counters are updated sequentially
+ * during orchestration aggregation and reconciliation.
+ * <p>
+ * This class is strictly single-thread-owned. Mutations must only happen on the main
+ * orchestrator thread after worker shutdown.
+ * <p>
+ * Request-scope balance: {@code requestedCount = purgedCount + failedCount + skippedRequestedCount}.
+ * Expanded-scope balance uses {@link #getExpandedEntityCount()} and deduplicated outcome counters.
+ */
+public final class PurgeExecutionStats {
+    private static final Logger LOG = LoggerFactory.getLogger(PurgeExecutionStats.class);
+
+    private final Set<String> originallyRequestedGuids;
+    private final Set<String> producedDeletionCandidates;
+    private final Set<String> accountedPurgedGuids   = new HashSet<>();
+    private final Set<String> accountedOutcomeGuids  = new HashSet<>();
+
+    private long validGuidCount;
+    private long batchCount;
+    private long reconciledUnprocessedCount;
+    private long purgedCount;
+    private long purgedDependenciesCount;
+    private long failedCount;
+    private long failedDependenciesCount;
+    private long skippedRequestedCount;
+    private long skippedDependenciesCount;
+    private boolean executionFailed;
+
+    public PurgeExecutionStats(Set<String> originallyRequestedGuids, long validGuidCount) {
+        this.originallyRequestedGuids    = originallyRequestedGuids;
+        this.validGuidCount              = validGuidCount;
+        this.producedDeletionCandidates  = new LinkedHashSet<>();
+    }
+
+    public Set<String> getOriginallyRequestedGuids() {
+        return originallyRequestedGuids;
+    }
+
+    public Set<String> getProducedDeletionCandidates() {
+        return producedDeletionCandidates;
+    }
+
+    public long getValidGuidCount() {
+        return validGuidCount;
+    }
+
+    public long getExpandedEntityCount() {
+        return producedDeletionCandidates.size();
+    }
+
+    public long getSkippedCount() {
+        return skippedRequestedCount + skippedDependenciesCount;
+    }
+
+    public long getReconciledUnprocessedCount() {
+        return reconciledUnprocessedCount;
+    }
+
+    public long getPurgedCount() {
+        return purgedCount;
+    }
+
+    public long getPurgedDependenciesCount() {
+        return purgedDependenciesCount;
+    }
+
+    public long getFailedCount() {
+        return failedCount;
+    }
+
+    public long getFailedDependenciesCount() {
+        return failedDependenciesCount;
+    }
+
+    public long getSkippedRequestedCount() {
+        return skippedRequestedCount;
+    }
+
+    public long getSkippedDependenciesCount() {
+        return skippedDependenciesCount;
+    }
+
+    public long getBatchCount() {
+        return batchCount;
+    }
+
+    public boolean isExecutionFailed() {
+        return executionFailed;
+    }
+
+    public void markExecutionFailed() {
+        executionFailed = true;
+    }
+
+    public void recordFailures(List<FailedEntity> failures) {
+        if (failures == null) {
+            return;
+        }
+
+        for (FailedEntity failedEntity : failures) {
+            recordFailure(failedEntity);
+        }
+    }
+
+    public void recordBatchOutcome(EntityMutationResponse batchResponse, Set<String> batchGuids) {
+        if (batchGuids == null || batchGuids.isEmpty()) {
+            return;
+        }
+
+        List<AtlasEntityHeader> purgedEntities = batchResponse != null ? batchResponse.getPurgedEntities() : null;
+        List<FailedEntity>      failedEntities = batchResponse != null ? batchResponse.getFailedEntities() : null;
+        recordBatchOutcome(purgedEntities, failedEntities, batchGuids);
+    }
+
+    public void recordBatchOutcome(List<AtlasEntityHeader> purgedEntities, List<FailedEntity> failedEntities,
+                                   Set<String> batchGuids) {
+        if (batchGuids == null || batchGuids.isEmpty()) {
+            return;
+        }
+
+        batchCount++;
+
+        applyOutcomes(purgedEntities, failedEntities);
+
+        validateBatchInvariant(batchGuids, purgedEntities, failedEntities);
+    }
+
+    public void recordBatchThrowable(Set<String> batchGuids, List<FailedEntity> batchFailures) {
+        if (batchGuids == null || batchGuids.isEmpty()) {
+            return;
+        }
+
+        batchCount++;
+
+        applyOutcomes(null, batchFailures);
+
+        validateBatchInvariant(batchGuids, null, batchFailures);
+    }
+
+    public void recordReconciledUnprocessed(long count) {
+        reconciledUnprocessedCount += count;
+    }
+
+    void recordPurged(String guid) {
+        if (guid == null || !accountedPurgedGuids.add(guid)) {
+            return;
+        }
+
+        if (accountedOutcomeGuids.remove(guid)) {
+            decrementOutcome(guid);
+        }
+
+        accountedOutcomeGuids.add(guid);
+
+        if (originallyRequestedGuids.contains(guid)) {
+            purgedCount++;
+        } else {
+            purgedDependenciesCount++;
+        }
+    }
+
+    public void recordFailure(FailedEntity failedEntity) {
+        if (failedEntity == null) {
+            return;
+        }
+
+        String guid      = failedEntity.getGuid();
+        String errorCode = failedEntity.getErrorCode();
+
+        if (guid == null || accountedPurgedGuids.contains(guid) || !accountedOutcomeGuids.add(guid)) {
+            return;
+        }
+
+        boolean requested = originallyRequestedGuids.contains(guid);
+
+        PurgeFailureCategory category = PurgeUtils.classifyPurgeFailureCode(errorCode);
+        incrementFailureCounters(category, requested);
+
+        if (category == PurgeFailureCategory.EXECUTION_FAILURE) {
+            executionFailed = true;
+        }
+    }
+
+    private void incrementFailureCounters(PurgeFailureCategory category, boolean requested) {
+        if (category == PurgeFailureCategory.SKIPPABLE) {
+            if (requested) {
+                skippedRequestedCount++;
+            } else {
+                skippedDependenciesCount++;
+            }
+        } else if (requested) {
+            failedCount++;
+        } else {
+            failedDependenciesCount++;
+        }
+    }
+
+    /**
+     * Rebuilds stats by scanning a completed response. Used by tests and legacy callers that
+     * do not run through the worker pipeline.
+     */
+    public static PurgeExecutionStats fromResponse(EntityMutationResponse response,
+                                                   Set<String> originallyRequestedGuids,
+                                                   long validGuidCount) {
+        PurgeExecutionStats stats = new PurgeExecutionStats(originallyRequestedGuids, validGuidCount);
+        stats.applyOutcomes(
+                response != null ? response.getPurgedEntities() : null,
+                response != null ? response.getFailedEntities() : null);
+
+        return stats;
+    }
+
+    private void applyOutcomes(List<AtlasEntityHeader> purgedEntities, List<FailedEntity> failedEntities) {
+        if (purgedEntities != null) {
+            for (AtlasEntityHeader header : purgedEntities) {
+                recordPurged(header.getGuid());
+            }
+        }
+
+        if (failedEntities != null) {
+            for (FailedEntity failedEntity : failedEntities) {
+                recordFailure(failedEntity);
+            }
+        }
+    }
+
+    public void validateSummaryBalances(PurgeSummary summary) {
+        long requestedBalance = summary.getPurgedCount() + summary.getFailedCount() + summary.getSkippedRequestedCount();
+        if (summary.getRequestedCount() != requestedBalance) {
+            LOG.warn("Purge summary request-scope balance mismatch: requestedCount={}, purged+failed+skippedRequested={}",
+                    summary.getRequestedCount(), requestedBalance);
+        }
+
+        // unprocessedCount is a breakdown of reconciled shutdown failures already included in failedCount.
+        long expandedBalance = summary.getPurgedCount() + summary.getPurgedDependenciesCount()
+                + summary.getFailedCount() + summary.getFailedDependenciesCount()
+                + summary.getSkippedRequestedCount() + summary.getSkippedDependenciesCount();
+        if (summary.getExpandedEntityCount() > 0 && summary.getExpandedEntityCount() != expandedBalance) {
+            LOG.warn("Purge summary expanded-scope balance mismatch: expandedEntityCount={}, outcomeTotal={}",
+                    summary.getExpandedEntityCount(), expandedBalance);
+        }
+    }
+
+    private void decrementOutcome(String guid) {
+        boolean requested = originallyRequestedGuids.contains(guid);
+
+        if (requested) {
+            if (purgedCount > 0) {
+                purgedCount--;
+                return;
+            }
+            if (failedCount > 0) {
+                failedCount--;
+                return;
+            }
+            if (skippedRequestedCount > 0) {
+                skippedRequestedCount--;
+            }
+        } else {
+            if (purgedDependenciesCount > 0) {
+                purgedDependenciesCount--;
+                return;
+            }
+            if (failedDependenciesCount > 0) {
+                failedDependenciesCount--;
+                return;
+            }
+            if (skippedDependenciesCount > 0) {
+                skippedDependenciesCount--;
+            }
+        }
+    }
+
+    private static void validateBatchInvariant(Set<String> batchGuids, List<AtlasEntityHeader> purgedEntities,
+                                               List<FailedEntity> failedEntities) {
+        int batchInputCount = batchGuids.size();
+        int batchPurged     = purgedEntities != null ? purgedEntities.size() : 0;
+        int batchFailed     = 0;
+        int batchSkipped    = 0;
+
+        if (failedEntities != null) {
+            for (FailedEntity failedEntity : failedEntities) {
+                if (PurgeUtils.classifyPurgeFailureCode(failedEntity.getErrorCode()) == PurgeFailureCategory.SKIPPABLE) {
+                    batchSkipped++;
+                } else {
+                    batchFailed++;
+                }
+            }
+        }
+
+        int batchAccounted = batchPurged + batchFailed + batchSkipped;
+        if (batchAccounted != batchInputCount) {
+            LOG.warn("Purge batch accounting mismatch: batchSize={}, purged={}, failed={}, skipped={}",
+                    batchInputCount, batchPurged, batchFailed, batchSkipped);
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/purge/PurgeFailureCategory.java
+++ b/repository/src/main/java/org/apache/atlas/repository/purge/PurgeFailureCategory.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.repository.purge;
+
+/**
+ * Outcome classification for a purge failure error code.
+ */
+public enum PurgeFailureCategory {
+    /** Not found or not in DELETED state; counts toward skippedCount. */
+    SKIPPABLE,
+    /** Pre-validation failures such as invalid GUID or unknown type; counts toward failedCount. */
+    PRE_VALIDATION_FAILURE,
+    /** Execution-time failure after pre-validation; sets executionFailed on requested outcomes. */
+    EXECUTION_FAILURE
+}

--- a/repository/src/main/java/org/apache/atlas/repository/purge/PurgeUtils.java
+++ b/repository/src/main/java/org/apache/atlas/repository/purge/PurgeUtils.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.repository.purge;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.FailedEntity;
+import org.apache.atlas.model.instance.PurgeSummary;
+
+/**
+ * Shared purge policy helpers for failure classification and summary attachment.
+ */
+public final class PurgeUtils {
+    private PurgeUtils() {
+    }
+
+    /**
+     * Returns true for skippable purge failure codes (not-found, not-deleted).
+     */
+    public static boolean isSkippablePurgeFailureCode(String errorCode) {
+        return classifyPurgeFailureCode(errorCode) == PurgeFailureCategory.SKIPPABLE;
+    }
+
+    /**
+     * Classifies a purge failure error code for stats, audit, and batch accounting.
+     */
+    public static PurgeFailureCategory classifyPurgeFailureCode(String errorCode) {
+        if (AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode().equals(errorCode)
+                || AtlasErrorCode.NOT_IN_DELETED_STATE.getErrorCode().equals(errorCode)) {
+            return PurgeFailureCategory.SKIPPABLE;
+        }
+        if (AtlasErrorCode.INVALID_GUID.getErrorCode().equals(errorCode)
+                || AtlasErrorCode.TYPE_NAME_NOT_FOUND.getErrorCode().equals(errorCode)) {
+            return PurgeFailureCategory.PRE_VALIDATION_FAILURE;
+        }
+        return PurgeFailureCategory.EXECUTION_FAILURE;
+    }
+
+    /**
+     * Returns true when the error code represents an execution-time failure (not pre-validation or skippable).
+     */
+    public static boolean isExecutionFailureCode(String errorCode) {
+        return classifyPurgeFailureCode(errorCode) == PurgeFailureCategory.EXECUTION_FAILURE;
+    }
+
+    /**
+     * Builds a {@link PurgeSummary} from incremental {@link PurgeExecutionStats} counters (O(1)).
+     */
+    public static PurgeSummary buildPurgeSummary(PurgeExecutionStats stats) {
+        PurgeSummary summary = new PurgeSummary(
+                stats.getOriginallyRequestedGuids().size(),
+                stats.getPurgedCount(),
+                stats.getPurgedDependenciesCount(),
+                stats.getFailedCount(),
+                stats.getFailedDependenciesCount(),
+                stats.getSkippedCount());
+        summary.setValidGuidCount(stats.getValidGuidCount());
+        summary.setExpandedEntityCount(stats.getExpandedEntityCount());
+        summary.setBatchCount(stats.getBatchCount());
+        summary.setSkippedRequestedCount(stats.getSkippedRequestedCount());
+        summary.setSkippedDependenciesCount(stats.getSkippedDependenciesCount());
+        summary.setUnprocessedCount(stats.getReconciledUnprocessedCount());
+        summary.setExecutionFailed(stats.isExecutionFailed());
+        return summary;
+    }
+
+    /**
+     * Default purge failure classification for a single GUID.
+     */
+    public static FailedEntity classifyPurgeFailure(String guid, Throwable error, String defaultMessage) {
+        if (error instanceof AtlasBaseException) {
+            AtlasBaseException atlasError = (AtlasBaseException) error;
+            return new FailedEntity(guid, atlasError.getAtlasErrorCode().getErrorCode(),
+                    error.getMessage());
+        }
+
+        String message = defaultMessage != null ? defaultMessage : (error != null ? error.getMessage() : null);
+        return new FailedEntity(guid, AtlasErrorCode.INTERNAL_ERROR.getErrorCode(), message);
+    }
+
+    /**
+     * Builds {@code summary} from incremental {@link PurgeExecutionStats} counters (O(1)).
+     */
+    public static void attachPurgeSummary(EntityMutationResponse response, PurgeExecutionStats stats) {
+        if (response == null || stats == null) {
+            return;
+        }
+
+        PurgeSummary summary = buildPurgeSummary(stats);
+        stats.validateSummaryBalances(summary);
+        response.setSummary(summary);
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/AtlasEntityStore.java
@@ -19,6 +19,7 @@ package org.apache.atlas.repository.store.graph;
 
 import org.apache.atlas.bulkimport.BulkImportResponse;
 import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.audit.AtlasAuditEntry.AuditOperation;
 import org.apache.atlas.model.instance.AtlasCheckStateRequest;
 import org.apache.atlas.model.instance.AtlasCheckStateResult;
 import org.apache.atlas.model.instance.AtlasClassification;
@@ -28,7 +29,7 @@ import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasEntityHeaders;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.EntityMutationResponse;
-import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.model.instance.FailedEntity;
 import org.apache.atlas.repository.store.graph.v2.EntityStream;
 import org.apache.atlas.type.AtlasEntityType;
 
@@ -227,12 +228,29 @@ public interface AtlasEntityStore {
      */
     EntityMutationResponse purgeByIds(Set<String> guids) throws AtlasBaseException;
 
+    /**
+     * Shared WIM worker purge path for REST and scheduled purge. Uses the transactional entity-store
+     * proxy ({@code PurgeBatchExecutor(self)}) so batch commits run inside {@code @GraphTransaction}.
+     */
+    EntityMutationResponse executePurgeWithWorkers(Set<String> originallyRequestedGuids,
+                                                          Set<String> validGuids,
+                                                          List<FailedEntity> preFailures,
+                                                          AuditOperation auditOperation) throws AtlasBaseException;
+
     /*
      * Returns set of auto-purged entity guids
      */
     EntityMutationResponse purgeEntitiesInBatch(Set<String> deletedVertices) throws AtlasBaseException;
 
-    Set<AtlasVertex> accumulateDeletionCandidates(Set<String> vertices) throws AtlasBaseException;
+    /*
+     * Resolves purge/delete dependency candidates for the given entity GUIDs.
+     *
+     * INCOMPATIBLE CHANGE (ATLAS-5317): return type changed from Set<AtlasVertex> to
+     * Set<String>. The method was added in ATLAS-4920; ATLAS-5317 returns GUIDs so
+     * worker-batch purge can enqueue candidates without leaking transaction-bound vertices.
+     * Custom AtlasEntityStore implementations must match this signature.
+     */
+    Set<String> accumulateDeletionCandidates(Set<String> vertices) throws AtlasBaseException;
 
     /**
      * Add classification(s)

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -221,7 +221,8 @@ public abstract class DeleteHandlerV1 {
     /*
         actually delete traits and then the vertex along its references
     */
-    public void deleteTraitsAndVertices(Collection<AtlasVertex> deletionCandidateVertices) throws AtlasBaseException {
+    public Collection<AtlasVertex> deleteTraitsAndVertices(Collection<AtlasVertex> deletionCandidateVertices) throws AtlasBaseException {
+        Collection<AtlasVertex> deletedVertices = new ArrayList<>();
         for (AtlasVertex deletionCandidateVertex : deletionCandidateVertices) {
             if (deletionCandidateVertex == null) {
                 continue;
@@ -235,10 +236,12 @@ public abstract class DeleteHandlerV1 {
             try {
                 deleteAllClassifications(deletionCandidateVertex);
                 deleteTypeVertex(deletionCandidateVertex, isInternalType(deletionCandidateVertex));
+                deletedVertices.add(deletionCandidateVertex);
             } catch (IllegalStateException e) {
                 LOG.warn("deleteTraitsAndVertices(): skipping vertex - already removed", e);
             }
         }
+        return deletedVertices;
     }
 
     public void addUpstreamProcessEntities(AtlasVertex entityVertex, Set<AtlasVertex> deletionCandidateVertices, Set<String> instanceVertexGuids) throws AtlasBaseException {
@@ -1157,7 +1160,7 @@ public abstract class DeleteHandlerV1 {
             LOG.debug("Removing edge from {} to {} with attribute name {}", string(outVertex), string(inVertex), attribute.getName());
         }
 
-        if (skipVertexForDelete(outVertex)) {
+        if (skipVertexForDelete(outVertex) || isDeletedEntity(outVertex)) {
             return;
         }
 
@@ -1433,13 +1436,10 @@ public abstract class DeleteHandlerV1 {
                 final RequestContext reqContext = RequestContext.get();
                 final String         guid       = AtlasGraphUtilsV2.getIdFromVertex(vertex);
 
-                if (guid != null && !reqContext.isDeletedEntity(guid)) {
-                    final AtlasEntity.Status vertexState = getState(vertex);
-                    if (reqContext.isPurgeRequested()) {
-                        ret = vertexState == ACTIVE; // skip purging ACTIVE vertices
-                    } else {
-                        ret = vertexState == DELETED; // skip deleting DELETED vertices
-                    }
+                if (reqContext.isPurgeRequested()) {
+                    ret = getState(vertex) == ACTIVE; // skip purging ACTIVE vertices
+                } else if (guid != null && !reqContext.isDeletedEntity(guid)) {
+                    ret = getState(vertex) == DELETED; // skip deleting DELETED vertices
                 }
             } catch (IllegalStateException excp) {
                 LOG.warn("skipVertexForDelete(): failed guid/state for the vertex", excp);

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2.java
@@ -18,6 +18,7 @@
 package org.apache.atlas.repository.store.graph.v2;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.DeleteType;
 import org.apache.atlas.GraphTransactionInterceptor;
@@ -32,6 +33,7 @@ import org.apache.atlas.bulkimport.BulkImportResponse;
 import org.apache.atlas.bulkimport.BulkImportResponse.ImportInfo;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.TypeCategory;
+import org.apache.atlas.model.audit.AtlasAuditEntry.AuditOperation;
 import org.apache.atlas.model.instance.AtlasCheckStateRequest;
 import org.apache.atlas.model.instance.AtlasCheckStateResult;
 import org.apache.atlas.model.instance.AtlasClassification;
@@ -43,15 +45,21 @@ import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasEntityHeaders;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.FailedEntity;
 import org.apache.atlas.model.typedef.AtlasBaseTypeDef;
+import org.apache.atlas.repository.audit.AtlasAuditService;
 import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.purge.PurgeExecutionStats;
+import org.apache.atlas.repository.purge.PurgeUtils;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.EntityGraphDiscovery;
 import org.apache.atlas.repository.store.graph.EntityGraphDiscoveryContext;
 import org.apache.atlas.repository.store.graph.v1.DeleteHandlerDelegate;
 import org.apache.atlas.repository.store.graph.v2.AtlasEntityComparator.AtlasEntityDiffResult;
+import org.apache.atlas.services.PurgeBatchExecutor;
+import org.apache.atlas.services.PurgeBatchOrchestrator;
 import org.apache.atlas.type.AtlasArrayType;
 import org.apache.atlas.type.AtlasBusinessMetadataType.AtlasBusinessAttribute;
 import org.apache.atlas.type.AtlasClassificationType;
@@ -70,9 +78,11 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -81,6 +91,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -110,6 +122,12 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     private final EntityGraphRetriever       entityRetriever;
     private       EntityRenameHandler        entityRenameHandler;
     private       boolean                    storeDifferentialAudits;
+    @Inject
+    @Lazy
+    private AtlasEntityStore self;
+    @Inject
+    @Lazy
+    private Provider<AtlasAuditService> auditServiceProvider;
 
     @Inject
     public AtlasEntityStoreV2(AtlasGraph graph, DeleteHandlerDelegate deleteDelegate, AtlasTypeRegistry typeRegistry, IAtlasEntityChangeNotifier entityChangeNotifier, EntityGraphMapper entityGraphMapper) {
@@ -130,6 +148,11 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     @VisibleForTesting
     public void setStoreDifferentialAudits(boolean val) {
         this.storeDifferentialAudits = val;
+    }
+
+    @VisibleForTesting
+    public void setSelf(AtlasEntityStore self) {
+        this.self = self;
     }
 
     @Override
@@ -547,79 +570,221 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
     }
 
     @Override
-    @GraphTransaction
     public EntityMutationResponse purgeByIds(Set<String> guids) throws AtlasBaseException {
         if (CollectionUtils.isEmpty(guids)) {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_PARAMETERS, "Guid(s) not specified");
         }
 
+        int purgeApiMaxRequestSize = AtlasConfiguration.PURGE_API_MAX_REQUEST_SIZE.getInt();
+        if (guids.size() > purgeApiMaxRequestSize) {
+            throw new AtlasBaseException(AtlasErrorCode.PURGE_REQUEST_SIZE_EXCEEDS_LIMIT, String.valueOf(guids.size()), String.valueOf(purgeApiMaxRequestSize));
+        }
+
         AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.ADMIN_PURGE), "purge entity: guids=", guids);
 
-        Collection<AtlasVertex> purgeCandidates = new ArrayList<>();
+        LOG.info("purgeByIds: requested {} guid(s)", guids.size());
 
+        // Pre-scan all GUIDs — validate format + lookup
+        Set<String>                               validGuids     = new LinkedHashSet<>();
+        List<FailedEntity> failedEntities = new ArrayList<>();
+
+        preScanGuids(guids, validGuids, failedEntities);
+
+        LOG.info("purgeByIds: preScan valid={}, failed={}", validGuids.size(), failedEntities.size());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("purgeByIds: preScan validGuids={}, failedEntities={}", validGuids, failedEntities);
+        }
+
+        // If no valid GUIDs, return 400-level response with failed entities
+        if (validGuids.isEmpty()) {
+            return buildPreValidationOnlyResponse(guids, failedEntities);
+        }
+
+        // Iteratively expand deletion candidates per root GUID and feed workers (aligned with PurgeService)
+        return executePurgeWithWorkers(guids, validGuids, failedEntities, AuditOperation.PURGE);
+    }
+
+    @Override
+    public EntityMutationResponse executePurgeWithWorkers(Set<String> originallyRequestedGuids,
+                                                                 Set<String> validGuids,
+                                                                 List<FailedEntity> preFailures,
+                                                                 AuditOperation auditOperation) throws AtlasBaseException {
+        PurgeBatchOrchestrator.initializePurgeContext();
+        try {
+            PurgeBatchExecutor executor = new PurgeBatchExecutor(self);
+            AtlasAuditService auditService = auditServiceProvider != null ? auditServiceProvider.get() : null;
+            PurgeBatchOrchestrator orchestrator = new PurgeBatchOrchestrator(executor, auditService, auditOperation);
+
+            PurgeExecutionStats stats = new PurgeExecutionStats(originallyRequestedGuids, validGuids.size());
+            EntityMutationResponse response = orchestrator.executePurge(validGuids, preFailures, stats);
+
+            PurgeUtils.attachPurgeSummary(response, stats);
+
+            LOG.info("executePurgeWithWorkers: completed purged={}, failed={}, summary={}",
+                    response.getPurgedEntities() != null ? response.getPurgedEntities().size() : 0,
+                    response.getFailedEntities() != null ? response.getFailedEntities().size() : 0,
+                    response.getSummary());
+
+            return response;
+        } finally {
+            PurgeBatchOrchestrator.resetPurgeContext();
+        }
+    }
+
+    private void preScanGuids(Set<String> guids, Set<String> validGuids, List<FailedEntity> failedEntities) {
         for (String guid : guids) {
-            AtlasVertex vertex = AtlasGraphUtilsV2.findDeletedByGuid(graph, guid);
-
-            if (vertex == null) {
-                // Entity does not exist - treat as non-error, since the caller
-                // wanted to delete the entity and it's already gone.
-                LOG.warn("Purge request ignored for non-existent/active entity with guid {}", guid);
-
-                continue;
+            FailedEntity failure = validatePurgePreconditions(guid);
+            if (failure != null) {
+                failedEntities.add(failure);
+            } else {
+                validGuids.add(guid);
             }
+        }
+    }
 
-            purgeCandidates.add(vertex);
+    private FailedEntity validatePurgePreconditions(String guid) {
+        if (!isValidUuid(guid)) {
+            LOG.debug("Purge request ignored for invalid GUID format: {}", guid);
+            return createPreScanFailure(guid, AtlasErrorCode.INVALID_GUID, guid);
         }
 
-        if (purgeCandidates.isEmpty()) {
-            LOG.info("No purge candidate entities were found for guids: {} which is already deleted", guids);
+        AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(graph, guid);
+
+        if (vertex == null) {
+            LOG.debug("Purge request ignored for non-existent entity: guid={}", guid);
+            return createPreScanFailure(guid, AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, guid);
         }
 
-        EntityMutationResponse ret = purgeVertices(purgeCandidates);
+        if (AtlasGraphUtilsV2.getState(vertex) != Status.DELETED) {
+            LOG.debug("Purge request ignored for entity not in DELETED state: guid={}", guid);
+            return createPreScanFailure(guid, AtlasErrorCode.NOT_IN_DELETED_STATE, guid);
+        }
 
-        // Notify the change listeners
-        entityChangeNotifier.onEntitiesMutated(ret, false);
+        String typeName = AtlasGraphUtilsV2.getTypeName(vertex);
+        if (StringUtils.isBlank(typeName)) {
+            LOG.debug("Purge request ignored for entity with missing type name: guid={}", guid);
+            return createPreScanFailure(guid, AtlasErrorCode.TYPE_NAME_NOT_FOUND, "null");
+        }
+        if (!typeRegistry.isRegisteredType(typeName)) {
+            LOG.debug("Purge request ignored for entity with unregistered type: guid={}, typeName={}", guid, typeName);
+            return createPreScanFailure(guid, AtlasErrorCode.TYPE_NAME_NOT_FOUND, typeName);
+        }
 
-        return ret;
+        return null;
+    }
+
+    private EntityMutationResponse buildPreValidationOnlyResponse(Set<String> requestedGuids,
+                                                                  List<FailedEntity> failedEntities) {
+        EntityMutationResponse response = new EntityMutationResponse();
+        response.setFailedEntities(failedEntities);
+        PurgeExecutionStats stats = new PurgeExecutionStats(requestedGuids, 0);
+        stats.recordFailures(failedEntities);
+        PurgeUtils.attachPurgeSummary(response, stats);
+
+        if (auditServiceProvider != null && auditServiceProvider.get() != null) {
+            PurgeBatchOrchestrator.writeBatchAudit(auditServiceProvider.get(), AuditOperation.PURGE, requestedGuids, response);
+        }
+
+        return response;
+    }
+
+    private FailedEntity createPreScanFailure(String guid, AtlasErrorCode errorCode, String... messageArgs) {
+        return new FailedEntity(guid,
+                errorCode.getErrorCode(),
+                errorCode.getFormattedErrorMessage(messageArgs));
+    }
+
+    private void addPurgeBatchFailure(EntityMutationResponse response, String guid, AtlasErrorCode errorCode) {
+        if (response != null) {
+            response.addFailedEntity(new FailedEntity(guid, errorCode.getErrorCode(), errorCode.getFormattedErrorMessage(guid)));
+        }
+    }
+
+    private boolean isValidUuid(String guid) {
+        if (guid == null) {
+            return false;
+        }
+        try {
+            java.util.UUID.fromString(guid);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     @Override
     @GraphTransaction
     public EntityMutationResponse purgeEntitiesInBatch(Set<String> purgeCandidates) throws AtlasBaseException {
-        LOG.info("==> purgeEntitiesInBatch()");
+        LOG.debug("purgeEntitiesInBatch: batchSize={}", purgeCandidates.size());
 
         Collection<AtlasVertex> purgeVertices = new ArrayList<>();
-        EntityMutationResponse response      = new EntityMutationResponse();
+        EntityMutationResponse response = new EntityMutationResponse();
+        Map<AtlasVertex, AtlasEntityHeader> prePurgeHeaders = new IdentityHashMap<>();
 
         RequestContext requestContext = RequestContext.get();
         requestContext.setDeleteType(DeleteType.HARD); // hard deleter
         requestContext.setPurgeRequested(true);
 
+        if (CollectionUtils.isNotEmpty(purgeCandidates)) {
+            GraphTransactionInterceptor.lockObjectAndReleasePostCommit(new ArrayList<>(purgeCandidates));
+            GraphTransactionInterceptor.clearCache();
+        }
         for (String guid : purgeCandidates) {
             AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(graph, guid);
-            if (vertex != null) {
+            if (vertex == null || !vertex.exists()) {
+                LOG.debug("Purge batch skipped guid={} as vertex was already removed (likely by concurrent batch)", guid);
+                addPurgeBatchFailure(response, guid, AtlasErrorCode.INSTANCE_GUID_NOT_FOUND);
+                continue;
+            }
+
+            try {
+                if (AtlasGraphUtilsV2.getState(vertex) != Status.DELETED) {
+                    LOG.warn("Purge batch skipped guid={} as it is no longer in DELETED state", guid);
+                    addPurgeBatchFailure(response, guid, AtlasErrorCode.NOT_IN_DELETED_STATE);
+                    continue;
+                }
+
                 AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(vertex);
                 purgeVertices.add(vertex);
-                response.addEntity(PURGE, entityHeader);
+                prePurgeHeaders.put(vertex, entityHeader);
+            } catch (IllegalStateException e) {
+                LOG.debug("Purge batch skipped guid={} as vertex was already removed (likely by concurrent batch)", guid, e);
+                addPurgeBatchFailure(response, guid, AtlasErrorCode.INSTANCE_GUID_NOT_FOUND);
             }
         }
 
-        deleteDelegate.getHandler().deleteTraitsAndVertices(purgeVertices);
+        Collection<AtlasVertex> deletedVertices = deleteDelegate.getHandler().deleteTraitsAndVertices(purgeVertices);
+        Set<AtlasVertex> deletedVertexSet = Collections.newSetFromMap(new IdentityHashMap<>());
+        deletedVertexSet.addAll(deletedVertices);
 
-        entityChangeNotifier.onEntitiesMutated(response, false);
+        EntityMutationResponse notificationResponse = new EntityMutationResponse();
 
-        for (AtlasEntityHeader entity : response.getPurgedEntities()) {
-            LOG.info("Auto purged entity with guid {}", entity.getGuid());
+        for (Map.Entry<AtlasVertex, AtlasEntityHeader> entry : prePurgeHeaders.entrySet()) {
+            if (deletedVertexSet.contains(entry.getKey())) {
+                response.addEntity(PURGE, entry.getValue());
+                notificationResponse.addEntity(PURGE, entry.getValue());
+            } else {
+                String guid = entry.getValue().getGuid();
+                LOG.debug("Purge batch skipped guid={} as vertex was not deleted by this batch, assuming concurrently removed", guid);
+                addPurgeBatchFailure(response, guid, AtlasErrorCode.INSTANCE_GUID_NOT_FOUND);
+            }
         }
 
-        LOG.info("<== purgeEntitiesInBatch()");
+        // Notify listeners only for vertices hard-deleted in this batch. GUIDs removed by a concurrent
+        // batch (during pre-check or delete) are already purged, so do not trigger notifications again.
+        entityChangeNotifier.onEntitiesMutated(notificationResponse, false);
+
+        if (CollectionUtils.isNotEmpty(response.getPurgedEntities())) {
+            LOG.debug("purgeEntitiesInBatch: purged {} entity(ies)", response.getPurgedEntities().size());
+        }
 
         return response;
     }
 
     @Override
-    public Set<AtlasVertex> accumulateDeletionCandidates(Set<String> guids) throws AtlasBaseException {
-        LOG.info("==> accumulateDeletionCandidates() !");
+    @GraphTransaction
+    public Set<String> accumulateDeletionCandidates(Set<String> guids) throws AtlasBaseException {
+        LOG.debug("accumulateDeletionCandidates: guidCount={}", guids.size());
         Set<AtlasVertex> vertices = new HashSet<>();
 
         for (String guid : guids) {
@@ -627,7 +792,18 @@ public class AtlasEntityStoreV2 implements AtlasEntityStore {
             vertices.add(vertex);
         }
 
-        return deleteDelegate.getHandler().accumulateDeletionCandidates(vertices);
+        Set<AtlasVertex> deletionCandidates = deleteDelegate.getHandler().accumulateDeletionCandidates(vertices);
+        Set<String>      candidateGuids       = new LinkedHashSet<>();
+
+        for (AtlasVertex vertex : deletionCandidates) {
+            String candidateGuid = AtlasGraphUtilsV2.getIdFromVertex(vertex);
+
+            if (candidateGuid != null) {
+                candidateGuids.add(candidateGuid);
+            }
+        }
+
+        return candidateGuids;
     }
 
     @Override

--- a/repository/src/main/java/org/apache/atlas/services/PurgeBatchExecutor.java
+++ b/repository/src/main/java/org/apache/atlas/services/PurgeBatchExecutor.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.services;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.GraphTransactionInterceptor;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+public class PurgeBatchExecutor {
+    private static final Logger LOG = LoggerFactory.getLogger(PurgeBatchExecutor.class);
+
+    private static final int MAX_RETRIES     = 3;
+    private static final int BASE_BACKOFF_MS = 500;
+
+    /**
+     * Fully-qualified class names treated as retryable lock or backend conflicts during purge batch
+     * execution. Names are matched against the throwable cause chain to avoid a compile-time dependency
+     * on JanusGraph or Berkeley JE types in the service layer.
+     * <p>
+     * Design default: {@code PermanentLockingException}. Berkeley JE lock timeouts/deadlocks and
+     * {@code PermanentBackendException} are included for the embedded Berkeley backend.
+     */
+    static final Set<String> RETRYABLE_LOCK_CONFLICT_EXCEPTION_CLASS_NAMES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(
+                    "org.janusgraph.diskstorage.locking.PermanentLockingException",
+                    "com.sleepycat.je.LockTimeoutException",
+                    "com.sleepycat.je.DeadlockException",
+                    "org.janusgraph.diskstorage.PermanentBackendException")));
+
+    private final AtlasEntityStore entityStore;
+
+    public PurgeBatchExecutor(AtlasEntityStore entityStore) {
+        this.entityStore = entityStore;
+    }
+
+    public AtlasEntityStore getEntityStore() {
+        return entityStore;
+    }
+
+    public EntityMutationResponse executeBatch(Set<String> batch) throws AtlasBaseException {
+        return withRetry(() -> entityStore.purgeEntitiesInBatch(batch));
+    }
+
+    /**
+     * Returns {@code true} when {@code throwable} or any of its causes matches a known retryable
+     * lock or backend conflict type.
+     */
+    static boolean isRetryableLockConflict(Throwable throwable) {
+        if (throwable == null) {
+            return false;
+        }
+
+        for (Throwable c = throwable; c != null; c = c.getCause()) {
+            if (RETRYABLE_LOCK_CONFLICT_EXCEPTION_CLASS_NAMES.contains(c.getClass().getName())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private <T> T withRetry(Callable<T> action) throws AtlasBaseException {
+        int attempt = 0;
+
+        while (true) {
+            try {
+                return action.call();
+            } catch (Throwable e) {
+                boolean canRetry = isRetryableLockConflict(e) && attempt < (MAX_RETRIES - 1);
+                if (canRetry) {
+                    GraphTransactionInterceptor.clearCache();
+                    RequestContext.get().clearCache();
+
+                    long backoff = (long) BASE_BACKOFF_MS * (attempt + 1);
+                    LOG.warn("Lock conflict for purge batch on attempt {}/{}, backing off {} ms",
+                            attempt + 1, MAX_RETRIES, backoff);
+                    try {
+                        Thread.sleep(backoff);
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                    attempt++;
+                    continue;
+                }
+
+                LOG.error("Failed to process purge batch on attempt {}/{}", attempt + 1, MAX_RETRIES, e);
+                if (e instanceof AtlasBaseException) {
+                    throw (AtlasBaseException) e;
+                }
+                throw new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, e);
+            }
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/services/PurgeBatchOrchestrator.java
+++ b/repository/src/main/java/org/apache/atlas/services/PurgeBatchOrchestrator.java
@@ -1,0 +1,587 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.services;
+
+import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.DeleteType;
+import org.apache.atlas.GraphTransactionInterceptor;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.audit.AtlasAuditEntry.AuditOperation;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.EntityMutations.EntityOperation;
+import org.apache.atlas.model.instance.FailedEntity;
+import org.apache.atlas.model.instance.PurgeSummary;
+import org.apache.atlas.pc.WorkItemBuilder;
+import org.apache.atlas.pc.WorkItemConsumer;
+import org.apache.atlas.pc.WorkItemManager;
+import org.apache.atlas.repository.audit.AtlasAuditService;
+import org.apache.atlas.repository.purge.PurgeExecutionStats;
+import org.apache.atlas.repository.purge.PurgeFailureCategory;
+import org.apache.atlas.repository.purge.PurgeUtils;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.configuration2.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.stream.Collectors;
+
+public class PurgeBatchOrchestrator {
+    private static final Logger LOG = LoggerFactory.getLogger(PurgeBatchOrchestrator.class);
+    public static final String  PURGE_WORKERS_NAME             = "Entity-Purge-Worker";
+    private static final String PURGE_WORKER_BATCH_SIZE_KEY    = "atlas.purge.worker.batch.size";
+    private static final String PURGE_WORKERS_COUNT_KEY        = "atlas.purge.workers.count";
+    private static final int    DEFAULT_PURGE_WORKER_BATCH_SIZE  = 100;
+    private static final int    DEFAULT_PURGE_WORKERS_COUNT      = 2;
+    private static final int    PURGE_AUDIT_SAMPLE_GUID_LIMIT  = 10;
+    static final String         UNPROCESSED_PURGE_GUID_MESSAGE = "Not processed during purge shutdown";
+
+    private final PurgeBatchExecutor     purgeBatchExecutor;
+    private final AtlasAuditService      auditService;
+    private final AuditOperation         auditOperation;
+
+    public PurgeBatchOrchestrator(PurgeBatchExecutor purgeBatchExecutor, AtlasAuditService auditService,
+                                  AuditOperation auditOperation) {
+        this.purgeBatchExecutor    = purgeBatchExecutor;
+        this.auditService          = auditService;
+        this.auditOperation        = auditOperation;
+    }
+
+    public EntityMutationResponse executePurge(Set<String> validGuids, List<FailedEntity> failedEntities,
+                                               PurgeExecutionStats stats) throws AtlasBaseException {
+        if (failedEntities == null) {
+            failedEntities = new ArrayList<>();
+        }
+
+        Configuration configuration = null;
+        try {
+            configuration = ApplicationProperties.get();
+        } catch (Exception e) {
+            LOG.warn("executePurge: failed to load application properties, using defaults", e);
+        }
+        int batchSize  = getWorkerBatchSize(configuration);
+        int numWorkers = getWorkersCount(configuration);
+
+        Set<String> producedDeletionCandidates = stats != null
+                ? stats.getProducedDeletionCandidates() : new LinkedHashSet<>();
+
+        WorkItemManager<String, PurgeBatchConsumer> manager = createManager(batchSize, numWorkers);
+
+        LOG.info("executePurge: starting iterative expand+WIM purge with batchSize={}, numWorkers={}, validGuids={}",
+                batchSize, numWorkers, validGuids.size());
+
+        EntityMutationResponse response = new EntityMutationResponse();
+        try {
+            for (String validGuid : validGuids) {
+                if (producedDeletionCandidates.contains(validGuid)) {
+                    continue;
+                }
+
+                try {
+                    expandDeletionCandidatesAndProduce(validGuid, producedDeletionCandidates, manager, purgeBatchExecutor.getEntityStore());
+                } catch (Exception e) {
+                    LOG.warn("executePurge: failed to accumulate deletion candidates for guid={}", validGuid, e);
+                    FailedEntity failedEntity = PurgeUtils.classifyPurgeFailure(validGuid, e, null);
+                    failedEntities.add(failedEntity);
+                } finally {
+                    clearPurgeCandidateExpansionState();
+                }
+            }
+
+            LOG.info("executePurge: produced {} guid(s) from {} valid request guid(s)",
+                    producedDeletionCandidates.size(), validGuids.size());
+        } finally {
+            try {
+                manager.shutdown();
+            } catch (InterruptedException e) {
+                LOG.warn("executePurge: purge worker shutdown interrupted; collecting partial results", e);
+                Thread.currentThread().interrupt();
+            }
+
+            aggregateBatchResults(manager.getResults(), response, stats, failedEntities);
+            reconcileUnprocessedGuids(producedDeletionCandidates, response, null, stats);
+        }
+
+        return response;
+    }
+
+    public static int getWorkerBatchSize(Configuration configuration) {
+        return configuration != null
+                ? configuration.getInt(PURGE_WORKER_BATCH_SIZE_KEY, DEFAULT_PURGE_WORKER_BATCH_SIZE)
+                : DEFAULT_PURGE_WORKER_BATCH_SIZE;
+    }
+
+    public static int getWorkersCount(Configuration configuration) {
+        return configuration != null
+                ? configuration.getInt(PURGE_WORKERS_COUNT_KEY, DEFAULT_PURGE_WORKERS_COUNT)
+                : DEFAULT_PURGE_WORKERS_COUNT;
+    }
+
+    public static void expandDeletionCandidatesAndProduce(String rootGuid, Set<String> producedDeletionCandidates,
+                                                          WorkItemManager<String, ?> manager,
+                                                          AtlasEntityStore entityStore) throws AtlasBaseException {
+        Set<String> deletionCandidateGuids = entityStore.accumulateDeletionCandidates(Collections.singleton(rootGuid));
+
+        for (String guid : deletionCandidateGuids) {
+            if (guid != null && producedDeletionCandidates.add(guid)) {
+                manager.checkProduce(guid);
+            }
+        }
+
+        if (producedDeletionCandidates.add(rootGuid)) {
+            manager.checkProduce(rootGuid);
+        }
+    }
+
+    /**
+     * Clears graph and RequestContext caches after one root GUID is expanded and enqueued,
+     * so the next expansion does not reuse stale vertex handles.
+     */
+    public static void clearPurgeCandidateExpansionState() {
+        GraphTransactionInterceptor.clearCache();
+        RequestContext.get().clearCache();
+        initializePurgeContext();
+    }
+
+    public static void initializePurgeContext() {
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+    }
+
+    public static void resetPurgeContext() {
+        GraphTransactionInterceptor.clearCache();
+        RequestContext.get().clearCache();
+        RequestContext.get().setDeleteType(DeleteType.DEFAULT);
+        RequestContext.get().setPurgeRequested(false);
+    }
+
+    public static int aggregateBatchResults(Queue<Object> results, EntityMutationResponse target,
+                                            PurgeExecutionStats stats, List<FailedEntity> expansionFailures) {
+        if (expansionFailures != null) {
+            for (FailedEntity failedEntity : expansionFailures) {
+                if (stats != null) {
+                    stats.recordFailure(failedEntity);
+                }
+                target.addFailedEntity(failedEntity);
+            }
+        }
+
+        if (results == null) {
+            LOG.warn("Purge worker results queue was not initialized");
+            return expansionFailures != null ? expansionFailures.size() : 0;
+        }
+
+        int resultCount = results.size();
+
+        while (!results.isEmpty()) {
+            Object res = results.poll();
+
+            if (res instanceof PurgeBatchResult) {
+                PurgeBatchResult batchResult = (PurgeBatchResult) res;
+
+                if (stats != null) {
+                    if (batchResult.hasBatchException()) {
+                        stats.recordBatchThrowable(batchResult.getBatchGuids(), batchResult.getFailedEntities());
+                    } else {
+                        stats.recordBatchOutcome(batchResult.getPurgedEntities(), batchResult.getFailedEntities(),
+                                batchResult.getBatchGuids());
+                    }
+                }
+
+                for (AtlasEntityHeader header : batchResult.getPurgedEntities()) {
+                    target.addEntity(EntityOperation.PURGE, header);
+                }
+
+                for (FailedEntity failedEntity : batchResult.getFailedEntities()) {
+                    target.addFailedEntity(failedEntity);
+                }
+            } else {
+                LOG.warn("Unexpected result type in purge worker queue: {}", res != null ? res.getClass().getName() : "null");
+            }
+        }
+
+        return resultCount + (expansionFailures != null ? expansionFailures.size() : 0);
+    }
+
+    public static int reconcileUnprocessedGuids(Collection<String> submittedGuids, EntityMutationResponse response,
+                                                List<FailedEntity> pendingFailures, PurgeExecutionStats stats) {
+        if (submittedGuids == null || submittedGuids.isEmpty()) {
+            return 0;
+        }
+
+        Set<String> accountedGuids = collectAccountedGuids(response, pendingFailures);
+        int           reconciledCount = 0;
+
+        for (String guid : submittedGuids) {
+            if (guid == null || accountedGuids.contains(guid)) {
+                continue;
+            }
+
+            FailedEntity failedEntity = PurgeUtils.classifyPurgeFailure(guid, null, UNPROCESSED_PURGE_GUID_MESSAGE);
+
+            if (pendingFailures != null) {
+                pendingFailures.add(failedEntity);
+            } else if (response != null) {
+                response.addFailedEntity(failedEntity);
+            }
+
+            if (stats != null) {
+                stats.recordReconciledUnprocessed(1);
+                stats.recordFailure(failedEntity);
+            }
+
+            accountedGuids.add(guid);
+            reconciledCount++;
+        }
+
+        if (reconciledCount > 0) {
+            LOG.warn("Purge reconciliation marked {} unprocessed guid(s) as failed", reconciledCount);
+        }
+
+        return reconciledCount;
+    }
+
+    private static Set<String> collectAccountedGuids(EntityMutationResponse response, List<FailedEntity> pendingFailures) {
+        Set<String> accountedGuids = new HashSet<>();
+
+        if (response != null) {
+            if (response.getPurgedEntities() != null) {
+                for (AtlasEntityHeader entityHeader : response.getPurgedEntities()) {
+                    if (entityHeader.getGuid() != null) {
+                        accountedGuids.add(entityHeader.getGuid());
+                    }
+                }
+            }
+
+            List<FailedEntity> failedEntities = response.getFailedEntities();
+            if (failedEntities != null) {
+                for (FailedEntity failedEntity : failedEntities) {
+                    if (failedEntity.getGuid() != null) {
+                        accountedGuids.add(failedEntity.getGuid());
+                    }
+                }
+            }
+        }
+
+        if (pendingFailures != null) {
+            for (FailedEntity failedEntity : pendingFailures) {
+                if (failedEntity.getGuid() != null) {
+                    accountedGuids.add(failedEntity.getGuid());
+                }
+            }
+        }
+
+        return accountedGuids;
+    }
+
+    public PurgeBatchManager createManager(int batchSize, int numWorkers) {
+        PurgeWorkerContext workerContext = PurgeWorkerContext.capture(RequestContext.get());
+
+        PurgeBatchConsumerBuilder builder = new PurgeBatchConsumerBuilder(purgeBatchExecutor, auditService,
+                auditOperation, batchSize, workerContext);
+        return new PurgeBatchManager(builder, batchSize, numWorkers);
+    }
+
+    /**
+     * Immutable snapshot of request audit context propagated to purge worker threads.
+     */
+    static final class PurgeWorkerContext {
+        private final String       user;
+        private final Set<String>  userGroups;
+        private final String       clientIPAddress;
+        private final List<String> forwardedAddresses;
+
+        private PurgeWorkerContext(String user, Set<String> userGroups, String clientIPAddress,
+                                   List<String> forwardedAddresses) {
+            this.user               = user;
+            this.userGroups         = userGroups;
+            this.clientIPAddress    = clientIPAddress;
+            this.forwardedAddresses = forwardedAddresses;
+        }
+
+        static PurgeWorkerContext capture(RequestContext source) {
+            Set<String>  groups    = source.getUserGroups();
+            List<String> forwarded = source.getForwardedAddresses();
+
+            return new PurgeWorkerContext(
+                    source.getUser(),
+                    groups != null ? new HashSet<>(groups) : null,
+                    source.getClientIPAddress(),
+                    forwarded != null ? new ArrayList<>(forwarded) : null);
+        }
+
+        void applyTo(RequestContext target) {
+            target.setUser(user, userGroups);
+            target.setClientIPAddress(clientIPAddress);
+            target.setForwardedAddresses(forwardedAddresses);
+        }
+    }
+
+    public static class PurgeBatchConsumer extends WorkItemConsumer<String> {
+        private final Set<String> batch = new LinkedHashSet<>();
+        private final PurgeBatchExecutor    purgeBatchExecutor;
+        private final AtlasAuditService     auditService;
+        private final AuditOperation        auditOperation;
+        private final int                   batchSize;
+        private final PurgeWorkerContext    workerContext;
+        private int                         batchesProcessed;
+
+        public PurgeBatchConsumer(BlockingQueue<String> queue, PurgeBatchExecutor purgeBatchExecutor,
+                                  AtlasAuditService auditService, AuditOperation auditOperation,
+                                  int batchSize, PurgeWorkerContext workerContext) {
+            super(queue);
+            this.purgeBatchExecutor    = purgeBatchExecutor;
+            this.auditService          = auditService;
+            this.auditOperation        = auditOperation;
+            this.batchSize             = batchSize;
+            this.workerContext         = workerContext;
+            this.batchesProcessed      = 0;
+            LOG.debug("Purge worker consumer started with batchSize={}", batchSize);
+        }
+
+        @Override
+        protected void processItem(String guid) {
+            LOG.debug("==> processing the entity {}", guid);
+            batch.add(guid);
+            commit();
+        }
+
+        @Override
+        protected void doCommit() {
+            if (batch.size() == batchSize) {
+                attemptCommit();
+            }
+        }
+
+        @Override
+        protected void commitDirty() {
+            if (!batch.isEmpty()) {
+                attemptCommit();
+            }
+            super.commitDirty();
+        }
+
+        protected void attemptCommit() {
+            if (batch.isEmpty()) {
+                return;
+            }
+
+            Set<String> batchGuids = new LinkedHashSet<>(batch);
+
+            RequestContext context = RequestContext.get();
+            context.clearCache();
+            try {
+                workerContext.applyTo(context);
+                initializePurgeContext();
+
+                EntityMutationResponse res = purgeBatchExecutor.executeBatch(batchGuids);
+
+                if (auditService != null && auditOperation != null) {
+                    writeBatchAudit(auditService, auditOperation, batchGuids, res);
+                }
+
+                addResult(new PurgeBatchResult(batchGuids,
+                        res != null ? res.getPurgedEntities() : null,
+                        res != null ? res.getFailedEntities() : null,
+                        false, null));
+            } catch (Throwable e) {
+                LOG.error("==> Exception in purge batch commit: {}", e.getMessage(), e);
+                List<FailedEntity> batchFailures = new ArrayList<>();
+                for (String guid : batch) {
+                    LOG.warn("Purge batch failure for guid={}: {}", guid, e.getMessage());
+                    FailedEntity failedEntity = PurgeUtils.classifyPurgeFailure(guid, e, null);
+                    batchFailures.add(failedEntity);
+                }
+
+                if (auditService != null && auditOperation != null) {
+                    EntityMutationResponse response = new EntityMutationResponse();
+                    for (FailedEntity fe : batchFailures) {
+                        response.addFailedEntity(fe);
+                    }
+                    writeBatchAudit(auditService, auditOperation, batchGuids, response);
+                }
+
+                addResult(new PurgeBatchResult(batchGuids, null, batchFailures, true, e));
+            } finally {
+                RequestContext.clear();
+                batchesProcessed++;
+                batch.clear();
+                LOG.debug("Purge worker processed batch {}", batchesProcessed);
+            }
+        }
+    }
+
+    public static void writeBatchAudit(AtlasAuditService auditService, AuditOperation operation, Set<String> batchGuids, EntityMutationResponse res) {
+        writeBatchAudit(auditService, operation, batchGuids, res, null);
+    }
+
+    public static void writeBatchAudit(AtlasAuditService auditService, AuditOperation operation, Set<String> batchGuids,
+                                       EntityMutationResponse res, Set<String> originallyRequestedGuids) {
+        if (res == null || CollectionUtils.isEmpty(batchGuids)) {
+            return;
+        }
+
+        PurgeAuditCounts counts = resolvePurgeAuditCounts(res, batchGuids, originallyRequestedGuids);
+        if (counts.purgedCount == 0 && counts.failedCount == 0 && counts.failedDependenciesCount == 0
+                && counts.skippedCount == 0) {
+            return;
+        }
+
+        String sampleRequested = batchGuids.stream().sorted().limit(PURGE_AUDIT_SAMPLE_GUID_LIMIT).collect(Collectors.joining(","));
+        String samplePurged = res.getPurgedEntities() != null ?
+                res.getPurgedEntities().stream().map(AtlasEntityHeader::getGuid).sorted()
+                        .limit(PURGE_AUDIT_SAMPLE_GUID_LIMIT).collect(Collectors.joining(",")) : "";
+        List<FailedEntity> failedEntities = res.getFailedEntities();
+        String sampleFailed = sampleFailedGuids(failedEntities, false);
+        String sampleSkipped = sampleFailedGuids(failedEntities, true);
+
+        String params = String.format("processedCount=%d, sampleGuids=[%s]", batchGuids.size(), sampleRequested);
+        String result = String.format(
+                "purgedCount=%d, failedCount=%d, failedDependenciesCount=%d, skippedCount=%d, samplePurgedGuids=[%s], sampleFailedGuids=[%s], sampleSkippedGuids=[%s]",
+                counts.purgedCount, counts.failedCount, counts.failedDependenciesCount, counts.skippedCount,
+                samplePurged, sampleFailed, sampleSkipped);
+
+        try {
+            auditService.add(operation, params, result, counts.purgedCount);
+        } catch (Exception e) {
+            LOG.warn("Failed to write purge batch audit entry", e);
+        }
+    }
+
+    private static PurgeAuditCounts resolvePurgeAuditCounts(EntityMutationResponse res, Set<String> batchGuids,
+                                                            Set<String> originallyRequestedGuids) {
+        PurgeSummary summary = res.getPurgeSummary();
+        if (summary != null) {
+            return new PurgeAuditCounts(
+                    toInt(summary.getPurgedCount()),
+                    toInt(summary.getFailedCount()),
+                    toInt(summary.getFailedDependenciesCount()),
+                    toInt(summary.getSkippedCount()));
+        }
+
+        int purgedCount              = 0;
+        int failedCount              = 0;
+        int failedDependenciesCount  = 0;
+        int skippedCount             = 0;
+
+        if (res.getPurgedEntities() != null) {
+            purgedCount = res.getPurgedEntities().size();
+        }
+
+        List<FailedEntity> failedEntities = res.getFailedEntities();
+        if (failedEntities != null) {
+            for (FailedEntity failedEntity : failedEntities) {
+                if (PurgeUtils.classifyPurgeFailureCode(failedEntity.getErrorCode()) == PurgeFailureCategory.SKIPPABLE) {
+                    skippedCount++;
+                } else if (isOriginallyRequested(failedEntity.getGuid(), originallyRequestedGuids, batchGuids)) {
+                    failedCount++;
+                } else {
+                    failedDependenciesCount++;
+                }
+            }
+        }
+
+        return new PurgeAuditCounts(purgedCount, failedCount, failedDependenciesCount, skippedCount);
+    }
+
+    private static boolean isOriginallyRequested(String guid, Set<String> originallyRequestedGuids, Set<String> batchGuids) {
+        if (originallyRequestedGuids != null && !originallyRequestedGuids.isEmpty()) {
+            return originallyRequestedGuids.contains(guid);
+        }
+        return batchGuids != null && batchGuids.contains(guid);
+    }
+
+    private static String sampleFailedGuids(List<FailedEntity> failedEntities, boolean skippable) {
+        if (failedEntities == null || failedEntities.isEmpty()) {
+            return "";
+        }
+
+        return failedEntities.stream()
+                .filter(failedEntity -> skippable == (PurgeUtils.classifyPurgeFailureCode(failedEntity.getErrorCode())
+                        == PurgeFailureCategory.SKIPPABLE))
+                .map(FailedEntity::getGuid)
+                .sorted()
+                .limit(PURGE_AUDIT_SAMPLE_GUID_LIMIT)
+                .collect(Collectors.joining(","));
+    }
+
+    private static int toInt(long value) {
+        return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) value;
+    }
+
+    private static final class PurgeAuditCounts {
+        private final int purgedCount;
+        private final int failedCount;
+        private final int failedDependenciesCount;
+        private final int skippedCount;
+
+        private PurgeAuditCounts(int purgedCount, int failedCount, int failedDependenciesCount, int skippedCount) {
+            this.purgedCount              = purgedCount;
+            this.failedCount              = failedCount;
+            this.failedDependenciesCount  = failedDependenciesCount;
+            this.skippedCount             = skippedCount;
+        }
+    }
+
+    public static class PurgeBatchConsumerBuilder implements WorkItemBuilder<PurgeBatchConsumer, String> {
+        private final PurgeBatchExecutor    purgeBatchExecutor;
+        private final AtlasAuditService     auditService;
+        private final AuditOperation        auditOperation;
+        private final int                   batchSize;
+        private final PurgeWorkerContext    workerContext;
+
+        public PurgeBatchConsumerBuilder(PurgeBatchExecutor purgeBatchExecutor, AtlasAuditService auditService,
+                                         AuditOperation auditOperation, int batchSize, PurgeWorkerContext workerContext) {
+            this.purgeBatchExecutor    = purgeBatchExecutor;
+            this.auditService          = auditService;
+            this.auditOperation        = auditOperation;
+            this.batchSize             = batchSize;
+            this.workerContext         = workerContext;
+        }
+
+        @Override
+        public PurgeBatchConsumer build(BlockingQueue<String> queue) {
+            return new PurgeBatchConsumer(queue, purgeBatchExecutor, auditService,
+                    auditOperation, batchSize, workerContext);
+        }
+    }
+
+    public static class PurgeBatchManager extends WorkItemManager<String, PurgeBatchConsumer> {
+        public PurgeBatchManager(PurgeBatchConsumerBuilder builder, int batchSize, int numWorkers) {
+            super(builder, PURGE_WORKERS_NAME, batchSize, numWorkers, true);
+        }
+
+        @Override
+        public void shutdown() throws InterruptedException {
+            LOG.debug("Shutting down purge worker manager");
+            drain();
+            super.shutdown();
+        }
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/services/PurgeBatchResult.java
+++ b/repository/src/main/java/org/apache/atlas/services/PurgeBatchResult.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.services;
+
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.FailedEntity;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents exactly one worker batch outcome.
+ * Workers enqueue this result instead of mutating PurgeExecutionStats directly.
+ */
+class PurgeBatchResult {
+    private final Set<String> batchGuids;
+    private final List<AtlasEntityHeader> purgedEntities;
+    private final List<FailedEntity> failedEntities;
+    private final boolean hasBatchException;
+    private final Throwable batchException;
+
+    public PurgeBatchResult(Set<String> batchGuids, List<AtlasEntityHeader> purgedEntities,
+                            List<FailedEntity> failedEntities, boolean hasBatchException,
+                            Throwable batchException) {
+        // Use defensive copies since worker collections might be cleared after execution
+        this.batchGuids = batchGuids != null ? new LinkedHashSet<>(batchGuids) : Collections.emptySet();
+        this.purgedEntities = purgedEntities != null ? new ArrayList<>(purgedEntities) : Collections.emptyList();
+        this.failedEntities = failedEntities != null ? new ArrayList<>(failedEntities) : Collections.emptyList();
+        this.hasBatchException = hasBatchException;
+        this.batchException = batchException;
+    }
+
+    public Set<String> getBatchGuids() {
+        return batchGuids;
+    }
+
+    public List<AtlasEntityHeader> getPurgedEntities() {
+        return purgedEntities;
+    }
+
+    public List<FailedEntity> getFailedEntities() {
+        return failedEntities;
+    }
+
+    public boolean hasBatchException() {
+        return hasBatchException;
+    }
+
+    public Throwable getBatchException() {
+        return batchException;
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/services/PurgeService.java
+++ b/repository/src/main/java/org/apache/atlas/services/PurgeService.java
@@ -20,19 +20,22 @@ package org.apache.atlas.services;
 
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasException;
-import org.apache.atlas.DeleteType;
-import org.apache.atlas.RequestContext;
 import org.apache.atlas.annotation.AtlasService;
 import org.apache.atlas.annotation.Timed;
+import org.apache.atlas.model.audit.AtlasAuditEntry.AuditOperation;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.FailedEntity;
 import org.apache.atlas.model.typedef.AtlasEntityDef;
 import org.apache.atlas.pc.WorkItemBuilder;
 import org.apache.atlas.pc.WorkItemConsumer;
 import org.apache.atlas.pc.WorkItemManager;
+import org.apache.atlas.repository.audit.AtlasAuditService;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasIndexQuery.Result;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.purge.PurgeExecutionStats;
+import org.apache.atlas.repository.purge.PurgeUtils;
 import org.apache.atlas.repository.store.graph.AtlasEntityStore;
 import org.apache.atlas.repository.store.graph.v1.DeleteHandlerV1;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
@@ -53,15 +56,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
 
-import static org.apache.atlas.model.instance.EntityMutations.EntityOperation.PURGE;
 import static org.apache.atlas.repository.Constants.ENTITY_TYPE_PROPERTY_KEY;
-import static org.apache.atlas.repository.Constants.GUID_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.MODIFICATION_TIMESTAMP_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.STATE_PROPERTY_KEY;
 import static org.apache.atlas.repository.Constants.VERTEX_INDEX;
@@ -72,10 +73,11 @@ import static org.apache.atlas.repository.Constants.VERTEX_INDEX;
 public class PurgeService implements Service {
     private static final Logger LOG       = LoggerFactory.getLogger(PurgeService.class);
     private static final Logger PERF_LOG  = AtlasPerfTracer.getPerfLogger("service.Purge");
-    private final AtlasGraph atlasGraph;
-    private static Configuration atlasProperties;
-    private final AtlasEntityStore entityStore;
-    private final AtlasTypeRegistry typeRegistry;
+    private final AtlasGraph            atlasGraph;
+    private static Configuration        atlasProperties;
+    private final AtlasEntityStore      entityStore;
+    private final AtlasTypeRegistry     typeRegistry;
+    private final AtlasAuditService     auditService;
 
     private static final String  ENABLE_PROCESS_SOFT_DELETION         = "atlas.enable.process.soft.delete";
     private static final boolean ENABLE_PROCESS_SOFT_DELETION_DEFAULT = false;
@@ -83,21 +85,16 @@ public class PurgeService implements Service {
     private static final String  SOFT_DELETE_ENABLED_PROCESS_TYPES    = "atlas.soft.delete.enabled.process.types";
     private static final String  PURGE_BATCH_SIZE                     = "atlas.purge.batch.size";
     private static final int     DEFAULT_PURGE_BATCH_SIZE             = 1000; // fetching limit at a time
-    private static final String  PURGE_WORKER_BATCH_SIZE              = "atlas.purge.worker.batch.size";
-    private static final int     DEFAULT_PURGE_WORKER_BATCH_SIZE      = 100;
     private static final String  CLEANUP_WORKER_BATCH_SIZE            = "atlas.cleanup.worker.batch.size";
     private static final int     DEFAULT_CLEANUP_WORKER_BATCH_SIZE    = 100;
     private static final String  PURGE_RETENTION_PERIOD               = "atlas.purge.deleted.entity.retention.days";
     private static final int     PURGE_RETENTION_PERIOD_DEFAULT       = 30; // days
-    private static final String  PURGE_WORKERS_COUNT                  = "atlas.purge.workers.count";
-    private static final int     DEFAULT_PURGE_WORKERS_COUNT          = 2;
     private static final String  CLEANUP_WORKERS_COUNT                = "atlas.cleanup.workers.count";
     private static final int     DEFAULT_CLEANUP_WORKERS_COUNT        = 2;
     private static final String  PROCESS_ENTITY_CLEANER_THREAD_NAME   = "Process-Entity-Cleaner";
     private final        String  indexSearchPrefix                    = AtlasGraphUtilsV2.getIndexSearchPrefix();
     private static final int     DEFAULT_CLEANUP_BATCH_SIZE           = 1000;
     private static final String  CLEANUP_WORKERS_NAME                 = "Process-Cleanup-Worker";
-    private static final String  PURGE_WORKERS_NAME                   = "Entity-Purge-Worker";
     private static final String  DELETED                              = "DELETED";
     private static final String  ACTIVE                               = "ACTIVE";
     private static final String  AND_STR                              = " AND ";
@@ -106,15 +103,17 @@ public class PurgeService implements Service {
         try {
             atlasProperties = ApplicationProperties.get();
         } catch (Exception e) {
-            LOG.info("Failed to load application properties", e);
+            LOG.warn("Failed to load application properties", e);
         }
     }
 
     @Inject
-    public PurgeService(AtlasGraph atlasgraph, AtlasEntityStore entityStore, AtlasTypeRegistry typeRegistry) {
-        this.atlasGraph   = atlasgraph;
-        this.entityStore  = entityStore;
-        this.typeRegistry = typeRegistry;
+    public PurgeService(AtlasGraph atlasgraph, AtlasEntityStore entityStore, AtlasTypeRegistry typeRegistry,
+                        AtlasAuditService auditService) {
+        this.atlasGraph            = atlasgraph;
+        this.entityStore           = entityStore;
+        this.typeRegistry          = typeRegistry;
+        this.auditService          = auditService;
     }
 
     @Override
@@ -157,13 +156,9 @@ public class PurgeService implements Service {
     @SuppressWarnings("unchecked")
     @Timed
     public EntityMutationResponse purgeEntities() {
-        LOG.info("==> PurgeService.purgeEntities()");
-        // index query of specific batch size
+        LOG.info("purgeEntities: starting");
         AtlasPerfTracer perf = null;
         EntityMutationResponse entityMutationResponse = new EntityMutationResponse();
-        RequestContext requestContext = RequestContext.get();
-        requestContext.setDeleteType(DeleteType.HARD); // hard delete
-        requestContext.setPurgeRequested(true);
 
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
@@ -171,21 +166,19 @@ public class PurgeService implements Service {
             }
 
             Set<String> allEligibleTypes = getEntityTypes();
+            Set<String> originallyRequestedGuids = new LinkedHashSet<>();
 
             try {
-                //bring n number of entities like 1000 at point of type Processes
-                WorkItemsQualifier wiq = createQualifier(typeRegistry, entityStore, atlasGraph, getPurgeWorkerBatchSize(), getPurgeWorkersCount(), true);
-
                 String indexQuery = getBulkQueryString(allEligibleTypes, getPurgeRetentionPeriod());
                 Iterator<Result> itr = atlasGraph.indexQuery(VERTEX_INDEX, indexQuery).vertices(0, getPurgeBatchSize());
-                LOG.info("==>  fetched Deleted entities");
 
                 if (!itr.hasNext()) {
-                    LOG.info("==> no Purge Entities found");
+                    LOG.info("purgeEntities: no eligible entities found");
+                    PurgeExecutionStats stats = new PurgeExecutionStats(originallyRequestedGuids,
+                            originallyRequestedGuids.size());
+                    PurgeUtils.attachPurgeSummary(entityMutationResponse, stats);
                     return entityMutationResponse;
                 }
-
-                Set<String> producedDeletionCandidates = new HashSet<>(); // look up
 
                 while (itr.hasNext()) {
                     AtlasVertex vertex = itr.next().getVertex();
@@ -194,48 +187,43 @@ public class PurgeService implements Service {
                         continue;
                     }
 
-                    String guid = vertex.getProperty(GUID_PROPERTY_KEY, String.class);
-
-                    if (!producedDeletionCandidates.contains(guid)) {
-                        Set<String> instanceVertex = new HashSet<>();
-                        instanceVertex.add(guid);
-
-                        Set<AtlasVertex> deletionCandidates = entityStore.accumulateDeletionCandidates(instanceVertex);
-
-                        for (AtlasVertex deletionCandidate : deletionCandidates) {
-                            String deletionCandidateGuid = deletionCandidate.getProperty(GUID_PROPERTY_KEY, String.class);
-                            if (!producedDeletionCandidates.contains(deletionCandidateGuid)) {
-                                producedDeletionCandidates.add(deletionCandidateGuid);
-                                wiq.checkProduce(deletionCandidate);
-                            }
-                        }
+                    String guid = AtlasGraphUtilsV2.getIdFromVertex(vertex);
+                    if (guid != null) {
+                        originallyRequestedGuids.add(guid);
                     }
                 }
 
-                wiq.shutdown();
-
-                // collecting all the results
-                Queue results = wiq.getResults();
-
-                LOG.info("==> Purged {} !", results.size());
-
-                while (!results.isEmpty()) {
-                    AtlasEntityHeader entityHeader = (AtlasEntityHeader) results.poll();
-                    if (entityHeader == null) {
-                        continue;
-                    }
-                    entityMutationResponse.addEntity(PURGE, entityHeader);
+                // Release the index-scan transaction before worker batches commit; an open read txn
+                // on this thread can block concurrent purge workers on graphindex write locks.
+                PurgeBatchOrchestrator.clearPurgeCandidateExpansionState();
+                try {
+                    atlasGraph.rollback();
+                } catch (Exception rollbackEx) {
+                    LOG.debug("purgeEntities: rollback after index scan ignored", rollbackEx);
                 }
+
+                List<FailedEntity> failedEntities = new ArrayList<>();
+                entityMutationResponse = entityStore.executePurgeWithWorkers(originallyRequestedGuids,
+                        originallyRequestedGuids, failedEntities, AuditOperation.AUTO_PURGE);
+
+                int resultCount = (entityMutationResponse.getPurgedEntities() != null ? entityMutationResponse.getPurgedEntities().size() : 0) +
+                        (entityMutationResponse.getFailedEntities() != null ? entityMutationResponse.getFailedEntities().size() : 0);
+
+                LOG.info("purgeEntities: completed resultCount={}, summary={}", resultCount,
+                        entityMutationResponse.getSummary());
             } catch (Exception ex) {
-                LOG.error("purge: failed!", ex);
-            } finally {
-                LOG.info("purge: Done!");
+                LOG.error("purgeEntities: failed", ex);
+                PurgeBatchOrchestrator.resetPurgeContext();
+                PurgeExecutionStats stats = new PurgeExecutionStats(originallyRequestedGuids,
+                        originallyRequestedGuids.size());
+                stats.markExecutionFailed();
+                PurgeUtils.attachPurgeSummary(entityMutationResponse, stats);
             }
         } finally {
             AtlasPerfTracer.log(perf);
         }
 
-        LOG.info("<== PurgeService.purgeEntities()");
+        LOG.info("purgeEntities: finished summary={}", entityMutationResponse.getSummary());
 
         return entityMutationResponse;
     }
@@ -318,7 +306,7 @@ public class PurgeService implements Service {
 
         @Override
         protected void processItem(AtlasVertex vertex) {
-            String guid =  vertex.getProperty(GUID_PROPERTY_KEY, String.class);
+            String guid = AtlasGraphUtilsV2.getIdFromVertex(vertex);
             LOG.info("==> processing the entity {}", guid);
 
             try {
@@ -353,15 +341,10 @@ public class PurgeService implements Service {
             List<AtlasEntityHeader> results = Collections.emptyList();
 
             try {
-                if (isPurgeEnabled) {
-                    // purging not by directly
-                    res = entityStore.purgeEntitiesInBatch(batch);
-                } else {
-                    List<String> batchList = new ArrayList<>(batch);
-                    res = entityStore.deleteByIds(batchList);
-                }
+                List<String> batchList = new ArrayList<>(batch);
+                res = entityStore.deleteByIds(batchList);
 
-                results = isPurgeEnabled ? res.getPurgedEntities() : res.getDeletedEntities();
+                results = res.getDeletedEntities();
 
                 if (CollectionUtils.isEmpty(results)) {
                     return;
@@ -403,7 +386,7 @@ public class PurgeService implements Service {
 
     static class WorkItemsQualifier extends WorkItemManager<AtlasVertex, EntityQualifier> {
         public WorkItemsQualifier(WorkItemBuilder builder, int batchSize, int numWorkers, boolean isPurgeEnabled) {
-            super(builder, isPurgeEnabled ? PURGE_WORKERS_NAME : CLEANUP_WORKERS_NAME, batchSize, numWorkers, true);
+            super(builder, isPurgeEnabled ? PurgeBatchOrchestrator.PURGE_WORKERS_NAME : CLEANUP_WORKERS_NAME, batchSize, numWorkers, true);
         }
 
         @Override
@@ -507,25 +490,11 @@ public class PurgeService implements Service {
         return DEFAULT_PURGE_BATCH_SIZE;
     }
 
-    private int getPurgeWorkersCount() {
-        if (atlasProperties != null) {
-            return atlasProperties.getInt(PURGE_WORKERS_COUNT, DEFAULT_PURGE_WORKERS_COUNT);
-        }
-        return DEFAULT_PURGE_WORKERS_COUNT;
-    }
-
     private int getCleanUpWorkersCount() {
         if (atlasProperties != null) {
             return atlasProperties.getInt(CLEANUP_WORKERS_COUNT, DEFAULT_CLEANUP_WORKERS_COUNT);
         }
         return DEFAULT_CLEANUP_WORKERS_COUNT;
-    }
-
-    private int getPurgeWorkerBatchSize() {
-        if (atlasProperties != null) {
-            return atlasProperties.getInt(PURGE_WORKER_BATCH_SIZE, DEFAULT_PURGE_WORKER_BATCH_SIZE);
-        }
-        return DEFAULT_PURGE_WORKER_BATCH_SIZE;
     }
 
     private int getCleanupWorkerBatchSize() {

--- a/repository/src/test/java/org/apache/atlas/repository/audit/AdminPurgeTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/audit/AdminPurgeTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.atlas.repository.audit;
 
+import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.TestModules;
 import org.apache.atlas.TestUtilsV2;
@@ -26,17 +27,17 @@ import org.apache.atlas.model.audit.AuditSearchParameters;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.FailedEntity;
 import org.apache.atlas.model.typedef.AtlasTypesDef;
 import org.apache.atlas.repository.AtlasTestBase;
 import org.apache.atlas.repository.graph.AtlasGraphProvider;
+import org.apache.atlas.repository.purge.PurgeUtils;
 import org.apache.atlas.repository.store.bootstrap.AtlasTypeDefStoreInitializer;
 import org.apache.atlas.repository.store.graph.v2.AtlasEntityStoreV2;
 import org.apache.atlas.repository.store.graph.v2.AtlasEntityStream;
 import org.apache.atlas.store.AtlasTypeDefStore;
 import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.TestResourceFileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -47,21 +48,20 @@ import org.testng.annotations.Test;
 import javax.inject.Inject;
 
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 @Guice(modules = TestModules.TestOnlyModule.class)
 public class AdminPurgeTest extends AtlasTestBase {
-    private static final Logger LOG = LoggerFactory.getLogger(AdminPurgeTest.class);
-
     private static final String CLIENT_HOST                  = "127.0.0.0";
     private static final String DEFAULT_USER                 = "Admin";
     private static final String AUDIT_PARAMETER_RESOURCE_DIR = "auditSearchParameters";
@@ -119,53 +119,70 @@ public class AdminPurgeTest extends AtlasTestBase {
         assertNotNull(emr.getCreatedEntities());
         assertFalse(emr.getCreatedEntities().isEmpty());
 
-        List<String> guids = emr.getCreatedEntities().stream().map(AtlasEntityHeader::getGuid).collect(Collectors.toList());
+        List<String> guids = emr.getCreatedEntities().stream()
+                .map(AtlasEntityHeader::getGuid)
+                .collect(Collectors.toList());
 
-        EntityMutationResponse response = entityStore.deleteByIds(guids);
+        EntityMutationResponse deleteResponse = entityStore.deleteByIds(guids);
 
         pauseForIndexCreation();
 
-        List<AtlasEntityHeader> responseDeletedEntities = response.getDeletedEntities();
+        assertSortedGuidsMatch(emr.getCreatedEntities(), deleteResponse.getDeletedEntities(), "deleteByIds");
 
-        assertNotNull(responseDeletedEntities);
-
-        responseDeletedEntities.sort(Comparator.comparing(AtlasEntityHeader::getGuid));
-
-        List<AtlasEntityHeader> toBeDeletedEntities = emr.getCreatedEntities();
-
-        toBeDeletedEntities.sort(Comparator.comparing(AtlasEntityHeader::getGuid));
-
-        assertEquals(responseDeletedEntities.size(), emr.getCreatedEntities().size());
-
-        for (int index = 0; index < responseDeletedEntities.size(); index++) {
-            assertEquals(responseDeletedEntities.get(index).getGuid(), emr.getCreatedEntities().get(index).getGuid());
-        }
+        ApplicationProperties.get().setProperty("atlas.purge.workers.count", "1");
 
         Date startTimestamp = new Date();
-
-        response = entityStore.purgeByIds(new HashSet<>(guids));
+        EntityMutationResponse purgeResponse = entityStore.purgeByIds(new HashSet<>(guids));
 
         pauseForIndexCreation();
 
-        List<AtlasEntityHeader> responsePurgedEntities = response.getPurgedEntities();
+        assertPurgeSucceededForRequestedGuids(guids, purgeResponse);
 
-        responsePurgedEntities.sort(Comparator.comparing(AtlasEntityHeader::getGuid));
+        auditService.add(DEFAULT_USER, AtlasAuditEntry.AuditOperation.PURGE, CLIENT_HOST, startTimestamp, new Date(),
+                guids.toString(), purgeResponse.getPurgedEntitiesIds(), purgeResponse.getPurgedEntities().size());
 
-        assertEquals(responsePurgedEntities.size(), responseDeletedEntities.size());
+        assertAuditEntry(auditService, createAuditParameter("audit-search-parameter-without-filter"));
+        assertAuditEntry(auditService, createAuditParameter("audit-search-parameter-purge"));
+    }
 
-        for (int index = 0; index < responsePurgedEntities.size(); index++) {
-            assertEquals(responsePurgedEntities.get(index).getGuid(), responseDeletedEntities.get(index).getGuid());
+    private void assertSortedGuidsMatch(List<AtlasEntityHeader> expected, List<AtlasEntityHeader> actual, String operation) {
+        assertNotNull(actual, operation + " returned null entities");
+        assertEquals(toSortedGuidList(actual), toSortedGuidList(expected), operation + " guid mismatch");
+    }
+
+    private void assertPurgeSucceededForRequestedGuids(List<String> requestedGuids, EntityMutationResponse response) {
+        assertNotNull(response.getPurgedEntities(), "purgeByIds returned no purged entities");
+        assertNotNull(response.getPurgeSummary(), "purgeByIds returned no summary");
+
+        Set<String> purgedGuids = response.getPurgedEntities().stream()
+                .map(AtlasEntityHeader::getGuid)
+                .collect(Collectors.toSet());
+
+        Set<String> skippedGuids = new HashSet<>();
+        if (response.getFailedEntities() != null) {
+            for (FailedEntity failedEntity : response.getFailedEntities()) {
+                if (PurgeUtils.isSkippablePurgeFailureCode(failedEntity.getErrorCode())) {
+                    skippedGuids.add(failedEntity.getGuid());
+                }
+            }
         }
 
-        auditService.add(DEFAULT_USER, AtlasAuditEntry.AuditOperation.PURGE, CLIENT_HOST, startTimestamp, new Date(), guids.toString(), response.getPurgedEntitiesIds(), response.getPurgedEntities().size());
+        for (String guid : requestedGuids) {
+            assertTrue(purgedGuids.contains(guid) || skippedGuids.contains(guid),
+                    "Expected requested guid to be purged or skipped as already removed: " + guid);
+        }
 
-        AuditSearchParameters auditParameterNull = createAuditParameter("audit-search-parameter-without-filter");
+        assertEquals(response.getPurgeSummary().getRequestedCount(), requestedGuids.size());
+        assertEquals(response.getPurgeSummary().getPurgedCount() + response.getPurgeSummary().getSkippedRequestedCount(),
+                requestedGuids.size());
+        assertEquals(response.getPurgeSummary().getFailedCount(), 0);
+    }
 
-        assertAuditEntry(auditService, auditParameterNull);
-
-        AuditSearchParameters auditSearchParameters = createAuditParameter("audit-search-parameter-purge");
-
-        assertAuditEntry(auditService, auditSearchParameters);
+    private static List<String> toSortedGuidList(List<AtlasEntityHeader> headers) {
+        return headers.stream()
+                .map(AtlasEntityHeader::getGuid)
+                .sorted()
+                .collect(Collectors.toList());
     }
 
     private AuditSearchParameters createAuditParameter(String fileName) {

--- a/repository/src/test/java/org/apache/atlas/repository/purge/PurgeTestUtils.java
+++ b/repository/src/test/java/org/apache/atlas/repository/purge/PurgeTestUtils.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.repository.purge;
+
+import org.apache.atlas.model.instance.EntityMutationResponse;
+
+import java.util.Set;
+
+/**
+ * Test helpers for purge summary and stats assertions.
+ */
+public final class PurgeTestUtils {
+    private PurgeTestUtils() {
+    }
+
+    /**
+     * Rebuilds summary by scanning a completed response. For tests only.
+     */
+    public static void attachPurgeSummaryFromResponse(EntityMutationResponse response,
+                                                      Set<String> originallyRequestedGuids,
+                                                      long validGuidCount) {
+        PurgeExecutionStats stats = PurgeExecutionStats.fromResponse(response, originallyRequestedGuids, validGuidCount);
+        PurgeUtils.attachPurgeSummary(response, stats);
+    }
+}

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1Test.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1Test.java
@@ -17,7 +17,9 @@
  */
 package org.apache.atlas.repository.store.graph.v1;
 
+import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.DeleteType;
+import org.apache.atlas.GraphTransactionInterceptor;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.TestModules;
 import org.apache.atlas.TestUtilsV2;
@@ -48,6 +50,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -132,7 +135,7 @@ public class DeleteHandlerV1Test extends AtlasTestBase {
         assertDoesNotThrow(() -> handler.isRelationshipEdge(managerEdge));
     }
 
-// ---------------------------------------------------------------
+    // ---------------------------------------------------------------
     // deleteTraitsAndVertices / deleteAllClassifications resilience
     // ---------------------------------------------------------------
 
@@ -155,12 +158,88 @@ public class DeleteHandlerV1Test extends AtlasTestBase {
 
         softDeleteGuids(Arrays.asList(mgrGuid, subGuid));
 
-        EntityMutationResponse purgeResp = purgeGuids(new HashSet<>(Arrays.asList(mgrGuid, subGuid)));
+        initRequestContext();
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+
+        EntityMutationResponse purgeResp = entityStore.purgeEntitiesInBatch(new HashSet<>(Arrays.asList(mgrGuid, subGuid)));
         assertEquals(purgeResp.getPurgedEntities().size(), 2);
         assertNull(AtlasGraphUtilsV2.findByGuid(mgrGuid), "Entity should be removed from graph after purge");
 
         DeleteHandlerV1 handler = deleteDelegate.getHandler();
         handler.deleteTraitsAndVertices(Collections.singleton(mgrVertex));
+    }
+
+    /**
+     * {@link DeleteHandlerV1#deleteTraitsAndVertices} must return only vertices actually deleted.
+     * Stale handles for already-removed entities are skipped and excluded from the return value.
+     */
+    @Test
+    public void testDeleteTraitsAndVerticesReturnsOnlyDeletedVertices() throws Exception {
+        EntityMutationResponse createResp = createManagerWithSubordinates("delete_return", 1);
+        String                 mgrGuid    = getGuidForName(createResp, "delete_return_mgr");
+        String                 subGuid    = getGuidForName(createResp, "delete_return_sub1");
+
+        assertNotNull(mgrGuid);
+        assertNotNull(subGuid);
+
+        AtlasVertex mgrVertex = AtlasGraphUtilsV2.findByGuid(mgrGuid);
+        AtlasVertex subVertex = AtlasGraphUtilsV2.findByGuid(subGuid);
+        assertNotNull(mgrVertex);
+        assertNotNull(subVertex);
+
+        softDeleteGuids(Arrays.asList(mgrGuid, subGuid));
+
+        initRequestContext();
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+
+        entityStore.purgeEntitiesInBatch(Collections.singleton(subGuid));
+
+        DeleteHandlerV1 handler = deleteDelegate.getHandler();
+        Collection<AtlasVertex> deletedVertices = handler.deleteTraitsAndVertices(
+                Arrays.asList(mgrVertex, subVertex));
+
+        assertEquals(deletedVertices.size(), 1);
+        assertTrue(deletedVertices.contains(mgrVertex));
+        assertNull(findByGuidFresh(subGuid));
+        assertNull(findByGuidFresh(mgrGuid));
+    }
+
+    /**
+     * When a batch contains an already-purged GUID, it must be recorded as a skippable failure
+     * rather than reported in {@code purgedEntities}.
+     */
+    @Test
+    public void testPurgeEntitiesInBatchDoesNotReportUnconfirmedDeletes() throws Exception {
+        EntityMutationResponse createResp = createManagerWithSubordinates("unconfirmed", 1);
+        String                 mgrGuid    = getGuidForName(createResp, "unconfirmed_mgr");
+        String                 subGuid    = getGuidForName(createResp, "unconfirmed_sub1");
+
+        assertNotNull(mgrGuid);
+        assertNotNull(subGuid);
+
+        softDeleteGuids(Arrays.asList(mgrGuid, subGuid));
+
+        initRequestContext();
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+
+        EntityMutationResponse subPurge = entityStore.purgeEntitiesInBatch(Collections.singleton(subGuid));
+        assertEntityPurged(subGuid, subPurge);
+
+        EntityMutationResponse batchResp = entityStore.purgeEntitiesInBatch(
+                new LinkedHashSet<>(Arrays.asList(mgrGuid, subGuid)));
+
+        assertNotNull(batchResp.getPurgedEntities());
+        assertEquals(batchResp.getPurgedEntities().size(), 1);
+        assertEquals(batchResp.getPurgedEntities().get(0).getGuid(), mgrGuid);
+        assertNotNull(batchResp.getFailedEntities());
+        assertEquals(batchResp.getFailedEntities().size(), 1);
+        assertEquals(batchResp.getFailedEntities().get(0).getGuid(), subGuid);
+        assertEquals(batchResp.getFailedEntities().get(0).getErrorCode(),
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode());
+        assertNull(findByGuidFresh(mgrGuid));
     }
 
     // ---------------------------------------------------------------
@@ -208,10 +287,44 @@ public class DeleteHandlerV1Test extends AtlasTestBase {
 
         softDeleteGuids(guidsToPurge);
 
-        EntityMutationResponse purgeResp = purgeGuids(guidsToPurge);
+        initRequestContext();
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+
+        // Single-transaction batch purge (not WIM workers) — exercises DeleteHandlerV1 edge
+        // iteration when manager and subordinates are removed in the same batch.
+        EntityMutationResponse purgeResp = entityStore.purgeEntitiesInBatch(guidsToPurge);
 
         assertEquals(purgeResp.getPurgedEntities().size(), guidsToPurge.size());
         assertEntitiesPurged(guidsToPurge, purgeResp);
+    }
+
+    /**
+     * Purge subordinates in a batch without the manager. The manager is soft-deleted but not
+     * included in the purge batch (as can happen when WIM workers split related entities).
+     * Inverse reference updates on the deleted manager must be skipped.
+     */
+    @Test
+    public void testPurgeSubordinatesWithoutManagerInSameBatch() throws Exception {
+        EntityMutationResponse createResp = createManagerWithSubordinates("sub_only_purge", 2);
+        String                 mgrGuid    = getGuidForName(createResp, "sub_only_purge_mgr");
+        String                 sub1Guid   = getGuidForName(createResp, "sub_only_purge_sub1");
+        String                 sub2Guid   = getGuidForName(createResp, "sub_only_purge_sub2");
+
+        Set<String> allGuids = new HashSet<>(Arrays.asList(mgrGuid, sub1Guid, sub2Guid));
+        softDeleteGuids(allGuids);
+
+        initRequestContext();
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+
+        EntityMutationResponse purgeResp = entityStore.purgeEntitiesInBatch(new HashSet<>(Arrays.asList(sub1Guid, sub2Guid)));
+
+        assertEquals(purgeResp.getPurgedEntities().size(), 2);
+        assertEntitiesPurged(new HashSet<>(Arrays.asList(sub1Guid, sub2Guid)), purgeResp);
+        assertNotNull(AtlasGraphUtilsV2.findByGuid(mgrGuid), "Manager should remain until explicitly purged");
+
+        assertEntityPurged(mgrGuid, purgeGuids(Collections.singleton(mgrGuid)));
     }
 
     // ---------------------------------------------------------------
@@ -290,12 +403,18 @@ public class DeleteHandlerV1Test extends AtlasTestBase {
         }
     }
 
+    private AtlasVertex findByGuidFresh(String guid) {
+        // WIM purge runs on worker threads; main-thread guidVertexCache can retain stale handles.
+        GraphTransactionInterceptor.clearCache();
+        return AtlasGraphUtilsV2.findByGuid(guid);
+    }
+
     private void assertEntityPurged(String guid, EntityMutationResponse purgeResp) {
         assertNotNull(purgeResp);
         assertNotNull(purgeResp.getPurgedEntities());
         assertTrue(purgeResp.getPurgedEntities().stream().anyMatch(h -> guid.equals(h.getGuid())),
                 "Expected guid " + guid + " in purged entities");
-        assertNull(AtlasGraphUtilsV2.findByGuid(guid), "Entity should be removed from graph after purge");
+        assertNull(findByGuidFresh(guid), "Entity should be removed from graph after purge");
     }
 
     private void assertEntitiesPurged(Set<String> expectedGuids, EntityMutationResponse purgeResp) {
@@ -309,7 +428,7 @@ public class DeleteHandlerV1Test extends AtlasTestBase {
         assertEquals(purgedGuids, expectedGuids);
 
         for (String guid : expectedGuids) {
-            assertNull(AtlasGraphUtilsV2.findByGuid(guid), "Entity " + guid + " should be removed from graph after purge");
+            assertNull(findByGuidFresh(guid), "Entity " + guid + " should be removed from graph after purge");
         }
     }
 }

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2Test.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityStoreV2Test.java
@@ -20,6 +20,7 @@ package org.apache.atlas.repository.store.graph.v2;
 import com.google.common.collect.ImmutableSet;
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.DeleteType;
 import org.apache.atlas.GraphTransactionInterceptor;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.TestModules;
@@ -41,12 +42,17 @@ import org.apache.atlas.model.instance.EntityMutations.EntityOperation;
 import org.apache.atlas.model.typedef.AtlasClassificationDef;
 import org.apache.atlas.model.typedef.AtlasEntityDef;
 import org.apache.atlas.model.typedef.AtlasTypesDef;
+import org.apache.atlas.repository.Constants;
+import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.services.PurgeBatchExecutor;
+import org.apache.atlas.services.PurgeBatchOrchestrator;
 import org.apache.atlas.type.AtlasEntityType;
 import org.apache.atlas.type.AtlasTypeUtil;
 import org.apache.atlas.util.FileUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.janusgraph.diskstorage.locking.PermanentLockingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
@@ -65,9 +71,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.atlas.AtlasConfiguration.STORE_DIFFERENTIAL_AUDITS;
 import static org.apache.atlas.AtlasErrorCode.INVALID_CUSTOM_ATTRIBUTE_KEY_CHARACTERS;
@@ -81,7 +92,11 @@ import static org.apache.atlas.TestUtilsV2.NAME;
 import static org.apache.atlas.TestUtilsV2.TABLE_TYPE;
 import static org.apache.atlas.TestUtilsV2.getFile;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -105,6 +120,9 @@ public class AtlasEntityStoreV2Test extends AtlasEntityTestBase {
 
     @Inject
     private EntityGraphMapper graphMapper;
+
+    @Inject
+    private AtlasEntityStoreV2 guiceEntityStore;
 
     @Inject
     private String dbEntityGuid;
@@ -141,12 +159,22 @@ public class AtlasEntityStoreV2Test extends AtlasEntityTestBase {
 
     @BeforeTest
     public void init() throws Exception {
-        entityStore = new AtlasEntityStoreV2(graph, deleteDelegate, typeRegistry, mockChangeNotifier, graphMapper);
+        AtlasEntityStoreV2 entityStoreV2 = new AtlasEntityStoreV2(graph, deleteDelegate, typeRegistry, mockChangeNotifier, graphMapper);
+        entityStoreV2.setSelf(entityStoreV2);
+        entityStore = entityStoreV2;
 
         RequestContext.clear();
         RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
 
         LOG.debug("RequestContext: activeCount={}, earliestActiveRequestTime={}", RequestContext.getActiveRequestsCount(), RequestContext.earliestActiveRequestTime());
+    }
+
+    private void initPurgeWorkerTest() throws Exception {
+        init();
+        //TestLoadModelUtils.loadBaseModel(typeDefStore, typeRegistry);
+        ApplicationProperties.get().setProperty("atlas.purge.workers.count", "1");
+        RequestContext.clear();
+        RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
     }
 
     @Test
@@ -1984,6 +2012,37 @@ public class AtlasEntityStoreV2Test extends AtlasEntityTestBase {
     }
 
     @Test
+    public void testPurgeByIdsExceedsMaxRequestSize() throws Exception {
+        init();
+
+        int maxSize = 5;
+        ApplicationProperties.get().setProperty("atlas.purge.api.max.request.size", maxSize);
+
+        Set<String> guids = new HashSet<>();
+        for (int i = 0; i < maxSize + 1; i++) {
+            guids.add(String.format("11111111-1111-1111-1111-%012d", i));
+        }
+
+        try {
+            entityStore.purgeByIds(guids);
+            fail("Expected AtlasBaseException for request size exceeding limit");
+        } catch (AtlasBaseException e) {
+            assertEquals(e.getAtlasErrorCode(), AtlasErrorCode.PURGE_REQUEST_SIZE_EXCEEDS_LIMIT);
+            assertTrue(e.getMessage().contains(String.valueOf(maxSize + 1)));
+            assertTrue(e.getMessage().contains(String.valueOf(maxSize)));
+        }
+
+        Set<String> atLimitGuids = new HashSet<>();
+        for (int i = 0; i < maxSize; i++) {
+            atLimitGuids.add(String.format("22222222-2222-2222-2222-%012d", i));
+        }
+
+        EntityMutationResponse response = entityStore.purgeByIds(atLimitGuids);
+        assertNotNull(response);
+        assertEquals(response.getFailedEntities().size(), maxSize);
+    }
+
+    @Test
     public void testAddClassificationsWithInvalidParameters() throws Exception {
         init();
 
@@ -2470,11 +2529,564 @@ public class AtlasEntityStoreV2Test extends AtlasEntityTestBase {
     public void testPurgeByIdsWithNonExistentEntities() throws Exception {
         init();
 
-        // Test purging non-existent entities (should not throw exception)
-        Set<String> guids = new HashSet<>(Arrays.asList("non-existent-guid-1", "non-existent-guid-2"));
+        Set<String> guids = new HashSet<>(Arrays.asList("11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222"));
         EntityMutationResponse response = entityStore.purgeByIds(guids);
         assertNotNull(response);
         assertTrue(response.getPurgedEntities() == null || response.getPurgedEntities().size() == 0);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 2);
+        assertEquals(response.getFailedEntities().get(0).getErrorCode(), AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode());
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 2);
+        assertEquals(response.getPurgeSummary().getPurgedCount(), 0);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 0);
+        assertEquals(response.getPurgeSummary().getSkippedCount(), 2);
+    }
+
+    @Test
+    public void testPurgeByIdsInvalidUuid() throws Exception {
+        init();
+
+        Set<String> guids = new HashSet<>(Arrays.asList("invalid-uuid-format"));
+        EntityMutationResponse response = entityStore.purgeByIds(guids);
+        assertNotNull(response);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+        assertEquals(response.getFailedEntities().get(0).getErrorCode(), AtlasErrorCode.INVALID_GUID.getErrorCode());
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 1);
+        assertEquals(response.getPurgeSummary().getPurgedCount(), 0);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 1);
+        assertEquals(response.getPurgeSummary().getSkippedCount(), 0);
+    }
+
+    @Test
+    public void testPurgeByIdsNotInDeletedState() throws Exception {
+        init();
+        AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
+        EntityMutationResponse createResponse = entityStore.createOrUpdate(new AtlasEntityStream(dbEntity), false);
+        String guid = createResponse.getCreatedEntities().get(0).getGuid();
+
+        Set<String> guids = new HashSet<>(Arrays.asList(guid));
+        EntityMutationResponse response = entityStore.purgeByIds(guids);
+        assertNotNull(response);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+        assertEquals(response.getFailedEntities().get(0).getErrorCode(), AtlasErrorCode.NOT_IN_DELETED_STATE.getErrorCode());
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 1);
+        assertEquals(response.getPurgeSummary().getPurgedCount(), 0);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 0);
+        assertEquals(response.getPurgeSummary().getSkippedCount(), 1);
+    }
+
+    @Test
+    public void testPurgeByIdsNullTypeName() throws Exception {
+        init();
+
+        AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
+        EntityMutationResponse createResponse = entityStore.createOrUpdate(new AtlasEntityStream(dbEntity), false);
+        String guid = createResponse.getCreatedEntities().get(0).getGuid();
+
+        entityStore.deleteById(guid);
+
+        GraphTransactionInterceptor.clearCache();
+        AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(graph, guid);
+        assertNotNull(vertex);
+        vertex.removeProperty(Constants.ENTITY_TYPE_PROPERTY_KEY);
+        graph.commit();
+
+        Set<String> guids = new HashSet<>(Arrays.asList(guid));
+        EntityMutationResponse response = entityStore.purgeByIds(guids);
+        assertNotNull(response);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+        assertEquals(response.getFailedEntities().get(0).getErrorCode(), AtlasErrorCode.TYPE_NAME_NOT_FOUND.getErrorCode());
+        assertTrue(response.getPurgedEntities() == null || response.getPurgedEntities().isEmpty());
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 1);
+        assertEquals(response.getPurgeSummary().getPurgedCount(), 0);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 1);
+        assertEquals(response.getPurgeSummary().getSkippedCount(), 0);
+    }
+
+    @Test
+    public void testPurgeByIdsSuccess() throws Exception {
+        initPurgeWorkerTest();
+
+        AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
+        EntityMutationResponse createResponse = guiceEntityStore.createOrUpdate(new AtlasEntityStream(dbEntity), false);
+        String guid = createResponse.getCreatedEntities().get(0).getGuid();
+
+        guiceEntityStore.deleteById(guid);
+
+        Set<String> guids = new HashSet<>(Arrays.asList(guid));
+        EntityMutationResponse response = guiceEntityStore.purgeByIds(guids);
+        assertNotNull(response);
+        assertNotNull(response.getPurgedEntities());
+        assertEquals(response.getPurgedEntities().size(), 1);
+        assertEquals(response.getPurgedEntities().get(0).getGuid(), guid);
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 1);
+        assertEquals(response.getPurgeSummary().getPurgedCount(), 1);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 0);
+        assertEquals(response.getPurgeSummary().getSkippedCount(), 0);
+    }
+
+    @Test
+    public void testPurgeByIdsWithExpandedDependencies() throws Exception {
+        initPurgeWorkerTest();
+
+        // Create a composite entity (Department with Employees) with a unique department name
+        AtlasEntity.AtlasEntitiesWithExtInfo deptPayload = TestUtilsV2.createDeptEg2();
+        String uniqueDeptName = "purge_deps_" + System.nanoTime();
+        for (AtlasEntity entity : deptPayload.getEntities()) {
+            if (TestUtilsV2.DEPARTMENT_TYPE.equals(entity.getTypeName())) {
+                entity.setAttribute("name", uniqueDeptName);
+                break;
+            }
+        }
+
+        EntityMutationResponse createResponse = guiceEntityStore.createOrUpdate(new AtlasEntityStream(deptPayload), false);
+        assertNotNull(createResponse);
+
+        AtlasEntityHeader deptHeader = createResponse.getFirstCreatedEntityByTypeName(TestUtilsV2.DEPARTMENT_TYPE);
+        assertNotNull(deptHeader, "Department entity should be created");
+        String deptGuid = deptHeader.getGuid();
+
+        // 2. Delete the Department entity. This should soft-delete the department and its dependent employees.
+        guiceEntityStore.deleteById(deptGuid);
+
+        // 3. Purge the Department entity
+        Set<String> guids = new HashSet<>(Arrays.asList(deptGuid));
+        EntityMutationResponse response = guiceEntityStore.purgeByIds(guids);
+
+        // 4. Assert that the purge was successful and dependencies were properly accounted for
+        assertNotNull(response);
+        assertNotNull(response.getPurgedEntities());
+
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 1);
+        assertEquals(response.getPurgeSummary().getPurgedCount(), 1);
+        assertTrue(response.getPurgeSummary().getPurgedDependenciesCount() > 0
+                        || response.getPurgeSummary().getSkippedCount() > 0,
+                "Expected expanded dependencies to be purged or skipped as already removed during the same request");
+        assertEquals(response.getPurgeSummary().getFailedCount(), 0);
+    }
+
+    /**
+     * Reproduces stale JanusGraph vertex handles on the coordinator thread when expansion runs
+     * without a per-root transaction boundary and workers delete vertices in parallel.
+     */
+    @Test
+    public void testExpansionWithoutPerRootTxnBoundaryFailsWithStaleHandles() throws Exception {
+        init();
+
+        String dept1Guid = createSoftDeletedDepartment("stale_txn_dept1");
+
+        initPurgeRequestContext();
+
+        try {
+            // Direct store instance — no GraphTransaction interceptor (pre-fix coordinator path).
+            Set<String> firstBatch = entityStore.accumulateDeletionCandidates(
+                    Collections.singleton(dept1Guid));
+            assertFalse(firstBatch.isEmpty(), "Expected deletion candidates from first expansion");
+
+            // Release Berkeley JE read locks from the coordinator txn, but keep guidVertexCache entries
+            // that the interceptor would have cleared after a per-root @GraphTransaction commit.
+            graph.rollback();
+
+            runPurgeBatchInWorker(firstBatch);
+
+            try {
+                // Re-expand a purged root: main-thread guidVertexCache still holds stale handles.
+                entityStore.accumulateDeletionCandidates(Collections.singleton(dept1Guid));
+                fail("Expected stale coordinator-thread graph transaction to fail second expansion");
+            } catch (Exception e) {
+                assertTrue(hasIllegalStateInChain(e),
+                        "Expected IllegalStateException from stale graph handles, got: " + e);
+            }
+        } finally {
+            graph.rollback();
+            GraphTransactionInterceptor.clearCache();
+            RequestContext.clear();
+        }
+    }
+
+    /**
+     * Verifies {@code @GraphTransaction} on accumulateDeletionCandidates plus
+     * {@link PurgeBatchOrchestrator#clearPurgeCandidateExpansionState()} prevent stale-handle failures
+     * when workers delete the first expansion's vertices before the next root is expanded.
+     */
+    @Test
+    public void testPerRootGraphTransactionSurvivesParallelWorkerDeletes() throws Exception {
+        init();
+
+        String dept1Guid = createSoftDeletedDepartment("per_root_txn_dept1");
+        String dept2Guid = createSoftDeletedDepartment("per_root_txn_dept2");
+
+        initPurgeRequestContext();
+
+        try {
+            Set<String> firstBatch = guiceEntityStore.accumulateDeletionCandidates(
+                    Collections.singleton(dept1Guid));
+            assertFalse(firstBatch.isEmpty());
+
+            runPurgeBatchInWorker(firstBatch);
+            PurgeBatchOrchestrator.clearPurgeCandidateExpansionState();
+
+            Set<String> secondBatch = guiceEntityStore.accumulateDeletionCandidates(
+                    Collections.singleton(dept2Guid));
+            assertFalse(secondBatch.isEmpty(), "Second expansion should succeed with per-root txn boundary");
+        } finally {
+            graph.rollback();
+            GraphTransactionInterceptor.clearCache();
+            RequestContext.clear();
+        }
+    }
+
+    /**
+     * Verifies {@link PurgeBatchExecutor} clears graph and RequestContext caches before retrying a
+     * batch after a lock conflict, so stale vertex handles from a rolled-back attempt do not break
+     * the next attempt.
+     */
+    @Test
+    public void testPurgeBatchRetryClearsStaleCachesAfterLockConflict() throws Exception {
+        initPurgeWorkerTest();
+
+        String guid = createSoftDeletedDepartment("retry_stale_dept");
+        Set<String> batch = Collections.singleton(guid);
+
+        initPurgeRequestContext();
+
+        try {
+            AtlasVertex vertex = AtlasGraphUtilsV2.findByGuid(graph, guid);
+            assertNotNull(vertex);
+            assertNotNull(GraphTransactionInterceptor.getVertexFromCache(guid),
+                    "Expected guidVertexCache entry before rollback");
+
+            graph.rollback();
+
+            AtlasEntityStoreV2 storeSpy = spy(guiceEntityStore);
+            PermanentLockingException ple = new PermanentLockingException("simulated lock conflict");
+            AtlasBaseException lockConflict = new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, ple);
+            doThrow(lockConflict)
+                    .doCallRealMethod()
+                    .when(storeSpy).purgeEntitiesInBatch(batch);
+
+            PurgeBatchExecutor executor = new PurgeBatchExecutor(storeSpy);
+            EntityMutationResponse response = executor.executeBatch(batch);
+
+            assertNotNull(response);
+            assertNotNull(response.getPurgedEntities());
+            assertEquals(response.getPurgedEntities().size(), 1);
+            assertEquals(response.getPurgedEntities().get(0).getGuid(), guid);
+            assertNull(AtlasGraphUtilsV2.findByGuid(graph, guid),
+                    "Entity should be purged after successful retry");
+            verify(storeSpy, times(2)).purgeEntitiesInBatch(batch);
+        } finally {
+            graph.rollback();
+            GraphTransactionInterceptor.clearCache();
+            RequestContext.clear();
+        }
+    }
+
+    @Test
+    public void testPurgeExpansionVsWorkerDeleteConcurrency() throws Exception {
+        init();
+
+        String dept1Guid = createSoftDeletedDepartment("conc_dept1");
+        String dept2Guid = createSoftDeletedDepartment("conc_dept2");
+
+        initPurgeRequestContext();
+
+        try {
+            Set<String> firstBatch = guiceEntityStore.accumulateDeletionCandidates(
+                    Collections.singleton(dept1Guid));
+            assertFalse(firstBatch.isEmpty());
+
+            CountDownLatch done = new CountDownLatch(1);
+            AtomicReference<Exception> workerError = new AtomicReference<>();
+            PurgeBatchExecutor purgeBatchExecutor = new PurgeBatchExecutor(guiceEntityStore);
+
+            Thread worker = new Thread(() -> {
+                try {
+                    RequestContext.clear();
+                    RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
+                    RequestContext.get().setDeleteType(DeleteType.HARD);
+                    RequestContext.get().setPurgeRequested(true);
+                    purgeBatchExecutor.executeBatch(firstBatch);
+                } catch (Exception e) {
+                    workerError.set(e);
+                } finally {
+                    done.countDown();
+                    RequestContext.clear();
+                }
+            }, "purge-race-worker");
+
+            worker.start();
+
+            Thread.sleep(100);
+
+            Set<String> secondBatch = guiceEntityStore.accumulateDeletionCandidates(
+                    Collections.singleton(dept2Guid));
+
+            assertTrue(done.await(60, TimeUnit.SECONDS), "Worker purge timed out");
+
+            if (workerError.get() != null) {
+                throw workerError.get();
+            }
+
+            assertFalse(secondBatch.isEmpty(), "Second expansion should succeed concurrently");
+
+            guiceEntityStore.purgeEntitiesInBatch(secondBatch);
+        } finally {
+            RequestContext.clear();
+            PurgeBatchOrchestrator.clearPurgeCandidateExpansionState();
+        }
+    }
+
+    @Test
+    public void testPurgeByIdsMultiRootExpansionAvoidsStaleGraphHandles() throws Exception {
+        initPurgeWorkerTest();
+        ApplicationProperties.get().setProperty("atlas.purge.worker.batch.size", "1");
+        ApplicationProperties.get().setProperty("atlas.purge.workers.count", "2");
+
+        String dept1Guid = createSoftDeletedDepartment("stale_handle_dept1");
+        String dept2Guid = createSoftDeletedDepartment("stale_handle_dept2");
+
+        Set<String> guids = new LinkedHashSet<>(Arrays.asList(dept1Guid, dept2Guid));
+        EntityMutationResponse response = guiceEntityStore.purgeByIds(guids);
+
+        assertNotNull(response);
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 2);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 0);
+        assertTrue(response.getPurgeSummary().getPurgedCount() >= 2,
+                "Both requested department roots should be purged");
+        assertTrue(response.getPurgeSummary().getPurgedDependenciesCount() > 0,
+                "Expanded employee dependencies should be purged");
+    }
+
+    @Test
+    public void testPurgeByIdsPartialPreScanAndPurge() throws Exception {
+        initPurgeWorkerTest();
+
+        AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
+        EntityMutationResponse createResponse = guiceEntityStore.createOrUpdate(new AtlasEntityStream(dbEntity), false);
+        String guid = createResponse.getCreatedEntities().get(0).getGuid();
+
+        guiceEntityStore.deleteById(guid);
+
+        Set<String> guids = new HashSet<>(Arrays.asList(
+                guid,
+                "22222222-2222-2222-2222-222222222222"));
+        EntityMutationResponse response = guiceEntityStore.purgeByIds(guids);
+        assertNotNull(response);
+        assertNotNull(response.getPurgedEntities());
+        assertEquals(response.getPurgedEntities().size(), 1);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 2);
+        assertEquals(response.getPurgeSummary().getPurgedCount(), 1);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 0);
+        assertEquals(response.getPurgeSummary().getSkippedCount(), 1);
+    }
+
+    @Test(expectedExceptions = AtlasBaseException.class, expectedExceptionsMessageRegExp = ".*exceeds maximum limit.*")
+    public void testPurgeByIdsExceedsSizeLimit() throws Exception {
+        init();
+        Set<String> guids = new HashSet<>();
+        for (int i = 0; i < 1001; i++) {
+            guids.add("11111111-1111-1111-1111-" + String.format("%012d", i));
+        }
+        entityStore.purgeByIds(guids);
+    }
+
+    @Test
+    public void testPurgeByIdsAtSizeLimit() throws Exception {
+        init();
+        Set<String> guids = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            guids.add("11111111-1111-1111-1111-" + String.format("%012d", i));
+        }
+
+        EntityMutationResponse response = entityStore.purgeByIds(guids);
+        assertNotNull(response);
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 1000);
+    }
+
+    @Test
+    public void testPurgeByIdsInvalidUuidMixedWithValid() throws Exception {
+        initPurgeWorkerTest();
+
+        AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
+        EntityMutationResponse createResponse = guiceEntityStore.createOrUpdate(new AtlasEntityStream(dbEntity), false);
+        String guid = createResponse.getCreatedEntities().get(0).getGuid();
+
+        guiceEntityStore.deleteById(guid);
+
+        Set<String> guids = new HashSet<>(Arrays.asList(guid, "not-a-valid-uuid"));
+        EntityMutationResponse response = guiceEntityStore.purgeByIds(guids);
+        assertNotNull(response);
+        assertNotNull(response.getPurgedEntities());
+        assertEquals(response.getPurgedEntities().size(), 1);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+        assertEquals(response.getFailedEntities().get(0).getErrorCode(), AtlasErrorCode.INVALID_GUID.getErrorCode());
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 2);
+        assertEquals(response.getPurgeSummary().getPurgedCount(), 1);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 1);
+        assertEquals(response.getPurgeSummary().getSkippedCount(), 0);
+    }
+
+    @Test
+    public void testPurgeEntitiesInBatchRejectsNonDeletedState() throws Exception {
+        init();
+
+        AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
+        EntityMutationResponse createResponse = entityStore.createOrUpdate(new AtlasEntityStream(dbEntity), false);
+        String guid = createResponse.getCreatedEntities().get(0).getGuid();
+
+        RequestContext.clear();
+        RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+
+        EntityMutationResponse response = entityStore.purgeEntitiesInBatch(Collections.singleton(guid));
+        assertNotNull(response);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+        assertEquals(response.getFailedEntities().get(0).getErrorCode(), AtlasErrorCode.NOT_IN_DELETED_STATE.getErrorCode());
+        assertTrue(response.getPurgedEntities() == null || response.getPurgedEntities().isEmpty());
+    }
+
+    @Test
+    public void testPurgeEntitiesInBatchSkipsAlreadyRemovedGuid() throws Exception {
+        init();
+
+        AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
+        EntityMutationResponse createResponse = entityStore.createOrUpdate(new AtlasEntityStream(dbEntity), false);
+        String guid = createResponse.getCreatedEntities().get(0).getGuid();
+
+        entityStore.deleteById(guid);
+
+        RequestContext.clear();
+        RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+
+        EntityMutationResponse firstPurge = entityStore.purgeEntitiesInBatch(Collections.singleton(guid));
+        assertNotNull(firstPurge);
+        assertNotNull(firstPurge.getPurgedEntities());
+        assertEquals(firstPurge.getPurgedEntities().size(), 1);
+        assertEquals(firstPurge.getPurgedEntities().get(0).getGuid(), guid);
+        assertNotNull(firstPurge.getPurgedEntities().get(0).getTypeName());
+
+        EntityMutationResponse secondPurge = entityStore.purgeEntitiesInBatch(Collections.singleton(guid));
+        assertNotNull(secondPurge);
+        assertNotNull(secondPurge.getFailedEntities());
+        assertEquals(secondPurge.getFailedEntities().size(), 1);
+        assertEquals(secondPurge.getFailedEntities().get(0).getGuid(), guid);
+        assertEquals(secondPurge.getFailedEntities().get(0).getErrorCode(),
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode());
+        assertTrue(secondPurge.getPurgedEntities() == null || secondPurge.getPurgedEntities().isEmpty());
+    }
+
+    /**
+     * Two threads purging the same soft-deleted GUID must not both report it as purged; the loser
+     * should record a skippable {@code INSTANCE_GUID_NOT_FOUND} failure.
+     */
+    @Test
+    public void testConcurrentPurgeSameGuidNotDoubleReported() throws Exception {
+        init();
+
+        AtlasEntity dbEntity = TestUtilsV2.createDBEntity();
+        EntityMutationResponse createResponse = guiceEntityStore.createOrUpdate(new AtlasEntityStream(dbEntity), false);
+        String guid = createResponse.getCreatedEntities().get(0).getGuid();
+
+        guiceEntityStore.deleteById(guid);
+        graph.rollback();
+
+        PurgeBatchExecutor executor = new PurgeBatchExecutor(guiceEntityStore);
+        CountDownLatch startGate = new CountDownLatch(1);
+        AtomicInteger purgedCount = new AtomicInteger(0);
+        AtomicInteger failedCount = new AtomicInteger(0);
+        AtomicReference<Exception> workerError = new AtomicReference<>();
+
+        Runnable concurrentPurge = () -> {
+            try {
+                startGate.await();
+                RequestContext.clear();
+                RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
+                RequestContext.get().setDeleteType(DeleteType.HARD);
+                RequestContext.get().setPurgeRequested(true);
+
+                EntityMutationResponse response = executor.executeBatch(Collections.singleton(guid));
+                if (response.getPurgedEntities() != null) {
+                    purgedCount.addAndGet(response.getPurgedEntities().size());
+                }
+                if (response.getFailedEntities() != null) {
+                    failedCount.addAndGet(response.getFailedEntities().size());
+                }
+            } catch (Exception e) {
+                workerError.set(e);
+            } finally {
+                RequestContext.clear();
+                GraphTransactionInterceptor.clearCache();
+            }
+        };
+
+        Thread worker1 = new Thread(concurrentPurge, "purge-race-1");
+        Thread worker2 = new Thread(concurrentPurge, "purge-race-2");
+        worker1.start();
+        worker2.start();
+        startGate.countDown();
+        worker1.join(TimeUnit.SECONDS.toMillis(60));
+        worker2.join(TimeUnit.SECONDS.toMillis(60));
+
+        if (workerError.get() != null) {
+            throw workerError.get();
+        }
+
+        assertEquals(purgedCount.get(), 1, "Exactly one concurrent purge should report success");
+        assertEquals(failedCount.get(), 1, "The other concurrent purge should record a skippable failure");
+        assertNull(AtlasGraphUtilsV2.findByGuid(guid), "Entity should be removed from graph after purge");
+    }
+
+    /**
+     * With multiple WIM workers, every expanded GUID must appear in either {@code purgedEntities}
+     * or {@code failedEntities}; none should fall through to reconciliation as {@code INTERNAL_ERROR}.
+     */
+    @Test
+    public void testPurgeByIdsTwoWorkersAllGuidsAccountedWithoutInternalError() throws Exception {
+        initPurgeWorkerTest();
+        ApplicationProperties.get().setProperty("atlas.purge.worker.batch.size", "1");
+        ApplicationProperties.get().setProperty("atlas.purge.workers.count", "2");
+
+        String deptGuid = createSoftDeletedDepartment("two_worker_acct_dept");
+
+        EntityMutationResponse response = guiceEntityStore.purgeByIds(Collections.singleton(deptGuid));
+
+        assertNotNull(response);
+        if (response.getFailedEntities() != null) {
+            assertFalse(response.getFailedEntities().stream()
+                            .anyMatch(f -> AtlasErrorCode.INTERNAL_ERROR.getErrorCode().equals(f.getErrorCode())),
+                    "No expanded guid should be marked as unprocessed INTERNAL_ERROR");
+        }
+        assertNotNull(response.getPurgeSummary());
+        assertEquals(response.getPurgeSummary().getRequestedCount(), 1);
+        assertEquals(response.getPurgeSummary().getFailedCount(), 0);
+        assertTrue(response.getPurgeSummary().getExpandedEntityCount() >= 1);
+        assertEquals(response.getPurgeSummary().getUnprocessedCount(), 0);
+        assertEquals(response.getPurgeSummary().getExpandedEntityCount(),
+                response.getPurgeSummary().getPurgedCount() + response.getPurgeSummary().getPurgedDependenciesCount()
+                        + response.getPurgeSummary().getFailedCount() + response.getPurgeSummary().getFailedDependenciesCount()
+                        + response.getPurgeSummary().getSkippedRequestedCount() + response.getPurgeSummary().getSkippedDependenciesCount());
+        assertNull(AtlasGraphUtilsV2.findByGuid(deptGuid), "Department should be purged from graph");
     }
 
     @Test
@@ -2790,5 +3402,72 @@ public class AtlasEntityStoreV2Test extends AtlasEntityTestBase {
         // Verify classification is deleted
         List<AtlasClassification> classifications = entityStore.getClassifications(guid);
         assertFalse(classifications.stream().anyMatch(c -> "TestClassificationForDeletion".equals(c.getTypeName())));
+    }
+
+    private String createSoftDeletedDepartment(String namePrefix) throws Exception {
+        AtlasEntity.AtlasEntitiesWithExtInfo deptPayload = TestUtilsV2.createDeptEg2();
+        String uniqueDeptName = namePrefix + "_" + System.nanoTime();
+
+        for (AtlasEntity entity : deptPayload.getEntities()) {
+            if (TestUtilsV2.DEPARTMENT_TYPE.equals(entity.getTypeName())) {
+                entity.setAttribute("name", uniqueDeptName);
+                break;
+            }
+        }
+
+        EntityMutationResponse createResponse = guiceEntityStore.createOrUpdate(new AtlasEntityStream(deptPayload), false);
+        AtlasEntityHeader deptHeader = createResponse.getFirstCreatedEntityByTypeName(TestUtilsV2.DEPARTMENT_TYPE);
+        assertNotNull(deptHeader, "Department entity should be created");
+
+        guiceEntityStore.deleteById(deptHeader.getGuid());
+        return deptHeader.getGuid();
+    }
+
+    private void initPurgeRequestContext() {
+        RequestContext.clear();
+        RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
+        RequestContext.get().setDeleteType(DeleteType.HARD);
+        RequestContext.get().setPurgeRequested(true);
+    }
+
+    private void runPurgeBatchInWorker(Set<String> guids) throws Exception {
+        // Ensure the coordinator thread is not holding a Berkeley JE read txn before worker writes.
+        graph.rollback();
+
+        CountDownLatch           done        = new CountDownLatch(1);
+        AtomicReference<Exception> workerError = new AtomicReference<>();
+        PurgeBatchExecutor       executor    = new PurgeBatchExecutor(guiceEntityStore);
+
+        Thread worker = new Thread(() -> {
+            try {
+                RequestContext.clear();
+                RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
+                RequestContext.get().setDeleteType(DeleteType.HARD);
+                RequestContext.get().setPurgeRequested(true);
+                executor.executeBatch(guids);
+            } catch (Exception e) {
+                workerError.set(e);
+            } finally {
+                done.countDown();
+                RequestContext.clear();
+            }
+        }, "purge-stale-handle-test-worker");
+
+        worker.start();
+        assertTrue(done.await(60, TimeUnit.SECONDS), "Worker purge timed out");
+
+        if (workerError.get() != null) {
+            throw workerError.get();
+        }
+    }
+
+    private static boolean hasIllegalStateInChain(Throwable t) {
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            if (c instanceof IllegalStateException) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityTestBase.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AtlasEntityTestBase.java
@@ -103,7 +103,9 @@ public class AtlasEntityTestBase extends AtlasTestBase {
 
     @BeforeTest
     public void init() throws Exception {
-        entityStore = new AtlasEntityStoreV2(graph, deleteDelegate, typeRegistry, mockChangeNotifier, graphMapper);
+        AtlasEntityStoreV2 entityStoreV2 = new AtlasEntityStoreV2(graph, deleteDelegate, typeRegistry, mockChangeNotifier, graphMapper);
+        entityStoreV2.setSelf(entityStoreV2);
+        entityStore = entityStoreV2;
 
         RequestContext.clear();
         RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);

--- a/repository/src/test/java/org/apache/atlas/services/PurgeBatchExecutorTest.java
+++ b/repository/src/test/java/org/apache/atlas/services/PurgeBatchExecutorTest.java
@@ -1,0 +1,208 @@
+package org.apache.atlas.services;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.GraphTransactionInterceptor;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.janusgraph.diskstorage.locking.PermanentLockingException;
+import org.mockito.MockedStatic;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class PurgeBatchExecutorTest {
+    private static final Set<String> BATCH = Collections.singleton("guid1");
+
+    @DataProvider(name = "retryableLockConflictExceptionClassNames")
+    public Object[][] retryableLockConflictExceptionClassNames() {
+        return new Object[][] {
+                {"org.janusgraph.diskstorage.locking.PermanentLockingException"},
+                {"com.sleepycat.je.LockTimeoutException"},
+                {"com.sleepycat.je.DeadlockException"},
+                {"org.janusgraph.diskstorage.PermanentBackendException"}
+        };
+    }
+
+    @Test
+    public void testExecuteBatchSuccess() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        when(mockStore.purgeEntitiesInBatch(BATCH)).thenReturn(mockResponse);
+
+        PurgeBatchExecutor executor = new PurgeBatchExecutor(mockStore);
+        EntityMutationResponse response = executor.executeBatch(BATCH);
+
+        assertEquals(response, mockResponse);
+        verify(mockStore, times(1)).purgeEntitiesInBatch(BATCH);
+    }
+
+    @Test
+    public void testIsRetryableLockConflictReturnsFalseForNull() {
+        assertFalse(PurgeBatchExecutor.isRetryableLockConflict(null));
+    }
+
+    @Test
+    public void testIsRetryableLockConflictReturnsFalseForNonRetryableException() {
+        assertFalse(PurgeBatchExecutor.isRetryableLockConflict(new RuntimeException("unexpected")));
+    }
+
+    @Test
+    public void testIsRetryableLockConflictMatchesWrappedCause() {
+        PermanentLockingException ple = new PermanentLockingException("lock conflict");
+        RuntimeException wrapped = new RuntimeException(new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, ple));
+
+        assertTrue(PurgeBatchExecutor.isRetryableLockConflict(wrapped));
+    }
+
+    @Test(dataProvider = "retryableLockConflictExceptionClassNames")
+    public void testIsRetryableLockConflictMatchesKnownTypes(String className) throws Exception {
+        Exception conflict = newExceptionByClassName(className, "lock conflict");
+
+        assertTrue(PurgeBatchExecutor.RETRYABLE_LOCK_CONFLICT_EXCEPTION_CLASS_NAMES.contains(className));
+        assertTrue(PurgeBatchExecutor.isRetryableLockConflict(conflict));
+        // Use message+cause form: RuntimeException(Throwable) calls cause.toString(), which NPEs on
+        // partially-initialized Berkeley JE DatabaseException instances created for this test.
+        assertTrue(PurgeBatchExecutor.isRetryableLockConflict(wrapWithCause(conflict)));
+    }
+
+    @Test
+    public void testExecuteBatchClearsCachesBeforeRetry() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        PermanentLockingException ple         = new PermanentLockingException("lock conflict");
+        AtlasBaseException wrappedException   = new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, ple);
+
+        when(mockStore.purgeEntitiesInBatch(BATCH))
+                .thenThrow(wrappedException)
+                .thenReturn(mockResponse);
+
+        try (MockedStatic<GraphTransactionInterceptor> interceptor = mockStatic(GraphTransactionInterceptor.class);
+                MockedStatic<RequestContext> requestContextStatic = mockStatic(RequestContext.class)) {
+            RequestContext mockContext = mock(RequestContext.class);
+            requestContextStatic.when(RequestContext::get).thenReturn(mockContext);
+            interceptor.when(GraphTransactionInterceptor::clearCache).thenAnswer(invocation -> null);
+            doNothing().when(mockContext).clearCache();
+
+            PurgeBatchExecutor executor = new PurgeBatchExecutor(mockStore);
+            EntityMutationResponse response = executor.executeBatch(BATCH);
+
+            assertEquals(response, mockResponse);
+            interceptor.verify(GraphTransactionInterceptor::clearCache, times(1));
+            verify(mockContext).clearCache();
+            verify(mockStore, times(2)).purgeEntitiesInBatch(BATCH);
+        }
+    }
+
+    @Test
+    public void testExecuteBatchRetryOnPermanentLockingException() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+
+        PermanentLockingException ple = new PermanentLockingException("Locking conflict");
+        AtlasBaseException wrappedException = new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, ple);
+
+        when(mockStore.purgeEntitiesInBatch(BATCH))
+                .thenThrow(wrappedException)
+                .thenThrow(wrappedException)
+                .thenReturn(mockResponse);
+
+        PurgeBatchExecutor executor = new PurgeBatchExecutor(mockStore);
+
+        long start = System.currentTimeMillis();
+        EntityMutationResponse response = executor.executeBatch(BATCH);
+        long duration = System.currentTimeMillis() - start;
+
+        assertEquals(response, mockResponse);
+        verify(mockStore, times(3)).purgeEntitiesInBatch(BATCH);
+        assertTrue(duration >= 1000, "Expected backoff delays but finished in " + duration + " ms");
+    }
+
+    @Test(dataProvider = "retryableLockConflictExceptionClassNames")
+    public void testExecuteBatchRetriesOnKnownLockConflictTypes(String className) throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        Exception conflict = newExceptionByClassName(className, "lock conflict");
+        AtlasBaseException wrappedException = new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, conflict);
+
+        when(mockStore.purgeEntitiesInBatch(BATCH))
+                .thenThrow(wrappedException)
+                .thenReturn(mockResponse);
+
+        PurgeBatchExecutor executor = new PurgeBatchExecutor(mockStore);
+        EntityMutationResponse response = executor.executeBatch(BATCH);
+
+        assertEquals(response, mockResponse);
+        verify(mockStore, times(2)).purgeEntitiesInBatch(BATCH);
+    }
+
+    @Test
+    public void testExecuteBatchFailsAfterMaxLockingConflicts() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        PermanentLockingException ple = new PermanentLockingException("lock conflict");
+        AtlasBaseException wrappedException = new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, ple);
+
+        when(mockStore.purgeEntitiesInBatch(BATCH)).thenThrow(wrappedException);
+
+        PurgeBatchExecutor executor = new PurgeBatchExecutor(mockStore);
+
+        AtlasBaseException ex = expectThrows(AtlasBaseException.class, () -> executor.executeBatch(BATCH));
+
+        assertEquals(ex.getAtlasErrorCode(), AtlasErrorCode.INTERNAL_ERROR);
+        verify(mockStore, times(3)).purgeEntitiesInBatch(BATCH);
+    }
+
+    @Test
+    public void testExecuteBatchNoRetryOnNonLockingException() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        RuntimeException nonRetryable = new RuntimeException("unexpected");
+        AtlasBaseException wrappedException = new AtlasBaseException(AtlasErrorCode.INTERNAL_ERROR, nonRetryable);
+
+        when(mockStore.purgeEntitiesInBatch(BATCH)).thenThrow(wrappedException);
+
+        PurgeBatchExecutor executor = new PurgeBatchExecutor(mockStore);
+
+        AtlasBaseException ex = expectThrows(AtlasBaseException.class, () -> executor.executeBatch(BATCH));
+
+        assertEquals(ex.getAtlasErrorCode(), AtlasErrorCode.INTERNAL_ERROR);
+        verify(mockStore, times(1)).purgeEntitiesInBatch(BATCH);
+    }
+
+    private static RuntimeException wrapWithCause(Throwable cause) {
+        return new RuntimeException("wrapped", cause);
+    }
+
+    private static Exception newExceptionByClassName(String className, String message) throws Exception {
+        try {
+            Class<?> clazz = Class.forName(className);
+            try {
+                return (Exception) clazz.getConstructor(String.class).newInstance(message);
+            } catch (NoSuchMethodException e) {
+                try {
+                    return (Exception) clazz.getConstructor().newInstance();
+                } catch (NoSuchMethodException e2) {
+                    java.lang.reflect.Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+                    f.setAccessible(true);
+                    sun.misc.Unsafe unsafe = (sun.misc.Unsafe) f.get(null);
+                    return (Exception) unsafe.allocateInstance(clazz);
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            throw new org.testng.SkipException("Required exception class not on classpath: " + className);
+        }
+    }
+}

--- a/repository/src/test/java/org/apache/atlas/services/PurgeBatchOrchestratorTest.java
+++ b/repository/src/test/java/org/apache/atlas/services/PurgeBatchOrchestratorTest.java
@@ -1,0 +1,899 @@
+package org.apache.atlas.services;
+
+import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.audit.AtlasAuditEntry.AuditOperation;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.EntityMutations.EntityOperation;
+import org.apache.atlas.model.instance.FailedEntity;
+import org.apache.atlas.model.instance.PurgeSummary;
+import org.apache.atlas.repository.audit.AtlasAuditService;
+import org.apache.atlas.repository.purge.PurgeExecutionStats;
+import org.apache.atlas.repository.purge.PurgeTestUtils;
+import org.apache.atlas.repository.purge.PurgeUtils;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class PurgeBatchOrchestratorTest {
+    private PurgeBatchExecutor mockExecutor;
+    private PurgeBatchOrchestrator orchestrator;
+    private final AtlasEntityStore entityStore = mock(AtlasEntityStore.class, CALLS_REAL_METHODS);
+
+    @BeforeMethod
+    public void setup() {
+        mockExecutor = mock(PurgeBatchExecutor.class);
+        orchestrator = new PurgeBatchOrchestrator(mockExecutor, null, null);
+        RequestContext.clear();
+        RequestContext.get().setUser("testUser", null);
+    }
+
+    @AfterMethod
+    public void teardown() {
+        RequestContext.clear();
+    }
+
+    @Test
+    public void testBatchFlushingAndResults() throws Exception {
+        PurgeBatchOrchestrator.PurgeBatchManager manager = orchestrator.createManager(2, 2);
+
+        // Setup mock response
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        AtlasEntityHeader header1 = new AtlasEntityHeader();
+        header1.setGuid("guid1");
+        AtlasEntityHeader header2 = new AtlasEntityHeader();
+        header2.setGuid("guid2");
+        Map<EntityOperation, List<AtlasEntityHeader>> mutatedEntities = new HashMap<>();
+        mutatedEntities.put(EntityOperation.PURGE, Arrays.asList(header1, header2));
+        mockResponse.setMutatedEntities(mutatedEntities);
+
+        when(mockExecutor.executeBatch(anySet())).thenReturn(mockResponse);
+
+        manager.checkProduce("guid1");
+        manager.checkProduce("guid2");
+        manager.checkProduce("guid3");
+
+        manager.shutdown();
+
+        Queue<Object> results = manager.getResults();
+        assertNotNull(results);
+
+        // One batch of 2 was processed, another batch of 1 was processed during shutdown
+        verify(mockExecutor, times(2)).executeBatch(anySet());
+    }
+
+    @Test
+    public void testExceptionHandlingConvertsToFailedEntities() throws Exception {
+        PurgeBatchOrchestrator.PurgeBatchManager manager = orchestrator.createManager(1, 1);
+
+        when(mockExecutor.executeBatch(anySet())).thenThrow(new OutOfMemoryError("OOM Test"));
+
+        manager.checkProduce("guid1");
+        manager.shutdown();
+
+        Queue<Object> results = manager.getResults();
+        assertEquals(results.size(), 1);
+
+        Object result = results.poll();
+        assertTrue(result instanceof PurgeBatchResult);
+        PurgeBatchResult batchResult = (PurgeBatchResult) result;
+        assertTrue(batchResult.hasBatchException());
+        assertEquals(batchResult.getBatchException().getMessage(), "OOM Test");
+        assertEquals(batchResult.getFailedEntities().size(), 1);
+        assertEquals(batchResult.getFailedEntities().get(0).getGuid(), "guid1");
+    }
+
+    @Test
+    public void testAuditWhenBatchCommitThrows() throws Exception {
+        AtlasAuditService mockAuditService = mock(AtlasAuditService.class);
+        PurgeBatchOrchestrator orchestratorWithAudit = new PurgeBatchOrchestrator(mockExecutor, mockAuditService,
+                AuditOperation.PURGE);
+
+        when(mockExecutor.executeBatch(anySet())).thenThrow(new RuntimeException("batch failed"));
+
+        PurgeBatchOrchestrator.PurgeBatchManager manager = orchestratorWithAudit.createManager(1, 1);
+        manager.checkProduce("guid1");
+        manager.shutdown();
+
+        ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAuditService, times(1)).add(
+                eq(AuditOperation.PURGE), anyString(), resultCaptor.capture(), eq(0L));
+
+        String result = resultCaptor.getValue();
+        assertTrue(result.contains("purgedCount=0"));
+        assertTrue(result.contains("failedCount=1"));
+        assertTrue(result.contains("skippedCount=0"));
+        assertTrue(result.contains("sampleFailedGuids=[guid1]"));
+    }
+
+    @Test
+    public void testReconcileUnprocessedGuidsMarksMissingAsFailed() {
+        EntityMutationResponse response = new EntityMutationResponse();
+        AtlasEntityHeader header1 = new AtlasEntityHeader();
+        header1.setGuid("guid1");
+        response.addEntity(EntityOperation.PURGE, header1);
+
+        List<FailedEntity> pendingFailures = new ArrayList<>();
+        pendingFailures.add(new FailedEntity(
+                "guid2",
+                org.apache.atlas.AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode(),
+                "already failed"));
+
+        Set<String> submittedGuids = new LinkedHashSet<>(Arrays.asList("guid1", "guid2", "guid3"));
+        int reconciledCount = PurgeBatchOrchestrator.reconcileUnprocessedGuids(submittedGuids, response, pendingFailures, null);
+
+        assertEquals(reconciledCount, 1);
+        assertEquals(pendingFailures.size(), 2);
+        assertEquals(pendingFailures.get(1).getGuid(), "guid3");
+        assertEquals(pendingFailures.get(1).getErrorCode(), org.apache.atlas.AtlasErrorCode.INTERNAL_ERROR.getErrorCode());
+        assertEquals(pendingFailures.get(1).getErrorMessage(), PurgeBatchOrchestrator.UNPROCESSED_PURGE_GUID_MESSAGE);
+    }
+
+    @Test
+    public void testReconcileUnprocessedGuidsNoOpWhenAllAccounted() {
+        EntityMutationResponse response = new EntityMutationResponse();
+        AtlasEntityHeader header1 = new AtlasEntityHeader();
+        header1.setGuid("guid1");
+        response.addEntity(EntityOperation.PURGE, header1);
+        response.addFailedEntity(new FailedEntity(
+                "guid2",
+                org.apache.atlas.AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "batch failure"));
+
+        int reconciledCount = PurgeBatchOrchestrator.reconcileUnprocessedGuids(
+                Arrays.asList("guid1", "guid2"), response, null, null);
+
+        assertEquals(reconciledCount, 0);
+        assertEquals(response.getFailedEntities().size(), 1);
+    }
+
+    @Test
+    public void testBatchWorkerReportsPurgedEntitiesOnSuccess() throws Exception {
+        PurgeBatchOrchestrator.PurgeBatchManager manager = orchestrator.createManager(2, 1);
+
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        AtlasEntityHeader header1 = new AtlasEntityHeader();
+        header1.setGuid("guid1");
+        AtlasEntityHeader header2 = new AtlasEntityHeader();
+        header2.setGuid("guid2");
+        Map<EntityOperation, List<AtlasEntityHeader>> mutatedEntities = new HashMap<>();
+        mutatedEntities.put(EntityOperation.PURGE, Arrays.asList(header1, header2));
+        mockResponse.setMutatedEntities(mutatedEntities);
+
+        when(mockExecutor.executeBatch(anySet())).thenReturn(mockResponse);
+
+        manager.checkProduce("guid1");
+        manager.checkProduce("guid2");
+        manager.shutdown();
+
+        Queue<Object> results = manager.getResults();
+        assertEquals(results.size(), 1);
+
+        Object result = results.poll();
+        assertTrue(result instanceof PurgeBatchResult);
+        PurgeBatchResult batchResult = (PurgeBatchResult) result;
+        assertEquals(batchResult.getPurgedEntities().size(), 2);
+        assertEquals(batchResult.getPurgedEntities().get(0).getGuid(), "guid1");
+        assertEquals(batchResult.getPurgedEntities().get(1).getGuid(), "guid2");
+    }
+
+    @Test
+    public void testBatchAlreadyRemovedEntitiesReportedAsSkipped() throws Exception {
+        PurgeBatchOrchestrator.PurgeBatchManager manager = orchestrator.createManager(1, 1);
+
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        mockResponse.addFailedEntity(new FailedEntity(
+                "guid1",
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode(),
+                "already removed"));
+
+        when(mockExecutor.executeBatch(anySet())).thenReturn(mockResponse);
+
+        manager.checkProduce("guid1");
+        manager.shutdown();
+
+        Queue<Object> results = manager.getResults();
+        assertEquals(results.size(), 1);
+
+        Object result = results.poll();
+        assertTrue(result instanceof PurgeBatchResult);
+        PurgeBatchResult batchResult = (PurgeBatchResult) result;
+        assertEquals(batchResult.getFailedEntities().size(), 1);
+        FailedEntity failedEntity = batchResult.getFailedEntities().get(0);
+        assertEquals(failedEntity.getGuid(), "guid1");
+        assertEquals(failedEntity.getErrorCode(), AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode());
+        assertTrue(PurgeUtils.isSkippablePurgeFailureCode(failedEntity.getErrorCode()));
+    }
+
+    @Test
+    public void testExecutePurgeSuccess() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        when(mockExecutor.getEntityStore()).thenReturn(mockStore);
+
+        String rootGuid = "11111111-1111-1111-1111-111111111111";
+        String dependencyGuid = "22222222-2222-2222-2222-222222222222";
+        when(mockStore.accumulateDeletionCandidates(Collections.singleton(rootGuid)))
+                .thenReturn(new LinkedHashSet<>(Collections.singletonList(dependencyGuid)));
+
+        EntityMutationResponse batchResponse = new EntityMutationResponse();
+        AtlasEntityHeader purgedDependency = new AtlasEntityHeader();
+        purgedDependency.setGuid(dependencyGuid);
+        AtlasEntityHeader purgedRoot = new AtlasEntityHeader();
+        purgedRoot.setGuid(rootGuid);
+        batchResponse.addEntity(EntityOperation.PURGE, purgedDependency);
+        batchResponse.addEntity(EntityOperation.PURGE, purgedRoot);
+        when(mockExecutor.executeBatch(anySet())).thenReturn(batchResponse);
+
+        List<FailedEntity> failedEntities = new ArrayList<>();
+        failedEntities.add(new FailedEntity(
+                "33333333-3333-3333-3333-333333333333",
+                AtlasErrorCode.INVALID_GUID.getErrorCode(),
+                "invalid guid"));
+
+        Set<String> validGuids = new LinkedHashSet<>(Collections.singletonList(rootGuid));
+        PurgeExecutionStats stats = new PurgeExecutionStats(validGuids, validGuids.size());
+        EntityMutationResponse response = orchestrator.executePurge(validGuids, failedEntities, stats);
+
+        assertNotNull(response.getPurgedEntities());
+        assertEquals(response.getPurgedEntities().size(), 2);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+        assertEquals(response.getFailedEntities().get(0).getErrorCode(), AtlasErrorCode.INVALID_GUID.getErrorCode());
+        verify(mockStore).accumulateDeletionCandidates(Collections.singleton(rootGuid));
+    }
+
+    @Test
+    public void testExecutePurgeRecordsExpansionFailure() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        when(mockExecutor.getEntityStore()).thenReturn(mockStore);
+
+        String rootGuid = "11111111-1111-1111-1111-111111111111";
+        when(mockStore.accumulateDeletionCandidates(Collections.singleton(rootGuid)))
+                .thenThrow(new AtlasBaseException(AtlasErrorCode.INSTANCE_GUID_NOT_FOUND, rootGuid));
+
+        List<FailedEntity> failedEntities = new ArrayList<>();
+        Set<String> validGuids = new LinkedHashSet<>(Collections.singletonList(rootGuid));
+        PurgeExecutionStats stats = new PurgeExecutionStats(validGuids, validGuids.size());
+        EntityMutationResponse response = orchestrator.executePurge(validGuids, failedEntities, stats);
+
+        assertTrue(response.getPurgedEntities() == null || response.getPurgedEntities().isEmpty());
+        assertEquals(failedEntities.size(), 1);
+        assertEquals(failedEntities.get(0).getGuid(), rootGuid);
+        assertEquals(failedEntities.get(0).getErrorCode(), AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode());
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+    }
+
+    @Test
+    public void testExecutePurgeMergesPartialResultsWhenShutdownInterrupted() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        when(mockExecutor.getEntityStore()).thenReturn(mockStore);
+
+        String rootGuid = "11111111-1111-1111-1111-111111111111";
+        String dependencyGuid = "22222222-2222-2222-2222-222222222222";
+        when(mockStore.accumulateDeletionCandidates(Collections.singleton(rootGuid)))
+                .thenReturn(new LinkedHashSet<>(Collections.singletonList(dependencyGuid)));
+
+        EntityMutationResponse batchResponse = new EntityMutationResponse();
+        AtlasEntityHeader purgedHeader = new AtlasEntityHeader();
+        purgedHeader.setGuid(dependencyGuid);
+        batchResponse.addEntity(EntityOperation.PURGE, purgedHeader);
+        when(mockExecutor.executeBatch(anySet())).thenReturn(batchResponse);
+
+        PurgeBatchOrchestrator orchestratorSpy = spy(orchestrator);
+        doAnswer(invocation -> {
+            PurgeBatchOrchestrator.PurgeBatchManager manager =
+                    (PurgeBatchOrchestrator.PurgeBatchManager) invocation.callRealMethod();
+            PurgeBatchOrchestrator.PurgeBatchManager managerSpy = spy(manager);
+
+            doAnswer(shutdownInvocation -> {
+                managerSpy.getResults().offer(new PurgeBatchResult(
+                        new LinkedHashSet<>(Collections.singletonList(dependencyGuid)),
+                        Collections.singletonList(purgedHeader), null, false, null));
+                throw new InterruptedException("simulated shutdown interrupt");
+            }).when(managerSpy).shutdown();
+
+            return managerSpy;
+        }).when(orchestratorSpy).createManager(anyInt(), anyInt());
+
+        List<FailedEntity> failedEntities = new ArrayList<>();
+        Set<String> validGuids = new LinkedHashSet<>(Collections.singletonList(rootGuid));
+        PurgeExecutionStats stats = new PurgeExecutionStats(validGuids, validGuids.size());
+        EntityMutationResponse response = orchestratorSpy.executePurge(validGuids, failedEntities, stats);
+
+        assertNotNull(response.getPurgedEntities());
+        assertEquals(response.getPurgedEntities().size(), 1);
+        assertEquals(response.getPurgedEntities().get(0).getGuid(), dependencyGuid);
+        assertNotNull(response.getFailedEntities());
+        assertEquals(response.getFailedEntities().size(), 1);
+        assertEquals(response.getFailedEntities().get(0).getGuid(), rootGuid);
+        assertEquals(response.getFailedEntities().get(0).getErrorCode(), AtlasErrorCode.INTERNAL_ERROR.getErrorCode());
+        assertEquals(response.getFailedEntities().get(0).getErrorMessage(),
+                PurgeBatchOrchestrator.UNPROCESSED_PURGE_GUID_MESSAGE);
+        assertTrue(Thread.interrupted(), "Expected interrupt flag to be set after shutdown interruption");
+    }
+
+    @Test
+    public void testExecutePurgeEmptyInputReturnsEmptyResponse() throws Exception {
+        when(mockExecutor.getEntityStore()).thenReturn(mock(AtlasEntityStore.class));
+
+        List<FailedEntity> failedEntities = new ArrayList<>();
+        Set<String> validGuids = new LinkedHashSet<>();
+        PurgeExecutionStats stats = new PurgeExecutionStats(validGuids, 0);
+        EntityMutationResponse response = orchestrator.executePurge(validGuids, failedEntities, stats);
+
+        assertNull(response.getPurgedEntities());
+        assertNull(response.getFailedEntities());
+        verify(mockExecutor, never()).executeBatch(anySet());
+    }
+
+    @Test
+    public void testAuditWriterInvokedOnCommit() throws Exception {
+        PurgeBatchExecutor mockExecutor = mock(PurgeBatchExecutor.class);
+        AtlasAuditService mockAuditService = mock(AtlasAuditService.class);
+
+        PurgeBatchOrchestrator orchestrator = new PurgeBatchOrchestrator(mockExecutor, mockAuditService,
+                AuditOperation.PURGE);
+
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        AtlasEntityHeader header1 = new AtlasEntityHeader();
+        header1.setGuid("guid1");
+        AtlasEntityHeader header2 = new AtlasEntityHeader();
+        header2.setGuid("guid2");
+        Map<EntityOperation, List<AtlasEntityHeader>> mutatedEntities = new HashMap<>();
+        mutatedEntities.put(EntityOperation.PURGE, Arrays.asList(header1, header2));
+        mockResponse.setMutatedEntities(mutatedEntities);
+
+        when(mockExecutor.executeBatch(anySet())).thenReturn(mockResponse);
+
+        PurgeBatchOrchestrator.PurgeBatchManager manager = orchestrator.createManager(2, 1);
+        manager.checkProduce("guid1");
+        manager.checkProduce("guid2");
+        manager.shutdown();
+
+        ArgumentCaptor<String> paramsCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAuditService, times(1)).add(
+                eq(AuditOperation.PURGE),
+                paramsCaptor.capture(),
+                resultCaptor.capture(),
+                eq(2L));
+
+        assertTrue(paramsCaptor.getValue().contains("processedCount=2"));
+        assertTrue(paramsCaptor.getValue().contains("sampleGuids=[guid1,guid2]"));
+        assertTrue(resultCaptor.getValue().contains("purgedCount=2"));
+        assertTrue(resultCaptor.getValue().contains("failedCount=0"));
+        assertTrue(resultCaptor.getValue().contains("skippedCount=0"));
+    }
+
+    @Test
+    public void testWriteBatchAuditUsesSummarySkippedAndFailedCounts() throws Exception {
+        AtlasAuditService mockAuditService = mock(AtlasAuditService.class);
+
+        Set<String> batchGuids = new LinkedHashSet<>(Arrays.asList(
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222",
+                "33333333-3333-3333-3333-333333333333"));
+
+        EntityMutationResponse response = new EntityMutationResponse();
+        response.addFailedEntity(new FailedEntity(
+                "11111111-1111-1111-1111-111111111111",
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode(),
+                "not found"));
+        response.addFailedEntity(new FailedEntity(
+                "22222222-2222-2222-2222-222222222222",
+                AtlasErrorCode.NOT_IN_DELETED_STATE.getErrorCode(),
+                "not deleted"));
+        response.addFailedEntity(new FailedEntity(
+                "33333333-3333-3333-3333-333333333333",
+                AtlasErrorCode.INVALID_GUID.getErrorCode(),
+                "invalid guid"));
+        response.setSummary(new PurgeSummary(3, 0, 0, 1, 2));
+
+        PurgeBatchOrchestrator.writeBatchAudit(mockAuditService, AuditOperation.PURGE, batchGuids, response);
+
+        ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAuditService).add(eq(AuditOperation.PURGE), anyString(), resultCaptor.capture(), eq(0L));
+
+        String result = resultCaptor.getValue();
+        assertTrue(result.contains("purgedCount=0"));
+        assertTrue(result.contains("failedCount=1"));
+        assertTrue(result.contains("skippedCount=2"));
+        assertTrue(result.contains("sampleFailedGuids=[33333333-3333-3333-3333-333333333333]"));
+        assertTrue(result.contains("sampleSkippedGuids=[11111111-1111-1111-1111-111111111111,22222222-2222-2222-2222-222222222222]"));
+    }
+
+    @Test
+    public void testWriteBatchAuditDerivesCountsWhenSummaryMissing() throws Exception {
+        AtlasAuditService mockAuditService = mock(AtlasAuditService.class);
+
+        Set<String> batchGuids = new LinkedHashSet<>(Collections.singletonList(
+                "11111111-1111-1111-1111-111111111111"));
+
+        EntityMutationResponse response = new EntityMutationResponse();
+        response.addFailedEntity(new FailedEntity(
+                "11111111-1111-1111-1111-111111111111",
+                AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "batch failure"));
+
+        PurgeBatchOrchestrator.writeBatchAudit(mockAuditService, AuditOperation.PURGE, batchGuids, response);
+
+        ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAuditService).add(eq(AuditOperation.PURGE), anyString(), resultCaptor.capture(), eq(0L));
+
+        String result = resultCaptor.getValue();
+        assertTrue(result.contains("failedCount=1"));
+        assertTrue(result.contains("skippedCount=0"));
+        assertTrue(result.contains("sampleFailedGuids=[11111111-1111-1111-1111-111111111111]"));
+    }
+
+    @Test
+    public void testWriteBatchAuditSplitsDependencyFailuresWhenOriginallyRequestedGuidsProvided() throws Exception {
+        AtlasAuditService mockAuditService = mock(AtlasAuditService.class);
+
+        Set<String> batchGuids = new LinkedHashSet<>(Arrays.asList(
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222"));
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(Collections.singletonList(
+                "11111111-1111-1111-1111-111111111111"));
+
+        EntityMutationResponse response = new EntityMutationResponse();
+        response.addFailedEntity(new FailedEntity(
+                "11111111-1111-1111-1111-111111111111",
+                AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "requested failure"));
+        response.addFailedEntity(new FailedEntity(
+                "22222222-2222-2222-2222-222222222222",
+                AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "dependency failure"));
+
+        PurgeBatchOrchestrator.writeBatchAudit(mockAuditService, AuditOperation.PURGE, batchGuids, response,
+                originallyRequestedGuids);
+
+        ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAuditService).add(eq(AuditOperation.PURGE), anyString(), resultCaptor.capture(), eq(0L));
+
+        String result = resultCaptor.getValue();
+        assertTrue(result.contains("failedCount=1"));
+        assertTrue(result.contains("failedDependenciesCount=1"));
+    }
+
+    @Test
+    public void testWriteBatchAuditAllPreScanSkippedUsesSummaryCounts() throws Exception {
+        AtlasAuditService mockAuditService = mock(AtlasAuditService.class);
+
+        Set<String> batchGuids = new LinkedHashSet<>(Arrays.asList(
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222"));
+
+        EntityMutationResponse response = new EntityMutationResponse();
+        response.addFailedEntity(new FailedEntity(
+                "11111111-1111-1111-1111-111111111111",
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode(),
+                "not found"));
+        response.addFailedEntity(new FailedEntity(
+                "22222222-2222-2222-2222-222222222222",
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode(),
+                "not found"));
+        response.setSummary(new PurgeSummary(2, 0, 0, 0, 2));
+
+        PurgeBatchOrchestrator.writeBatchAudit(mockAuditService, AuditOperation.PURGE, batchGuids, response);
+
+        ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAuditService).add(eq(AuditOperation.PURGE), anyString(), resultCaptor.capture(), eq(0L));
+
+        String result = resultCaptor.getValue();
+        assertTrue(result.contains("failedCount=0"));
+        assertTrue(result.contains("failedDependenciesCount=0"));
+        assertTrue(result.contains("skippedCount=2"));
+    }
+
+    @Test
+    public void testWriteBatchAuditIncludesFailedDependenciesCountFromSummary() throws Exception {
+        AtlasAuditService mockAuditService = mock(AtlasAuditService.class);
+
+        Set<String> batchGuids = new LinkedHashSet<>(Arrays.asList(
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222"));
+
+        EntityMutationResponse response = new EntityMutationResponse();
+        AtlasEntityHeader purgedRequested = new AtlasEntityHeader();
+        purgedRequested.setGuid("11111111-1111-1111-1111-111111111111");
+        response.addEntity(EntityOperation.PURGE, purgedRequested);
+        response.addFailedEntity(new FailedEntity(
+                "22222222-2222-2222-2222-222222222222",
+                AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "dependency batch failure"));
+        response.setSummary(new PurgeSummary(1, 1, 0, 0, 1, 0));
+
+        PurgeBatchOrchestrator.writeBatchAudit(mockAuditService, AuditOperation.PURGE, batchGuids, response);
+
+        ArgumentCaptor<String> resultCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAuditService).add(eq(AuditOperation.PURGE), anyString(), resultCaptor.capture(), eq(1L));
+
+        String result = resultCaptor.getValue();
+        assertTrue(result.contains("purgedCount=1"));
+        assertTrue(result.contains("failedCount=0"));
+        assertTrue(result.contains("failedDependenciesCount=1"));
+        assertTrue(result.contains("skippedCount=0"));
+        assertTrue(result.contains("sampleFailedGuids=[22222222-2222-2222-2222-222222222222]"));
+    }
+
+    @Test
+    public void testAuditWriterBoundsLargeBatchParams() throws Exception {
+        PurgeBatchExecutor mockExecutor = mock(PurgeBatchExecutor.class);
+        AtlasAuditService mockAuditService = mock(AtlasAuditService.class);
+        PurgeBatchOrchestrator orchestrator = new PurgeBatchOrchestrator(mockExecutor, mockAuditService,
+                AuditOperation.PURGE);
+
+        Set<String> batchGuids = new LinkedHashSet<>();
+        for (int i = 0; i < 12; i++) {
+            batchGuids.add(String.format("11111111-1111-1111-1111-%012d", i));
+        }
+
+        EntityMutationResponse mockResponse = new EntityMutationResponse();
+        AtlasEntityHeader header = new AtlasEntityHeader();
+        header.setGuid("11111111-1111-1111-1111-000000000000");
+        mockResponse.addEntity(EntityOperation.PURGE, header);
+
+        when(mockExecutor.executeBatch(anySet())).thenReturn(mockResponse);
+
+        PurgeBatchOrchestrator.PurgeBatchManager manager = orchestrator.createManager(12, 1);
+        for (String guid : batchGuids) {
+            manager.checkProduce(guid);
+        }
+        manager.shutdown();
+
+        ArgumentCaptor<String> paramsCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAuditService).add(eq(AuditOperation.PURGE), paramsCaptor.capture(), anyString(), eq(1L));
+        assertTrue(paramsCaptor.getValue().contains("processedCount=12"));
+        assertTrue(paramsCaptor.getValue().length() < batchGuids.toString().length());
+    }
+
+    @Test
+    public void testAttachPurgeSummarySetsExecutionFailedForNonInternalErrorBatchFailure() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        String requestedGuid = "11111111-1111-1111-1111-111111111111";
+        String failedGuid    = "22222222-2222-2222-2222-222222222222";
+
+        AtlasEntityHeader purgedRequested = new AtlasEntityHeader();
+        purgedRequested.setGuid(requestedGuid);
+        response.addEntity(EntityOperation.PURGE, purgedRequested);
+
+        response.addFailedEntity(new FailedEntity(
+                failedGuid,
+                AtlasErrorCode.REFERENCED_ENTITY_NOT_FOUND.getErrorCode(),
+                "Referenced entity missing during batch purge"));
+
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(Arrays.asList(requestedGuid, failedGuid));
+        PurgeTestUtils.attachPurgeSummaryFromResponse(response, originallyRequestedGuids, originallyRequestedGuids.size());
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertTrue(summary.getExecutionFailed());
+        assertEquals(summary.getPurgedCount(), 1);
+        assertEquals(summary.getFailedCount(), 1);
+        assertEquals(summary.getSkippedCount(), 0);
+    }
+
+    @Test
+    public void testAttachPurgeSummaryDoesNotSetExecutionFailedForPreScanFailures() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        String purgedGuid  = "11111111-1111-1111-1111-111111111111";
+        String invalidGuid = "not-a-valid-uuid";
+
+        AtlasEntityHeader purgedRequested = new AtlasEntityHeader();
+        purgedRequested.setGuid(purgedGuid);
+        response.addEntity(EntityOperation.PURGE, purgedRequested);
+
+        response.addFailedEntity(new FailedEntity(
+                invalidGuid,
+                AtlasErrorCode.INVALID_GUID.getErrorCode(),
+                "invalid guid"));
+
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(Arrays.asList(purgedGuid, invalidGuid));
+        PurgeTestUtils.attachPurgeSummaryFromResponse(response, originallyRequestedGuids, 1);
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertFalse(summary.getExecutionFailed());
+        assertEquals(summary.getPurgedCount(), 1);
+        assertEquals(summary.getFailedCount(), 1);
+        assertEquals(summary.getSkippedCount(), 0);
+    }
+
+    @Test
+    public void testAttachPurgeSummaryCountsNonSkippableDependencyFailuresSeparately() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        String requestedGuid  = "11111111-1111-1111-1111-111111111111";
+        String dependencyGuid = "22222222-2222-2222-2222-222222222222";
+
+        AtlasEntityHeader purgedRequested = new AtlasEntityHeader();
+        purgedRequested.setGuid(requestedGuid);
+        response.addEntity(EntityOperation.PURGE, purgedRequested);
+
+        AtlasEntityHeader purgedDependency = new AtlasEntityHeader();
+        purgedDependency.setGuid(dependencyGuid);
+        response.addEntity(EntityOperation.PURGE, purgedDependency);
+
+        response.addFailedEntity(new FailedEntity(
+                dependencyGuid,
+                AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "dependency batch failure"));
+
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(Arrays.asList(requestedGuid));
+        PurgeTestUtils.attachPurgeSummaryFromResponse(response, originallyRequestedGuids, 1);
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertEquals(summary.getRequestedCount(), 1);
+        assertEquals(summary.getPurgedCount(), 1);
+        assertEquals(summary.getPurgedDependenciesCount(), 1);
+        assertEquals(summary.getFailedCount(), 0);
+        assertEquals(summary.getFailedDependenciesCount(), 0);
+        assertEquals(response.getFailedEntities().size(), 1);
+    }
+
+    @Test
+    public void testAttachPurgeSummaryIgnoresSkippableDependencyFailures() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        String requestedGuid  = "11111111-1111-1111-1111-111111111111";
+        String dependencyGuid = "22222222-2222-2222-2222-222222222222";
+
+        AtlasEntityHeader purgedRequested = new AtlasEntityHeader();
+        purgedRequested.setGuid(requestedGuid);
+        response.addEntity(EntityOperation.PURGE, purgedRequested);
+
+        response.addFailedEntity(new FailedEntity(
+                dependencyGuid,
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode(),
+                "dependency already removed by concurrent batch"));
+
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(Arrays.asList(requestedGuid));
+        PurgeTestUtils.attachPurgeSummaryFromResponse(response, originallyRequestedGuids, 1);
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertEquals(summary.getRequestedCount(), 1);
+        assertEquals(summary.getPurgedCount(), 1);
+        assertEquals(summary.getPurgedDependenciesCount(), 0);
+        assertEquals(summary.getFailedCount(), 0);
+        assertEquals(summary.getFailedDependenciesCount(), 0);
+        assertEquals(summary.getSkippedDependenciesCount(), 1);
+        assertEquals(summary.getSkippedCount(), 1);
+    }
+
+    @Test
+    public void testAttachPurgeSummaryCountsRequestedAndDependencyFailuresSeparately() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        String requestedGuid  = "11111111-1111-1111-1111-111111111111";
+        String dependencyGuid = "22222222-2222-2222-2222-222222222222";
+
+        response.addFailedEntity(new FailedEntity(
+                requestedGuid,
+                AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "requested root expand failure"));
+        response.addFailedEntity(new FailedEntity(
+                dependencyGuid,
+                AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "dependency batch failure"));
+
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(Arrays.asList(requestedGuid));
+        PurgeTestUtils.attachPurgeSummaryFromResponse(response, originallyRequestedGuids, 1);
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertEquals(summary.getRequestedCount(), 1);
+        assertEquals(summary.getPurgedCount(), 0);
+        assertEquals(summary.getPurgedDependenciesCount(), 0);
+        assertEquals(summary.getFailedCount(), 1);
+        assertEquals(summary.getFailedDependenciesCount(), 1);
+        assertEquals(summary.getSkippedCount(), 0);
+        assertEquals(response.getFailedEntities().size(), 2);
+    }
+
+    @Test
+    public void testAttachPurgeSummaryBalanceFormula() {
+        EntityMutationResponse response = new EntityMutationResponse();
+
+        String requestedGuid  = "11111111-1111-1111-1111-111111111111";
+        String dependencyGuid = "22222222-2222-2222-2222-222222222222";
+        String failedDependencyGuid = "33333333-3333-3333-3333-333333333333";
+
+        response.addFailedEntity(new FailedEntity(
+                requestedGuid,
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode(),
+                "Not found"));
+        response.addFailedEntity(new FailedEntity(
+                dependencyGuid,
+                AtlasErrorCode.INSTANCE_GUID_NOT_FOUND.getErrorCode(),
+                "Dependency not found"));
+        response.addFailedEntity(new FailedEntity(
+                failedDependencyGuid,
+                AtlasErrorCode.INTERNAL_ERROR.getErrorCode(),
+                "Dependency failed"));
+
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(Collections.singletonList(requestedGuid));
+        PurgeTestUtils.attachPurgeSummaryFromResponse(response, originallyRequestedGuids, 1);
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertEquals(summary.getRequestedCount(), 1);
+        assertEquals(summary.getSkippedRequestedCount(), 1);
+        assertEquals(summary.getSkippedDependenciesCount(), 1);
+        assertEquals(summary.getSkippedCount(), 2);
+        assertEquals(summary.getFailedCount(), 0);
+        assertEquals(summary.getFailedDependenciesCount(), 1);
+        assertEquals(summary.getPurgedCount(), 0);
+        assertEquals(summary.getPurgedDependenciesCount(), 0);
+
+        assertEquals(summary.getRequestedCount(),
+                summary.getPurgedCount() + summary.getFailedCount() + summary.getSkippedRequestedCount());
+    }
+
+    @Test
+    public void testAttachPurgeSummarySetsValidGuidCount() {
+        EntityMutationResponse response = new EntityMutationResponse();
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(
+                Collections.singletonList("11111111-1111-1111-1111-111111111111"));
+
+        PurgeTestUtils.attachPurgeSummaryFromResponse(response, originallyRequestedGuids, 1);
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertEquals(summary.getValidGuidCount(), 1);
+    }
+
+    @Test
+    public void testReconcileUnprocessedGuidsUpdatesExecutionStats() {
+        Set<String> originallyRequestedGuids = new LinkedHashSet<>(Arrays.asList(
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222",
+                "33333333-3333-3333-3333-333333333333"));
+        PurgeExecutionStats stats = new PurgeExecutionStats(originallyRequestedGuids, originallyRequestedGuids.size());
+        stats.getProducedDeletionCandidates().addAll(originallyRequestedGuids);
+
+        EntityMutationResponse response = new EntityMutationResponse();
+        int reconciledCount = PurgeBatchOrchestrator.reconcileUnprocessedGuids(
+                stats.getProducedDeletionCandidates(), response, null, stats);
+
+        assertEquals(reconciledCount, 3);
+        assertEquals(stats.getReconciledUnprocessedCount(), 3);
+        assertEquals(stats.getFailedCount(), 3);
+        PurgeUtils.attachPurgeSummary(response, stats);
+        assertEquals(response.getPurgeSummary().getUnprocessedCount(), 3);
+    }
+
+    @Test
+    public void testExecutePurgeExpandedWorkloadAccounting() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        when(mockExecutor.getEntityStore()).thenReturn(mockStore);
+
+        Set<String> requestedGuids = new LinkedHashSet<>();
+        for (int i = 0; i < 10; i++) {
+            requestedGuids.add(String.format("11111111-1111-1111-1111-%012d", i));
+        }
+
+        when(mockStore.accumulateDeletionCandidates(any())).thenAnswer(invocation -> {
+            Set<String> root = invocation.getArgument(0);
+            String rootGuid = root.iterator().next();
+            Set<String> deps = new LinkedHashSet<>();
+            for (int j = 0; j < 4; j++) {
+                deps.add(rootGuid.replaceFirst("1111", String.format("%04d", j + 2)));
+            }
+            return deps;
+        });
+
+        when(mockExecutor.executeBatch(anySet())).thenAnswer(invocation -> {
+            EntityMutationResponse batchResponse = new EntityMutationResponse();
+            Set<String> batchGuids = invocation.getArgument(0);
+            for (String guid : batchGuids) {
+                AtlasEntityHeader header = new AtlasEntityHeader();
+                header.setGuid(guid);
+                batchResponse.addEntity(EntityOperation.PURGE, header);
+            }
+            return batchResponse;
+        });
+
+        PurgeExecutionStats stats = new PurgeExecutionStats(requestedGuids, requestedGuids.size());
+        EntityMutationResponse response = orchestrator.executePurge(requestedGuids, new ArrayList<>(), stats);
+        PurgeUtils.attachPurgeSummary(response, stats);
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertEquals(summary.getRequestedCount(), 10);
+        assertEquals(summary.getExpandedEntityCount(), 50);
+        assertEquals(summary.getPurgedCount(), 10);
+        assertEquals(summary.getPurgedDependenciesCount(), 40);
+        assertEquals(summary.getUnprocessedCount(), 0);
+        assertTrue(summary.getBatchCount() > 0);
+        assertEquals(summary.getExpandedEntityCount(),
+                summary.getPurgedCount() + summary.getPurgedDependenciesCount());
+    }
+
+    @Test
+    public void testMultiWorkerPurgeStatsAccounting() throws Exception {
+        AtlasEntityStore mockStore = mock(AtlasEntityStore.class);
+        when(mockExecutor.getEntityStore()).thenReturn(mockStore);
+
+        Set<String> requestedGuids = new LinkedHashSet<>();
+        for (int i = 0; i < 6; i++) {
+            requestedGuids.add(String.format("11111111-1111-1111-1111-%012d", i));
+        }
+
+        when(mockStore.accumulateDeletionCandidates(any())).thenAnswer(invocation -> {
+            Set<String> root = invocation.getArgument(0);
+            return new LinkedHashSet<>(root);
+        });
+
+        when(mockExecutor.executeBatch(anySet())).thenAnswer(invocation -> {
+            Set<String> batchGuids = invocation.getArgument(0);
+            EntityMutationResponse batchResponse = new EntityMutationResponse();
+            for (String guid : batchGuids) {
+                if ("11111111-1111-1111-1111-000000000003".equals(guid)) {
+                    batchResponse.addFailedEntity(new FailedEntity(guid,
+                            AtlasErrorCode.INTERNAL_ERROR.getErrorCode(), "batch failure"));
+                } else {
+                    AtlasEntityHeader header = new AtlasEntityHeader();
+                    header.setGuid(guid);
+                    batchResponse.addEntity(EntityOperation.PURGE, header);
+                }
+            }
+            return batchResponse;
+        });
+
+        PurgeBatchOrchestrator orchestratorSpy = spy(orchestrator);
+        doAnswer(invocation -> orchestrator.createManager(1, 2))
+                .when(orchestratorSpy).createManager(anyInt(), anyInt());
+
+        PurgeExecutionStats stats = new PurgeExecutionStats(requestedGuids, requestedGuids.size());
+        EntityMutationResponse response = orchestratorSpy.executePurge(requestedGuids, new ArrayList<>(), stats);
+        PurgeUtils.attachPurgeSummary(response, stats);
+
+        PurgeSummary summary = response.getPurgeSummary();
+        assertNotNull(summary);
+        assertEquals(summary.getRequestedCount(), 6);
+        assertEquals(summary.getPurgedCount(), 5);
+        assertEquals(summary.getFailedCount(), 1);
+        assertTrue(summary.getExecutionFailed());
+        assertTrue(summary.getBatchCount() >= 6);
+    }
+}

--- a/repository/src/test/java/org/apache/atlas/services/PurgeServiceTest.java
+++ b/repository/src/test/java/org/apache/atlas/services/PurgeServiceTest.java
@@ -18,18 +18,26 @@
 package org.apache.atlas.services;
 
 import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.DeleteType;
+import org.apache.atlas.GraphTransactionInterceptor;
 import org.apache.atlas.RequestContext;
+import org.apache.atlas.TestUtilsV2;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.FailedEntity;
 import org.apache.atlas.repository.AtlasTestBase;
 import org.apache.atlas.repository.Constants;
+import org.apache.atlas.repository.audit.AtlasAuditService;
+import org.apache.atlas.repository.graphdb.AtlasEdge;
+import org.apache.atlas.repository.graphdb.AtlasEdgeDirection;
 import org.apache.atlas.repository.graphdb.AtlasElement;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
+import org.apache.atlas.repository.purge.PurgeUtils;
 import org.apache.atlas.repository.store.graph.v2.AtlasEntityStoreV2;
 import org.apache.atlas.repository.store.graph.v2.AtlasEntityStream;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
@@ -49,11 +57,22 @@ import javax.inject.Inject;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 @Guice(modules = org.apache.atlas.TestModules.TestOnlyModule.class)
@@ -70,6 +89,9 @@ public class PurgeServiceTest extends AtlasTestBase {
     @Inject
     private AtlasGraph atlasGraph;
 
+    @Inject
+    private AtlasAuditService atlasAuditService;
+
     @BeforeClass
     public void setup() throws Exception {
         RequestContext.clear();
@@ -84,13 +106,16 @@ public class PurgeServiceTest extends AtlasTestBase {
     @Test
     public void testPurgeEntities() throws Exception {
         // Approach (pre-commit check on async flow):
-        // - Spy store's IAtlasEntityChangeNotifier and capture onEntitiesMutated(response,false) to assert
-        //   the purged GUID before commit/locking paths.
+        // - Spy store's IAtlasEntityChangeNotifier and capture onEntitiesMutated(response,false) per
+        //   worker batch to assert the purged GUID before commit/locking paths.
         // Create DB and table
         AtlasEntity db = newHiveDb(null);
         String dbGuid = persistAndGetGuid(db);
         AtlasEntity tbl = newHiveTable(db, null);
         String tblGuid = persistAndGetGuid(tbl);
+
+        // Clear context so a prior test's purge flags do not turn deleteByIds into purge mode
+        RequestContext.clear();
 
         // Soft-delete table
         EntityMutationResponse del = entityStore.deleteByIds(Collections.singletonList(tblGuid));
@@ -112,26 +137,211 @@ public class PurgeServiceTest extends AtlasTestBase {
         // Inject notifier spy to capture pre-commit signal (pre-commit verification point)
         Object originalNotifier = injectNotifierSpy(entityStore);
 
-        new PurgeService(atlasGraph, entityStore, typeRegistry).purgeEntities();
+        EntityMutationResponse purgeResponse = new PurgeService(atlasGraph, entityStore, typeRegistry, atlasAuditService).purgeEntities();
 
-        // Verify notifier call and capture response before transaction commit (async-safe via timeout)
+        // Verify notifier calls (one per worker batch; batch size 1 => one call per deletion candidate)
         IAtlasEntityChangeNotifier spy = (IAtlasEntityChangeNotifier) getNotifier(entityStore);
         ArgumentCaptor<EntityMutationResponse> cap = ArgumentCaptor.forClass(EntityMutationResponse.class);
-        Mockito.verify(spy, Mockito.timeout(5000)).onEntitiesMutated(cap.capture(), Mockito.eq(false));
+        Mockito.verify(spy, Mockito.timeout(5000).atLeastOnce())
+                .onEntitiesMutated(cap.capture(), Mockito.eq(false));
 
-        EntityMutationResponse notified = cap.getValue();
-        assertNotNull(notified);
-        List<AtlasEntityHeader> purged = notified.getPurgedEntities();
-        assertNotNull(purged);
+        List<AtlasEntityHeader> allPurged = new ArrayList<>();
+        for (EntityMutationResponse notified : cap.getAllValues()) {
+            assertNotNull(notified);
+            List<AtlasEntityHeader> batchPurged = notified.getPurgedEntities();
+            if (batchPurged != null) {
+                allPurged.addAll(batchPurged);
+            }
+        }
 
-        assertTrue(purged.stream().anyMatch(h -> tblGuid.equals(h.getGuid())));
+        assertTrue(allPurged.stream().anyMatch(h -> tblGuid.equals(h.getGuid())));
 
         // Restore original notifier to leave the store in a clean state
         restoreNotifier(entityStore, originalNotifier);
 
-        // Flag assertions
-        assertTrue(RequestContext.get().isPurgeRequested());
-        assertEquals(RequestContext.get().getDeleteType(), DeleteType.HARD);
+        // Verify purge response; notifier capture above is the pre-commit signal per worker batch.
+        assertNotNull(purgeResponse);
+        assertNotNull(purgeResponse.getPurgeSummary());
+        assertTrue(purgeResponse.getPurgeSummary().getRequestedCount() > 0,
+                "Expected index scan to find at least one purge-eligible entity");
+
+        List<AtlasEntityHeader> responsePurged = purgeResponse.getPurgedEntities();
+        if (responsePurged != null && !responsePurged.isEmpty()) {
+            long totalPurgedInSummary = purgeResponse.getPurgeSummary().getPurgedCount()
+                    + purgeResponse.getPurgeSummary().getPurgedDependenciesCount();
+            assertTrue(totalPurgedInSummary > 0,
+                    "Expected purge summary to report at least one purged entity");
+            assertTrue(responsePurged.stream().anyMatch(h -> tblGuid.equals(h.getGuid())));
+        }
+
+        assertFalse(RequestContext.get().isPurgeRequested(),
+                "Scheduled purge should reset purgeRequested on the cron thread");
+        assertEquals(RequestContext.get().getDeleteType(), DeleteType.DEFAULT,
+                "Scheduled purge should reset delete type on the cron thread");
+    }
+
+    @Test
+    public void testPurgeEntitiesMultipleIndexHits() throws Exception {
+        AtlasEntity db = newHiveDb(null);
+        persistAndGetGuid(db);
+
+        String tbl1Guid = persistAndGetGuid(newHiveTable(db, null));
+        String tbl2Guid = persistAndGetGuid(newHiveTable(db, null));
+
+        RequestContext.clear();
+
+        entityStore.deleteByIds(Collections.singletonList(tbl1Guid));
+        entityStore.deleteByIds(Collections.singletonList(tbl2Guid));
+
+        backdateModificationTimestamp(tbl1Guid, 31);
+        backdateModificationTimestamp(tbl2Guid, 31);
+        reindexVertices(tbl1Guid, tbl2Guid);
+        pauseForIndexCreation();
+
+        ApplicationProperties.get().setProperty("atlas.purge.enabled.services", "hive");
+        ApplicationProperties.get().setProperty("atlas.purge.workers.count", "1");
+        ApplicationProperties.get().setProperty("atlas.purge.worker.batch.size", "1");
+
+        RequestContext.clear();
+
+        Object originalNotifier = injectNotifierSpy(entityStore);
+
+        EntityMutationResponse purgeResponse = new PurgeService(atlasGraph, entityStore, typeRegistry, atlasAuditService).purgeEntities();
+
+        restoreNotifier(entityStore, originalNotifier);
+
+        assertNotNull(purgeResponse);
+        assertNotNull(purgeResponse.getPurgeSummary());
+        assertEquals(purgeResponse.getPurgeSummary().getRequestedCount(), 2,
+                "Expected two index hits for two purge-eligible tables");
+
+        Set<String> purgedGuids = new HashSet<>();
+        if (purgeResponse.getPurgedEntities() != null) {
+            for (AtlasEntityHeader header : purgeResponse.getPurgedEntities()) {
+                purgedGuids.add(header.getGuid());
+            }
+        }
+
+        assertTrue(purgedGuids.contains(tbl1Guid), "Expected first table to be purged");
+        assertTrue(purgedGuids.contains(tbl2Guid), "Expected second table to be purged");
+        assertNull(findByGuidFresh(tbl1Guid), "First table should be removed from graph");
+        assertNull(findByGuidFresh(tbl2Guid), "Second table should be removed from graph");
+
+        assertTrue(RequestContext.get().getDeletedEntities().isEmpty(),
+                "Cron producer thread should clear expansion delete records after each index hit");
+        assertFalse(RequestContext.get().isPurgeRequested());
+        assertEquals(RequestContext.get().getDeleteType(), DeleteType.DEFAULT);
+    }
+
+    /**
+     * Design v3 allows REST purge while scheduled purge is in progress. Overlapping GUIDs must be
+     * purged exactly once across both paths. When a path attempts to purge a GUID already removed
+     * by the other path, it records {@code INSTANCE_GUID_NOT_FOUND} as a skip — not
+     * {@code INTERNAL_ERROR}. Skippable failures are not required on every concurrent run (e.g.
+     * each path may win a different GUID, or scheduled index scan may miss entities REST already
+     * hard-purged).
+     */
+    @Test
+    public void testConcurrentScheduledAndRestPurgeOverlappingGuids() throws Exception {
+        AtlasEntity db = newHiveDb(null);
+        String dbGuid = persistAndGetGuid(db);
+        String tbl1Guid = persistAndGetGuid(newHiveTable(db, null));
+        String tbl2Guid = persistAndGetGuid(newHiveTable(db, null));
+
+        RequestContext.clear();
+        entityStore.deleteByIds(Arrays.asList(tbl1Guid, tbl2Guid));
+
+        backdateModificationTimestamp(tbl1Guid, 31);
+        backdateModificationTimestamp(tbl2Guid, 31);
+        reindexVertices(tbl1Guid, tbl2Guid);
+        pauseForIndexCreation();
+
+        ApplicationProperties.get().setProperty("atlas.purge.enabled.services", "hive");
+        ApplicationProperties.get().setProperty("atlas.purge.workers.count", "2");
+        ApplicationProperties.get().setProperty("atlas.purge.worker.batch.size", "1");
+
+        // Setup mutations above can leave an open graph txn on this thread; release it before
+        // concurrent purge workers start so main does not hold graphindex read locks.
+        RequestContext.clear();
+        GraphTransactionInterceptor.clearCache();
+        try {
+            atlasGraph.rollback();
+        } catch (Exception ignored) { }
+
+        Set<String> overlapGuids = new HashSet<>(Arrays.asList(tbl1Guid, tbl2Guid));
+        CountDownLatch startGate = new CountDownLatch(1);
+        AtomicReference<EntityMutationResponse> scheduledResponse = new AtomicReference<>();
+        AtomicReference<EntityMutationResponse> restResponse = new AtomicReference<>();
+        AtomicReference<Exception> scheduledError = new AtomicReference<>();
+        AtomicReference<Exception> restError = new AtomicReference<>();
+
+        PurgeService purgeService = new PurgeService(atlasGraph, entityStore, typeRegistry, atlasAuditService);
+
+        Thread scheduledThread = new Thread(() -> {
+            try {
+                startGate.await();
+                RequestContext.clear();
+                scheduledResponse.set(purgeService.purgeEntities());
+            } catch (Exception e) {
+                scheduledError.set(e);
+            } finally {
+                RequestContext.clear();
+                GraphTransactionInterceptor.clearCache();
+            }
+        }, "scheduled-purge-overlap");
+
+        Thread restThread = new Thread(() -> {
+            try {
+                startGate.await();
+                RequestContext.clear();
+                RequestContext.get().setUser(TestUtilsV2.TEST_USER, null);
+                restResponse.set(entityStore.purgeByIds(overlapGuids));
+            } catch (Exception e) {
+                restError.set(e);
+            } finally {
+                RequestContext.clear();
+                GraphTransactionInterceptor.clearCache();
+            }
+        }, "rest-purge-overlap");
+
+        scheduledThread.start();
+        restThread.start();
+        startGate.countDown();
+        scheduledThread.join(TimeUnit.SECONDS.toMillis(120));
+        restThread.join(TimeUnit.SECONDS.toMillis(120));
+
+        if (scheduledError.get() != null) {
+            throw scheduledError.get();
+        }
+        if (restError.get() != null) {
+            throw restError.get();
+        }
+
+        EntityMutationResponse scheduledResult = scheduledResponse.get();
+        EntityMutationResponse restResult = restResponse.get();
+        assertNotNull(scheduledResult, "Scheduled purge should return a response");
+        assertNotNull(restResult, "REST purge should return a response");
+
+        assertNoInternalErrorPurgeFailures(scheduledResult, "scheduled purge");
+        assertNoInternalErrorPurgeFailures(restResult, "REST purge");
+
+        Map<String, Integer> purgedCountByGuid = new HashMap<>();
+        collectPurgedGuidCounts(scheduledResult, purgedCountByGuid);
+        collectPurgedGuidCounts(restResult, purgedCountByGuid);
+
+        for (String guid : overlapGuids) {
+            assertEquals(purgedCountByGuid.getOrDefault(guid, 0).intValue(), 1,
+                    "Each overlapping GUID should be purged exactly once across both paths");
+            assertNull(findByGuidFresh(guid), "Purged table should be removed from graph: " + guid);
+        }
+
+        assertConcurrentOverlapFailuresAreSkippable(scheduledResult, overlapGuids);
+        assertConcurrentOverlapFailuresAreSkippable(restResult, overlapGuids);
+        assertEquals(countFailures(scheduledResult, false) + countFailures(restResult, false), 0,
+                "Concurrent overlap should not produce non-skippable purge failures");
+
+        assertNotNull(findByGuidFresh(dbGuid), "Parent DB should remain after table purge");
+        assertNoOrphanEdgesToPurgedGuids(dbGuid, overlapGuids);
     }
 
     private AtlasEntity newHiveDb(String nameOpt) {
@@ -165,12 +375,20 @@ public class PurgeServiceTest extends AtlasTestBase {
         return guid;
     }
 
+    private AtlasVertex findByGuidFresh(String guid) {
+        // WIM purge runs on worker threads; main-thread guidVertexCache can retain stale handles.
+        GraphTransactionInterceptor.clearCache();
+        return AtlasGraphUtilsV2.findByGuid(atlasGraph, guid);
+    }
+
     private void backdateModificationTimestamp(String guid, int days) {
         AtlasVertex v = AtlasGraphUtilsV2.findByGuid(atlasGraph, guid);
         if (v != null) {
             long delta = days * 24L * 60 * 60 * 1000;
             long ts = System.currentTimeMillis() - delta;
             AtlasGraphUtilsV2.setProperty(v, Constants.MODIFICATION_TIMESTAMP_PROPERTY_KEY, ts);
+            atlasGraph.commit();
+            GraphTransactionInterceptor.clearCache();
         }
     }
 
@@ -189,6 +407,8 @@ public class PurgeServiceTest extends AtlasTestBase {
             try {
                 atlasGraph.getManagementSystem().reindex(Constants.VERTEX_INDEX, elements);
                 atlasGraph.getManagementSystem().reindex(Constants.FULLTEXT_INDEX, elements);
+                atlasGraph.commit();
+                GraphTransactionInterceptor.clearCache();
             } catch (Exception ignored) { }
         }
     }
@@ -216,5 +436,72 @@ public class PurgeServiceTest extends AtlasTestBase {
         Field f = AtlasEntityStoreV2.class.getDeclaredField("entityChangeNotifier");
         f.setAccessible(true);
         f.set(storeV2, original);
+    }
+
+    private static void collectPurgedGuidCounts(EntityMutationResponse response, Map<String, Integer> purgedCountByGuid) {
+        if (response == null || response.getPurgedEntities() == null) {
+            return;
+        }
+
+        for (AtlasEntityHeader header : response.getPurgedEntities()) {
+            purgedCountByGuid.merge(header.getGuid(), 1, Integer::sum);
+        }
+    }
+
+    private static void assertNoInternalErrorPurgeFailures(EntityMutationResponse response, String pathLabel) {
+        if (response.getFailedEntities() == null) {
+            return;
+        }
+
+        for (FailedEntity failedEntity : response.getFailedEntities()) {
+            assertFalse(AtlasErrorCode.INTERNAL_ERROR.getErrorCode().equals(failedEntity.getErrorCode()),
+                    pathLabel + " should not record INTERNAL_ERROR for overlapping GUID handling: "
+                            + failedEntity.getGuid());
+        }
+    }
+
+    private static void assertConcurrentOverlapFailuresAreSkippable(EntityMutationResponse response,
+                                                                    Set<String> overlapGuids) {
+        if (response.getFailedEntities() == null) {
+            return;
+        }
+
+        for (FailedEntity failedEntity : response.getFailedEntities()) {
+            assertTrue(overlapGuids.contains(failedEntity.getGuid()),
+                    "Concurrent overlap failure should reference an overlapping GUID: " + failedEntity.getGuid());
+            assertTrue(PurgeUtils.isSkippablePurgeFailureCode(failedEntity.getErrorCode()),
+                    "Concurrent overlap failure must be skippable, not " + failedEntity.getErrorCode());
+        }
+    }
+
+    private static int countFailures(EntityMutationResponse response, boolean skippable) {
+        if (response.getFailedEntities() == null) {
+            return 0;
+        }
+
+        int count = 0;
+        for (FailedEntity failedEntity : response.getFailedEntities()) {
+            if (PurgeUtils.isSkippablePurgeFailureCode(failedEntity.getErrorCode()) == skippable) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private void assertNoOrphanEdgesToPurgedGuids(String anchorGuid, Set<String> purgedGuids) {
+        AtlasVertex anchorVertex = findByGuidFresh(anchorGuid);
+        assertNotNull(anchorVertex, "Anchor vertex should exist for orphan-edge check");
+
+        Iterator<AtlasEdge> edges = anchorVertex.getEdges(AtlasEdgeDirection.BOTH).iterator();
+        while (edges.hasNext()) {
+            AtlasEdge edge = edges.next();
+            String outGuid = AtlasGraphUtilsV2.getIdFromVertex(edge.getOutVertex());
+            String inGuid = AtlasGraphUtilsV2.getIdFromVertex(edge.getInVertex());
+            String otherGuid = anchorGuid.equals(outGuid) ? inGuid : outGuid;
+
+            assertFalse(purgedGuids.contains(otherGuid),
+                    "Anchor vertex should not retain edges to purged GUID: " + otherGuid);
+        }
     }
 }

--- a/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
+++ b/webapp/src/main/java/org/apache/atlas/web/resources/AdminResource.java
@@ -51,6 +51,7 @@ import org.apache.atlas.model.instance.AtlasCheckStateResult;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.PurgeSummary;
 import org.apache.atlas.model.metrics.AtlasMetrics;
 import org.apache.atlas.model.metrics.AtlasMetricsMapToChart;
 import org.apache.atlas.model.metrics.AtlasMetricsStat;
@@ -210,11 +211,11 @@ public class AdminResource {
 
     @Inject
     public AdminResource(ServiceState serviceState, MetricsService metricsService, AtlasTypeRegistry typeRegistry,
-            ExportService exportService, ImportService importService, SearchTracker activeSearches,
-            MigrationProgressService migrationProgressService, AtlasServerService serverService,
-            ExportImportAuditService exportImportAuditService, AtlasEntityStore entityStore,
-            AtlasPatchManager patchManager, AtlasAuditService auditService, EntityAuditRepository auditRepository,
-            TaskManagement taskManagement, AtlasDebugMetricsSink debugMetricsRESTSink, AtlasAuditReductionService atlasAuditReductionService, AtlasMetricsUtil atlasMetricsUtil,
+             ExportService exportService, ImportService importService, SearchTracker activeSearches,
+             MigrationProgressService migrationProgressService, AtlasServerService serverService,
+             ExportImportAuditService exportImportAuditService, AtlasEntityStore entityStore,
+             AtlasPatchManager patchManager, AtlasAuditService auditService, EntityAuditRepository auditRepository,
+             TaskManagement taskManagement, AtlasDebugMetricsSink debugMetricsRESTSink, AtlasAuditReductionService atlasAuditReductionService, AtlasMetricsUtil atlasMetricsUtil,
                          PurgeService purgeService) {
         this.serviceState              = serviceState;
         this.metricsService            = metricsService;
@@ -772,6 +773,22 @@ public class AdminResource {
         }
     }
 
+    /**
+     * Hard-purge entities in DELETED state by GUID.
+     * The response includes {@code mutatedEntities.PURGE}, {@code failedEntities}, and {@code summary}.
+     * Each entry in {@code failedEntities} carries {@code guid}, {@code errorCode}, and {@code errorMessage}.
+     * {@code summary} contains {@code requestedCount}, {@code purgedCount} (requested GUIDs purged),
+     * {@code purgedDependenciesCount} (dependency-expanded entities purged beyond the request),
+     * {@code failedCount} (non-skippable failures among originally requested GUIDs),
+     * {@code failedDependenciesCount} (non-skippable failures among dependency-expanded GUIDs),
+     * and {@code skippedCount}.
+     *
+     * @param guids set of entity GUIDs to purge
+     * @return consolidated purge result with per-GUID outcomes and summary counts
+     * @throws AtlasBaseException if the request exceeds {@code atlas.purge.api.max.request.size} or authorization fails
+     * @HTTP 200 the request was processed successfully. The response body contains detailed execution
+     *              outcomes, including purged, failed, and skipped counts.
+     */
     @PUT
     @Path("/purge")
     @Consumes(Servlets.JSON_MEDIA_TYPE)
@@ -787,16 +804,11 @@ public class AdminResource {
 
         try {
             if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
-                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "AdminResource.purgeByIds(" + guids + ")");
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG,
+                        "AdminResource.purgeByIds(count=" + (guids != null ? guids.size() : 0) + ")");
             }
 
             EntityMutationResponse resp = entityStore.purgeByIds(guids);
-
-            final List<AtlasEntityHeader> purgedEntities = resp.getPurgedEntities();
-
-            if (purgedEntities != null && !purgedEntities.isEmpty()) {
-                auditService.add(AuditOperation.PURGE, guids.toString(), resp.getPurgedEntitiesIds(), resp.getPurgedEntities().size());
-            }
 
             return resp;
         } finally {
@@ -806,33 +818,42 @@ public class AdminResource {
 
     @Scheduled(cron = "#{getPurgeCronExpression}")
     public void schedulePurgeEntities() throws AtlasBaseException {
+        boolean lockAcquired = false;
         try {
             Thread.currentThread().setName(PURGE_THREAD_NAME);
-            if (acquireCronPurgeOperationLock()) {
+            lockAcquired = acquireCronPurgeOperationLock();
+            if (!lockAcquired) {
+                LOG.info("==> Scheduled purge skipped because another purge operation is already running");
+            } else {
                 String state = serviceState.getState().toString();
                 LOG.info("==> Status of current node is {}", state);
                 if (state.equals(ACTIVE)) {
                     LOG.info("==> Scheduled Purging has started");
                     EntityMutationResponse entityMutationResponse = purgeService.purgeEntities();
-                    Set<String> guids = new HashSet<>();
 
                     final List<AtlasEntityHeader> purgedEntities = entityMutationResponse.getPurgedEntities() != null
                             ? entityMutationResponse.getPurgedEntities()
                             : Collections.emptyList();
 
+                    PurgeSummary summary = entityMutationResponse.getPurgeSummary();
+                    if (summary != null) {
+                        LOG.info("==> Purge execution summary: {}", summary);
+                    }
+
                     if (CollectionUtils.isEmpty(purgedEntities)) {
-                        LOG.info("==> no entities got purged");
+                        if (summary != null
+                                && (summary.getFailedCount() > 0
+                                || summary.getFailedDependenciesCount() > 0)) {
+                            LOG.info("==> no entities got purged, but encountered failures");
+                        } else if (summary != null && summary.getSkippedCount() > 0) {
+                            LOG.info("==> no entities got purged, but some were skipped");
+                        } else {
+                            LOG.info("==> no entities got purged");
+                        }
                         return;
                     }
 
-                    for (AtlasEntityHeader entityHeader : entityMutationResponse.getPurgedEntities()) {
-                        guids.add(entityHeader.getGuid());
-                    }
-
                     LOG.info("==> Purged Entities {}", purgedEntities.size());
-
-                    auditService.add(AuditOperation.AUTO_PURGE, guids.toString(), entityMutationResponse.getPurgedEntitiesIds(),
-                            entityMutationResponse.getPurgedEntities().size());
 
                     LOG.info("==> Scheduled Purging has finished");
                 } else {
@@ -845,7 +866,9 @@ public class AdminResource {
         } finally {
             RequestContext.clear();
             LOG.info("==> clearing the context");
-            cronPurgeOperationLock.unlock();
+            if (lockAcquired) {
+                cronPurgeOperationLock.unlock();
+            }
         }
     }
 

--- a/webapp/src/test/java/org/apache/atlas/web/errors/AtlasBaseExceptionMapperTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/errors/AtlasBaseExceptionMapperTest.java
@@ -38,6 +38,25 @@ public class AtlasBaseExceptionMapperTest {
     }
 
     @Test
+    public void testPurgeRequestSizeExceedsLimitMapsToHttp400() {
+        AtlasBaseException exception = new AtlasBaseException(
+                AtlasErrorCode.PURGE_REQUEST_SIZE_EXCEEDS_LIMIT, "1001", "1000");
+
+        Response response = atlasBaseExceptionMapper.toResponse(exception);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+        assertNotNull(response.getEntity());
+
+        String entity = (String) response.getEntity();
+        assertTrue(entity.contains(AtlasErrorCode.PURGE_REQUEST_SIZE_EXCEEDS_LIMIT.getErrorCode()));
+        assertTrue(entity.contains("errorCode"));
+        assertTrue(entity.contains("errorMessage"));
+        assertTrue(entity.contains("1001"));
+        assertTrue(entity.contains("1000"));
+    }
+
+    @Test
     public void testToResponse() {
         // Test the toResponse method execution
         // This tests the main functionality including exception handling and response building

--- a/webapp/src/test/java/org/apache/atlas/web/resources/AdminResourceTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/resources/AdminResourceTest.java
@@ -42,6 +42,7 @@ import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
 import org.apache.atlas.model.instance.AtlasObjectId;
 import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.model.instance.PurgeSummary;
 import org.apache.atlas.model.metrics.AtlasMetrics;
 import org.apache.atlas.model.metrics.AtlasMetricsMapToChart;
 import org.apache.atlas.model.metrics.AtlasMetricsStat;
@@ -93,6 +94,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -246,6 +248,22 @@ public class AdminResourceTest {
         responseField.set(adminResource, httpServletResponse);
     }
 
+    private static PurgeSummary buildPurgeSummary(long requested, long purged, long purgedDeps,
+                                                                         long failed, long failedDeps, long skipped,
+                                                                         boolean executionFailed) {
+        return buildPurgeSummary(requested, purged, purgedDeps, failed, failedDeps, skipped, 0, executionFailed);
+    }
+
+    private static PurgeSummary buildPurgeSummary(long requested, long purged, long purgedDeps,
+                                                                         long failed, long failedDeps, long skipped,
+                                                                         long validGuidCount, boolean executionFailed) {
+        PurgeSummary summary =
+                new PurgeSummary(requested, purged, purgedDeps, failed, failedDeps, skipped);
+        summary.setValidGuidCount(validGuidCount);
+        summary.setExecutionFailed(executionFailed);
+        return summary;
+    }
+
     @Test
     public void testGetThreadDump() {
         AdminResource adminResource = createAdminResource();
@@ -342,7 +360,6 @@ public class AdminResourceTest {
     public void testPurgeByIds() throws Exception {
         Set<String> guids = new HashSet<>();
         guids.add("guid1");
-        guids.add("guid2");
 
         EntityMutationResponse mockResponse = mock(EntityMutationResponse.class);
         List<AtlasEntityHeader> purgedEntities = new ArrayList<>();
@@ -352,8 +369,11 @@ public class AdminResourceTest {
         when(entityStore.purgeByIds(guids)).thenReturn(mockResponse);
         when(mockResponse.getPurgedEntities()).thenReturn(purgedEntities);
         when(mockResponse.getPurgedEntitiesIds()).thenReturn(String.valueOf(new ArrayList<>(guids)));
+        when(mockResponse.getFailedEntities()).thenReturn(null);
+        when(mockResponse.getPurgeSummary()).thenReturn(new PurgeSummary(1, 1, 0, 0, 0));
 
         AdminResource adminResource = createAdminResource();
+        injectHttpServletResponse(adminResource);
 
         EntityMutationResponse result = adminResource.purgeByIds(guids);
 
@@ -370,12 +390,62 @@ public class AdminResourceTest {
         when(mockResponse.getPurgedEntities()).thenReturn(new ArrayList<>());
 
         AdminResource adminResource = createAdminResource();
+        injectHttpServletResponse(adminResource);
 
         EntityMutationResponse result = adminResource.purgeByIds(emptyGuids);
 
         assertNotNull(result);
         verify(entityStore).purgeByIds(emptyGuids);
-        // Should not call audit service for empty results
+    }
+
+    @Test
+    public void testPurgeByIdsRequestSizeExceedsLimit() throws Exception {
+        Set<String> guids = new LinkedHashSet<>();
+        for (int i = 0; i < 1001; i++) {
+            guids.add(String.format("11111111-1111-1111-1111-%012d", i));
+        }
+
+        when(entityStore.purgeByIds(guids)).thenThrow(new AtlasBaseException(
+                AtlasErrorCode.PURGE_REQUEST_SIZE_EXCEEDS_LIMIT,
+                String.valueOf(guids.size()), "1000"));
+
+        AdminResource adminResource = createAdminResource();
+        injectHttpServletResponse(adminResource);
+
+        try {
+            adminResource.purgeByIds(guids);
+            fail("Expected AtlasBaseException for request size exceeding limit");
+        } catch (AtlasBaseException e) {
+            assertEquals(e.getAtlasErrorCode(), AtlasErrorCode.PURGE_REQUEST_SIZE_EXCEEDS_LIMIT);
+            assertTrue(e.getMessage().contains("1001"));
+            assertTrue(e.getMessage().contains("1000"));
+        }
+
+        verify(entityStore).purgeByIds(guids);
+        verify(httpServletResponse, never()).setStatus(anyInt());
+    }
+
+    @Test
+    public void testPurgeByIdsDoesNotWriteAggregateAudit() throws Exception {
+        Set<String> guids = new LinkedHashSet<>();
+        for (int i = 0; i < 15; i++) {
+            guids.add(String.format("11111111-1111-1111-1111-%012d", i));
+        }
+
+        EntityMutationResponse mockResponse = mock(EntityMutationResponse.class);
+        List<AtlasEntityHeader> purgedEntities = new ArrayList<>();
+        purgedEntities.add(mock(AtlasEntityHeader.class));
+
+        when(entityStore.purgeByIds(guids)).thenReturn(mockResponse);
+        when(mockResponse.getPurgedEntities()).thenReturn(purgedEntities);
+        when(mockResponse.getFailedEntities()).thenReturn(null);
+        when(mockResponse.getPurgeSummary()).thenReturn(new PurgeSummary(15, 15, 0, 0, 0));
+
+        AdminResource adminResource = createAdminResource();
+        injectHttpServletResponse(adminResource);
+
+        adminResource.purgeByIds(guids);
+
         verify(auditService, never()).add(any(), anyString(), any(), anyInt());
     }
 


### PR DESCRIPTION
## Attachments
1. **Design specification:**[ATLAS-5317-Resilient-Bulk-Purge-In-Atlas-DESIGN.pdf](https://github.com/user-attachments/files/29999296/ATLAS-5317-Resilient-Bulk-Purge-In-Atlas-DESIGN.pdf)`
2. **Implementation notes:** [ATLAS-5317-Resilient-Bulk-Purge-In-Atlas-IMPLEMENTATION_NOTES.docx](https://github.com/user-attachments/files/29999318/ATLAS-5317-Resilient-Bulk-Purge-In-Atlas-IMPLEMENTATION_NOTES.docx)

---

## What changes were proposed in this pull request?

This PR implements resilient bulk purge per the attached design specification (*Resilient Bulk Purge in Atlas Using Transaction Batching*). It replaces the old single-transaction REST bulk purge with pre-validated, worker-batch processing shared by REST and scheduled (cron) purge.
### Key changes
- **Pre-validation before writes** — REST purge GUIDs are checked for UUID format, graph existence, DELETED state, and registered type before any mutation. Invalid GUIDs are returned in `failedEntities` with `errorCode` / `errorMessage`.
- **Request size limit** — New config `atlas.purge.api.max.request.size` (default 1000) caps GUIDs per REST purge request.
- **Shared worker-batch path** — REST and cron both use `PurgeBatchOrchestrator` / `WorkItemManager` with `atlas.purge.worker.batch.size` (default 100) and `atlas.purge.workers.count` (default 2).
- **Isolated batch transactions** — Each worker batch runs in its own graph transaction. Lock conflicts retry at batch level; other batch failures roll back only that batch and processing continues.
- **Partial success** — Earlier committed batches are kept when a later batch fails permanently.
- **Enriched response** — `EntityMutationResponse` adds `failedEntities` and `PurgeSummary` (including `purgedDependenciesCount` / `failedDependenciesCount`).
- **Per-batch audit** — Successful batches write bounded PURGE / AUTO_PURGE audit entries (up to 10 sample GUIDs), not one large entry per REST/cron call.
- **Cron alignment** — Scheduled purge keeps its existing worker-batch model; REST is aligned to that path with shared orchestration, enriched accounting, batch retry, and shutdown reconciliation.
- **Parallel-batch hardening** — `DeleteHandlerV1` tolerates vertices/edges already removed by another worker (ATLAS-4766). `accumulateDeletionCandidates()` returns `Set<String>` (GUIDs) for worker-safe enqueueing.
- **Schema** — `AUTO_PURGE` added to `atlas_operation` in `0010-base_model.json` for scheduled purge audit on fresh installs.
### Compatibility and behavior notes
- `accumulateDeletionCandidates()` now returns `Set<String>` (GUIDs) instead of `Set<AtlasVertex>`. Custom `AtlasEntityStore` implementations should update their method signature; Apache Atlas ships only `AtlasEntityStoreV2`.
- Missing or ineligible GUIDs appear in `failedEntities` on REST (no longer silently ignored).
- Completed purge responses return HTTP 200 with outcome in the body — read `summary` and `failedEntities` for the result (implementation plan Section 10).
- Large purges produce multiple audit entries (one per successful worker batch).
For full flow, design deviations, configuration, and review focus areas, see the attached implementation plan.
---



## How was this patch tested?

Unit and module tests were added or extended in this PR. 
| Area | Test class | Coverage |
|------|------------|----------|
| Worker orchestration | `PurgeBatchOrchestratorTest`, `PurgeBatchExecutorTest` | WIM lifecycle, batch commit, lock retry, shutdown reconciliation, per-batch audit |
| Store / REST purge | `AtlasEntityStoreV2Test` | Pre-validation, size limit, success/partial failure, dependency expansion, concurrent expansion vs worker delete, summary accounting |
| Scheduled purge | `PurgeServiceTest` | Shared worker path, REST/cron GUID overlap |
| Delete handler | `DeleteHandlerV1Test` | Parallel batch purge; skip already-removed vertices/edges |
| REST layer | `AdminResourceTest`, `AtlasBaseExceptionMapperTest` | No aggregate audit on REST purge; request-size-exceeded → HTTP 400 |
| Client / model | `AtlasClientV2Test`, `TestEntityMutationResponse` | HTTP 200 + purge field deserialization; `addEntity` GUID dedup |
| End-to-end purge | `AdminPurgeTest` | REST purge with enriched response and summary |

Detailed test mapping: implementation plan Section 11.

**Suggested verification commands:**
```bash
mvn test -pl repository \
  -Dtest=PurgeBatchOrchestratorTest,PurgeBatchExecutorTest,PurgeServiceTest,AtlasEntityStoreV2Test,DeleteHandlerV1Test,AdminPurgeTest \
  -Drat.skip=true
mvn test -pl webapp \
  -Dtest=AdminResourceTest,AtlasBaseExceptionMapperTest \
  -Drat.skip=true
mvn test -pl intg,client/client-v2 \
  -Dtest=TestEntityMutationResponse,AtlasClientV2Test \
  -Drat.skip=true
