### PR TITLE
ATLAS-5325 : Atlas startup failure in embedded-hbase-solr profile due…

### DIFF
--- a/graphdb/janus/pom.xml
+++ b/graphdb/janus/pom.xml
@@ -90,17 +90,6 @@
             <version>${hadoop.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase-shaded-mapreduce</artifactId>
-            <version>${hbase.version}-hadoop3</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-distcp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
             <version>${lucene-solr.version}</version>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -555,7 +555,7 @@
                             <addClasspath>true</addClasspath>
                         </manifest>
                     </archive>
-                    <packagingExcludes>WEB-INF/lib/hbase-shaded-client-${hbase.version}-hadoop3.jar,WEB-INF/lib/dom4j-*.jar,WEB-INF/lib/jsp-api*.jar,${packages.to.exclude}</packagingExcludes>
+                    <packagingExcludes>WEB-INF/lib/hbase-shaded-client-${hbase.version}-hadoop3.jar,WEB-INF/lib/hbase-shaded-mapreduce-${hbase.version}-hadoop3.jar,WEB-INF/lib/dom4j-*.jar,WEB-INF/lib/jsp-api*.jar,${packages.to.exclude}</packagingExcludes>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
… to conflicting HBase shaded MapReduce dependency

What changes were proposed in this pull request?
Removed the direct hbase-shaded-mapreduce dependency from graphdb/janus/pom.xml to eliminate HBase shaded classpath conflicts at runtime.
Added hbase-shaded-mapreduce-${hbase.version}-hadoop3.jar to packagingExcludes in webapp/pom.xml to prevent it from being packaged in the Atlas distribution.

How was this patch tested?

Manual testing :- mvn -Pdist,embedded-hbase-solr -DskipTests clean package
Verified hbase-shaded-mapreduce-2.6.4-hadoop3.jar is not packaged under server/webapp/atlas/WEB-INF/lib/.
Started Atlas with embedded HBase and Solr.
Confirmed Atlas starts successfully without the NoSuchMethodError.
Verified the Atlas UI is accessible after startup.
