### PR TITLE
ATLAS-5321 : Fix basic search by glossary termName after parent gloss…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/SearchContext.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/SearchContext.java
@@ -23,11 +23,9 @@ import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.discovery.SearchParameters;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.typedef.AtlasClassificationDef;
-import org.apache.atlas.repository.Constants;
 import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.graphdb.AtlasEdge;
 import org.apache.atlas.repository.graphdb.AtlasGraph;
-import org.apache.atlas.repository.graphdb.AtlasGraphQuery;
 import org.apache.atlas.repository.graphdb.AtlasVertex;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.atlas.repository.store.graph.v2.EntityGraphRetriever;
@@ -48,7 +46,9 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -582,15 +582,16 @@ public class SearchContext {
         AtlasVertex ret = null;
 
         if (StringUtils.isNotEmpty(termName)) {
-            AtlasEntityType termType = getTermEntityType();
-            AtlasAttribute  attrName = termType.getAttribute(TermSearchProcessor.ATLAS_GLOSSARY_TERM_ATTR_QNAME);
-            AtlasGraphQuery query    = graph.query().has(Constants.ENTITY_TYPE_PROPERTY_KEY, termType.getTypeName())
-                    .has(attrName.getVertexPropertyName(), termName)
-                    .has(Constants.STATE_PROPERTY_KEY, AtlasEntity.Status.ACTIVE.name());
+            AtlasEntityType     termType       = getTermEntityType();
+            Map<String, Object> uniqAttributes = new HashMap<>();
 
-            Iterator<AtlasVertex> results = query.vertices().iterator();
+            uniqAttributes.put(TermSearchProcessor.ATLAS_GLOSSARY_TERM_ATTR_QNAME, termName);
 
-            ret = results.hasNext() ? results.next() : null;
+            ret = AtlasGraphUtilsV2.findByUniqueAttributes(graph, termType, uniqAttributes);
+
+            if (ret != null && AtlasGraphUtilsV2.getState(ret) != AtlasEntity.Status.ACTIVE) {
+                ret = null;
+            }
         }
 
         return ret;

--- a/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
+++ b/repository/src/main/java/org/apache/atlas/glossary/GlossaryService.java
@@ -311,8 +311,10 @@ public class GlossaryService {
         if (!storeObject.equals(atlasGlossary)) {
             atlasGlossary.setGuid(storeObject.getGuid());
             atlasGlossary.setQualifiedName(storeObject.getQualifiedName());
+            atlasGlossary.setTerms(null);
+            atlasGlossary.setCategories(null);
 
-            storeObject = dataAccess.save(atlasGlossary);
+            storeObject = dataAccess.savePartial(atlasGlossary);
 
             setInfoForRelations(storeObject);
         }

--- a/repository/src/main/java/org/apache/atlas/repository/ogm/DataAccess.java
+++ b/repository/src/main/java/org/apache/atlas/repository/ogm/DataAccess.java
@@ -63,6 +63,12 @@ public class DataAccess {
         return this.load(obj);
     }
 
+    public <T extends AtlasBaseModelObject> T savePartial(T obj) throws AtlasBaseException {
+        savePartialNoLoad(obj);
+
+        return this.load(obj);
+    }
+
     public <T extends AtlasBaseModelObject> void saveNoLoad(T obj) throws AtlasBaseException {
         requireNonNull(obj, "Can't save a null object");
 
@@ -77,6 +83,34 @@ public class DataAccess {
 
             AtlasEntityWithExtInfo entityWithExtInfo      = dto.toEntityWithExtInfo(obj);
             EntityMutationResponse entityMutationResponse = entityStore.createOrUpdate(new AtlasEntityStream(entityWithExtInfo), false);
+
+            // Update GUID assignment for newly created entity
+            if (CollectionUtils.isNotEmpty(entityMutationResponse.getCreatedEntities())) {
+                String assignedGuid = entityMutationResponse.getGuidAssignments().get(obj.getGuid());
+
+                if (!obj.getGuid().equals(assignedGuid)) {
+                    obj.setGuid(assignedGuid);
+                }
+            }
+        } finally {
+            AtlasPerfTracer.log(perf);
+        }
+    }
+
+    public <T extends AtlasBaseModelObject> void savePartialNoLoad(T obj) throws AtlasBaseException {
+        requireNonNull(obj, "Can't save a null object");
+
+        AtlasPerfTracer perf = null;
+
+        try {
+            if (AtlasPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+                perf = AtlasPerfTracer.getPerfTracer(PERF_LOG, "DataAccess.savePartial()");
+            }
+
+            DataTransferObject<T> dto = dtoRegistry.get((Class<T>) obj.getClass());
+
+            AtlasEntityWithExtInfo entityWithExtInfo      = dto.toEntityWithExtInfo(obj);
+            EntityMutationResponse entityMutationResponse = entityStore.createOrUpdate(new AtlasEntityStream(entityWithExtInfo), true);
 
             // Update GUID assignment for newly created entity
             if (CollectionUtils.isNotEmpty(entityMutationResponse.getCreatedEntities())) {

--- a/repository/src/test/java/org/apache/atlas/discovery/AtlasDiscoveryServiceTest.java
+++ b/repository/src/test/java/org/apache/atlas/discovery/AtlasDiscoveryServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.atlas.discovery;
 
 import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasClient;
+import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.BasicTestSetup;
 import org.apache.atlas.SortOrder;
 import org.apache.atlas.TestModules;
@@ -29,6 +30,7 @@ import org.apache.atlas.model.discovery.AtlasSearchResult;
 import org.apache.atlas.model.discovery.QuickSearchParameters;
 import org.apache.atlas.model.discovery.RelationshipSearchParameters;
 import org.apache.atlas.model.discovery.SearchParameters;
+import org.apache.atlas.model.glossary.AtlasGlossary;
 import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.model.instance.AtlasEntity;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
@@ -109,6 +111,26 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
         SearchParameters params = new SearchParameters();
 
         params.setTermName(SALES_TERM + "@" + SALES_GLOSSARY);
+
+        assertSearchProcessorWithoutMarker(params, 10);
+    }
+
+    @Test
+    public void termSearchAfterGlossaryUpdate() throws AtlasBaseException {
+        List<AtlasGlossary> glossaries = glossaryService.getGlossaries(100, 0, SortOrder.ASCENDING);
+        AtlasGlossary       glossary   = glossaries.stream()
+                .filter(g -> SALES_GLOSSARY.equals(g.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AtlasBaseException(AtlasErrorCode.BAD_REQUEST, "Glossary not found: " + SALES_GLOSSARY));
+
+        SearchParameters params = new SearchParameters();
+
+        params.setTermName(SALES_TERM + "@" + SALES_GLOSSARY);
+
+        assertSearchProcessorWithoutMarker(params, 10);
+
+        glossary.setShortDescription("updated after glossary update");
+        glossaryService.updateGlossary(glossary);
 
         assertSearchProcessorWithoutMarker(params, 10);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Basic Search (POST /api/atlas/v2/search/basic) with the termName parameter fails with ATLAS-400-00-06E ("Unknown/invalid glossary term") after the parent glossary is updated, even though the term still exists and can be retrieved by GUID. This patch fixes term resolution in search and hardens glossary update persistence.

**Root cause**
SearchContext.getGlossaryTermVertex() used a raw JanusGraph composite query (entity type + qualifiedName + ACTIVE) to validate glossary terms. After a glossary update, this lookup could fail while the term remained in the graph. The rest of Atlas (GlossaryService, EntityStore, etc.) resolves terms via AtlasGraphUtilsV2.findByUniqueAttributes(), which uses the __u_qualifiedName global unique index.

**Changes:-**

1) SearchContext.java (primary fix)
1.1. --Updated getGlossaryTermVertex() to use AtlasGraphUtilsV2.findByUniqueAttributes() instead of a direct composite graph query.
1.2. --Added an explicit check that the resolved term vertex is in ACTIVE state before proceeding.
1.3. --Aligns Basic Search term validation with the canonical lookup used elsewhere in Atlas.

2) GlossaryService.java (hardening)
2.1. -- Updated updateGlossary() to clear in-memory terms and categories before persisting.
2.2. -- Switched from dataAccess.save() (full update) to dataAccess.savePartial() so glossary attribute-only changes use partial update semantics.


3) DataAccess.java (supporting API)
3.1. -- Added savePartial() and savePartialNoLoad() methods that invoke entityStore.createOrUpdate(..., isPartialUpdate=true).

4) AtlasDiscoveryServiceTest.java (regression test)
4.1. -- Added termSearchAfterGlossaryUpdate() to verify basic search by term qualified name succeeds both before and after a glossary update.

**How was this patch tested?**
**Unit tests**

- -Added AtlasDiscoveryServiceTest#termSearchAfterGlossaryUpdate
- -Creates/finds the test glossary and term from existing test setup
- -Performs basic search by termName (qualified name)
- -Updates the glossary via GlossaryService.updateGlossary()
- -Re-runs the same basic search and asserts it still succeeds

## How was this patch tested?
Manual tests:-
1) Created glossary (e.g. gloss5321test142500)
2) Created term via POST /api/atlas/v2/glossary/term with anchor to glossary
3) Ran POST /api/atlas/v2/search/basic with "termName": "term2@gloss5321test142500" → 200 OK, "queryType": "BASIC", no ATLAS-400-00-06E
4) Updated glossary via:
5) PUT /api/atlas/v2/glossary/{guid}/partial (partial update), and
6) PUT /api/atlas/v2/glossary/{guid} (full update)
7) Re-ran the same basic search → 200 OK, no ATLAS-400-00-06E
8) Confirmed term still exists via GET /api/atlas/v2/glossary/term/{termGuid} with unchanged qualifiedName.