### PR TITLE
ATLAS-5366 - Exclude node_modules from source release tarball

### DIFF
--- a/distro/src/main/assemblies/src-package.xml
+++ b/distro/src/main/assemblies/src-package.xml
@@ -44,11 +44,11 @@
                 <exclude>**/${sys:atlas.data}/**</exclude>
                 <exclude>**/atlas.data/**</exclude>
                 <exclude>**/*.patch</exclude>
-                <exclude>dashboardv2/node_modules/**</exclude>
+                <exclude>**/node_modules/**</exclude>
+                <exclude>**/.frontend-toolchain/**</exclude>
                 <exclude>dev-support/atlas-docker/data/**</exclude>
                 <exclude>dev-support/atlas-docker/dist/**</exclude>
                 <exclude>dev-support/atlas-docker/downloads/**</exclude>
-                <exclude>docs/node_modules/**</exclude>
             </excludes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update _distro/src/main/assemblies/src-package.xml_ to exclude all frontend dependency directories:

```
<exclude>**/node_modules/**</exclude>
<exclude>**/.frontend-toolchain/**</exclude>
```
Remove the module-specific exclusions (_dashboardv2/node_modules/**, docs/node_modules/**_) since the glob pattern covers all modules.


## How was this patch tested?

After applying the fix and rebuilding:
`mvn clean package -Pdist -DskipTests
`
`tar tzf distro/target/apache-atlas-2.6.0-sources.tar.gz | grep node_modules` # Must return no output