### PR TITLE
ATLAS-5347: Atlas React UI: Skeleton loader stuck indefinitely in Administration Audit tab when expanding Purge/Auto-Purge entity details

### DIFF
--- a/dashboard/src/views/Administrator/Audits/AuditResults.tsx
+++ b/dashboard/src/views/Administrator/Audits/AuditResults.tsx
@@ -232,7 +232,7 @@ const AuditResults = ({ componentProps, row }: any) => {
           button2Handler={undefined}
           maxWidth="lg"
         >
-          <AuditsTab auditResultGuid={currentPurgeResultObj} />
+          <AuditsTab auditResultGuid={currentPurgeResultObj} loading={false} />
         </CustomModal>
       )}
     </>

--- a/dashboard/src/views/Administrator/Audits/__tests__/AuditResults.test.tsx
+++ b/dashboard/src/views/Administrator/Audits/__tests__/AuditResults.test.tsx
@@ -112,8 +112,8 @@ jest.mock('@utils/Muiutils', () => ({
 
 jest.mock('@views/DetailPage/EntityDetailTabs/AuditsTab', () => ({
   __esModule: true,
-  default: ({ auditResultGuid }: any) => (
-    <div data-testid="audits-tab">AuditsTab - {auditResultGuid}</div>
+  default: ({ auditResultGuid, loading }: any) => (
+    <div data-testid="audits-tab" data-loading={loading}>AuditsTab - {auditResultGuid}</div>
   )
 }));
 
@@ -425,6 +425,7 @@ describe('AuditResults Component', () => {
 
       expect(screen.getByTestId('modal-title')).toHaveTextContent('Purged Entity Details: guid-1');
       expect(screen.getByTestId('audits-tab')).toBeInTheDocument();
+      expect(screen.getByTestId('audits-tab')).toHaveAttribute('data-loading', 'false');
     });
 
     it('should open auto purge modal with correct title', async () => {

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/AttributeProperties.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/AttributeProperties.tsx
@@ -222,7 +222,7 @@ const AttributeProperties = ({
           </Stack>
         </AccordionSummary>
         <AccordionDetails>
-          {loading == undefined || loading || isEmpty(entityData) ? (
+          {loading === true || (!auditDetails && isEmpty(entityData)) ? (
             <>
               <SkeletonLoader count={3} animation="wave" />
             </>

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/__tests__/AttributeProperties.test.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/__tests__/AttributeProperties.test.tsx
@@ -325,7 +325,7 @@ describe('AttributeProperties', () => {
 			expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
 		});
 
-		it('should render loading skeleton when loading is undefined', () => {
+		it('should render properties when loading is undefined and entityData is available', () => {
 			render(
 				<TestWrapper>
 					<AttributeProperties
@@ -337,7 +337,7 @@ describe('AttributeProperties', () => {
 				</TestWrapper>
 			);
 
-			expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
+			expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument();
 		});
 
 		it('should render loading skeleton when entityData is empty', () => {

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/__tests__/AttributeProperties.test.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/__tests__/AttributeProperties.test.tsx
@@ -364,6 +364,40 @@ describe('AttributeProperties', () => {
 			expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
 		});
 
+		it('should not render skeleton in auditDetails mode when loading is undefined', () => {
+			mockUseSelector.mockImplementation((selector: any) =>
+				selector({ entity: { entityData: {} } })
+			);
+			render(
+				<TestWrapper>
+					<AttributeProperties
+						entity={defaultMockEntity}
+						referredEntities={defaultMockReferredEntities}
+						loading={undefined}
+						auditDetails={true}
+						propertiesName="Technical"
+					/>
+				</TestWrapper>
+			);
+			expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument();
+			expect(screen.getByText('Technical Properties')).toBeInTheDocument();
+		});
+
+		it('should render skeleton in auditDetails mode when loading is true', () => {
+			render(
+				<TestWrapper>
+					<AttributeProperties
+						entity={defaultMockEntity}
+						referredEntities={defaultMockReferredEntities}
+						loading={true}
+						auditDetails={true}
+						propertiesName="Technical"
+					/>
+				</TestWrapper>
+			);
+			expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
+		});
+
 		it('should render "No Record Found" when properties are empty', () => {
 			const emptyEntity = {
 				typeName: 'DataSet',


### PR DESCRIPTION
## What changes were proposed in this pull request?

**ATLAS-5347: Fix Skeleton Loader stuck indefinitely in Administration Audit tab for Purge operations**

When expanding the details for `PURGE` or `AUTO_PURGE` operations in the React UI Administration Audits tab, the skeleton loader would get stuck spinning indefinitely. 

This patch fixes the issue by:
1. Explicitly passing `loading={false}` to `<AuditsTab />` within `AuditResults.tsx`.
2. Updating the rendering condition in `AttributeProperties.tsx` to strictly check for `loading === true` rather than defaulting to the skeleton loader when `loading` is undefined.
3. Updating the corresponding Jest unit tests in `AttributeProperties.test.tsx` to match the new strict conditional rendering logic.

## How was this patch tested?

- **Manual Testing:** Verified locally that expanding `PURGE` and `AUTO_PURGE` operations in the Administration Audits UI successfully loads the data without freezing the skeleton loader.
- **Unit Tests:** Updated and successfully ran Jest unit tests (`AttributeProperties.test.tsx`) to verify that the loader disappears correctly when entity data is available and `loading` is not explicitly set to `true`.
