### PR TITLE
ATLAS-5365: Missing SERVICE_NOTIFICATION_POST authorization on rest-notification NotificationREST POST /topic/{topicName}.

### DIFF
--- a/rest-notification-webapp/src/main/java/org/apache/atlas/notification/rest/web/rest/NotificationREST.java
+++ b/rest-notification-webapp/src/main/java/org/apache/atlas/notification/rest/web/rest/NotificationREST.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.authorize.AtlasAdminAccessRequest;
+import org.apache.atlas.authorize.AtlasAuthorizationUtils;
+import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.hook.AtlasHook;
 import org.apache.atlas.kafka.KafkaNotification;
@@ -87,6 +90,8 @@ public class NotificationREST {
     @Consumes({Servlets.JSON_MEDIA_TYPE, MediaType.APPLICATION_JSON})
     public void handleNotifications(@PathParam("topicName") String topicName, @Context HttpServletRequest request) throws AtlasBaseException, IOException {
         LOG.debug("Handling notifications for topic {}", topicName);
+
+        AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.SERVICE_NOTIFICATION_POST), "post on rest notification service");
 
         if (!TOPICS.contains(topicName)) {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_TOPIC_NAME, topicName);

--- a/rest-notification-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/rest-notification-webapp/src/main/webapp/WEB-INF/web.xml
@@ -32,14 +32,6 @@
             com.sun.jersey.spi.spring.container.servlet.SpringServlet
         </servlet-class>
         <init-param>
-            <param-name>com.sun.jersey.config.property.resourceClassNames</param-name>
-            <param-value>org.apache.atlas.notification.rest.web.rest.NotificationREST;org.apache.atlas.notification.rest.web.resources.AdminResource</param-value>
-        </init-param>
-        <init-param>
-            <param-name>com.sun.jersey.config.property.provider.classnames</param-name>
-            <param-value>org.apache.atlas.server.common.errors.AtlasBaseExceptionMapper;org.apache.atlas.server.common.errors.AllExceptionMapper;org.apache.atlas.server.common.errors.NotFoundExceptionMapper</param-value>
-        </init-param>
-        <init-param>
             <param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
             <param-value>true</param-value>
         </init-param>

--- a/rest-notification-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/rest-notification-webapp/src/main/webapp/WEB-INF/web.xml
@@ -32,8 +32,12 @@
             com.sun.jersey.spi.spring.container.servlet.SpringServlet
         </servlet-class>
         <init-param>
-            <param-name>com.sun.jersey.config.property.packages</param-name>
-            <param-value>org.apache.atlas.notification.rest</param-value>
+            <param-name>com.sun.jersey.config.property.resourceClassNames</param-name>
+            <param-value>org.apache.atlas.notification.rest.web.rest.NotificationREST;org.apache.atlas.notification.rest.web.resources.AdminResource</param-value>
+        </init-param>
+        <init-param>
+            <param-name>com.sun.jersey.config.property.provider.classnames</param-name>
+            <param-value>org.apache.atlas.server.common.errors.AtlasBaseExceptionMapper;org.apache.atlas.server.common.errors.AllExceptionMapper;org.apache.atlas.server.common.errors.NotFoundExceptionMapper</param-value>
         </init-param>
         <init-param>
             <param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>

--- a/server-common/pom.xml
+++ b/server-common/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>jersey-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/server-common/src/main/java/org/apache/atlas/server/common/errors/AllExceptionMapper.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/errors/AllExceptionMapper.java
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.atlas.web.errors;
 
-import org.apache.atlas.exception.NotFoundException;
+package org.apache.atlas.server.common.errors;
+
 import org.springframework.stereotype.Component;
 
 import javax.ws.rs.core.Response;
@@ -26,16 +26,22 @@ import javax.ws.rs.ext.Provider;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Exception mapper for Jersey.
+ */
 @Provider
 @Component
-public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
+public class AllExceptionMapper implements ExceptionMapper<Exception> {
     @Override
-    public Response toResponse(NotFoundException e) {
+    public Response toResponse(Exception exception) {
         final long id = ThreadLocalRandom.current().nextLong();
 
+        // Log the response and use the error codes from the Exception
+        ExceptionMapperUtil.logException(id, exception);
+
         return Response
-                .status(Response.Status.NOT_FOUND)
-                .entity(ExceptionMapperUtil.formatErrorMessage(id, e))
+                .serverError()
+                .entity(ExceptionMapperUtil.formatErrorMessage(id, exception))
                 .build();
     }
 }

--- a/server-common/src/main/java/org/apache/atlas/server/common/errors/AtlasBaseExceptionMapper.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/errors/AtlasBaseExceptionMapper.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.atlas.web.errors;
+package org.apache.atlas.server.common.errors;
 
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.exception.AtlasBaseException;

--- a/server-common/src/main/java/org/apache/atlas/server/common/errors/ExceptionMapperUtil.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/errors/ExceptionMapperUtil.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.atlas.web.errors;
+package org.apache.atlas.server.common.errors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,16 +28,16 @@ public class ExceptionMapperUtil {
     }
 
     @SuppressWarnings("UnusedParameters")
-    protected static String formatErrorMessage(long id, Exception exception) {
+    public static String formatErrorMessage(long id, Exception exception) {
         return String.format("There was an error processing your request. It has been logged (ID %016x).", id);
     }
 
-    protected static void logException(long id, Exception exception) {
+    public static void logException(long id, Exception exception) {
         LOGGER.error(formatLogMessage(id, exception), exception);
     }
 
     @SuppressWarnings("UnusedParameters")
-    protected static String formatLogMessage(long id, Throwable exception) {
+    public static String formatLogMessage(long id, Throwable exception) {
         return String.format("Error handling a request: %016x", id);
     }
 }

--- a/server-common/src/main/java/org/apache/atlas/server/common/errors/NotFoundExceptionMapper.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/errors/NotFoundExceptionMapper.java
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.atlas.server.common.errors;
 
-package org.apache.atlas.web.errors;
-
+import org.apache.atlas.exception.NotFoundException;
 import org.springframework.stereotype.Component;
 
 import javax.ws.rs.core.Response;
@@ -26,22 +26,16 @@ import javax.ws.rs.ext.Provider;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-/**
- * Exception mapper for Jersey.
- */
 @Provider
 @Component
-public class AllExceptionMapper implements ExceptionMapper<Exception> {
+public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
     @Override
-    public Response toResponse(Exception exception) {
+    public Response toResponse(NotFoundException e) {
         final long id = ThreadLocalRandom.current().nextLong();
 
-        // Log the response and use the error codes from the Exception
-        ExceptionMapperUtil.logException(id, exception);
-
         return Response
-                .serverError()
-                .entity(ExceptionMapperUtil.formatErrorMessage(id, exception))
+                .status(Response.Status.NOT_FOUND)
+                .entity(ExceptionMapperUtil.formatErrorMessage(id, e))
                 .build();
     }
 }

--- a/webapp/src/test/java/org/apache/atlas/web/errors/AllExceptionMapperTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/errors/AllExceptionMapperTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.atlas.web.errors;
 
+import org.apache.atlas.server.common.errors.AllExceptionMapper;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/webapp/src/test/java/org/apache/atlas/web/errors/AtlasBaseExceptionMapperTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/errors/AtlasBaseExceptionMapperTest.java
@@ -20,6 +20,7 @@ package org.apache.atlas.web.errors;
 
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.server.common.errors.AtlasBaseExceptionMapper;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -62,5 +63,18 @@ public class AtlasBaseExceptionMapperTest {
             // Exception is acceptable as it might be thrown by the utility methods
             assertTrue(true);
         }
+    }
+
+    @Test
+    public void testUnauthorizedAccessResponse() {
+        AtlasBaseException testException = new AtlasBaseException(
+                AtlasErrorCode.UNAUTHORIZED_ACCESS, "testuser", "post on rest notification service");
+
+        Response response = atlasBaseExceptionMapper.toResponse(testException);
+
+        assertEquals(response.getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+        String entity = (String) response.getEntity();
+        assertTrue(entity.contains("ATLAS-403-00-001"));
+        assertTrue(entity.contains("not authorized to perform post on rest notification service"));
     }
 }

--- a/webapp/src/test/java/org/apache/atlas/web/errors/ExceptionMapperUtilTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/errors/ExceptionMapperUtilTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.atlas.web.errors;
 
+import org.apache.atlas.server.common.errors.ExceptionMapperUtil;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;

--- a/webapp/src/test/java/org/apache/atlas/web/errors/NotFoundExceptionMapperTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/errors/NotFoundExceptionMapperTest.java
@@ -19,6 +19,7 @@
 package org.apache.atlas.web.errors;
 
 import org.apache.atlas.exception.NotFoundException;
+import org.apache.atlas.server.common.errors.NotFoundExceptionMapper;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem

The `rest-notification-webapp` module (introduced in ATLAS-5207) exposes  
`POST /api/atlas/v2/notification/topic/{topicName}` on port **41000** as a headless REST side door for hook messages to Kafka.

The **main webapp** `NotificationREST` already enforces `SERVICE_NOTIFICATION_POST` via `AtlasAuthorizationUtils.verifyAccess()`, but the **rest-notification** copy did **not**. This allowed any **authenticated read-only** user (e.g. `rangertagsync` / `DATA_SCIENTIST`) to POST hook messages (including `ENTITY_CREATE_V2`) to `ATLAS_HOOK`, bypassing the authorization enforced on port 21000.

Additionally, when authorization or validation exceptions were thrown on the rest server, responses were returned as **HTTP 500 HTML** (Jetty default) instead of the structured **JSON error bodies** returned by the main webapp (e.g. `ATLAS-403-00-001`).

### Solution

This PR addresses both issues:

#### 1. CVE authorization fix (rest-notification)

**File:** `rest-notification-webapp/src/main/java/org/apache/atlas/notification/rest/web/rest/NotificationREST.java`

Added the same authorization check as the main webapp:

```java
AtlasAuthorizationUtils.verifyAccess(
    new AtlasAdminAccessRequest(AtlasPrivilege.SERVICE_NOTIFICATION_POST),
    "post on rest notification service");
```

**Effect:** Read-only users are denied **before** the message is published to Kafka. Admin users can still POST (HTTP 204).

---

#### 2. Shared Jersey exception mappers (server-common)

**Moved** the following classes from `webapp/src/main/java/org/apache/atlas/web/errors/` to  
`server-common/src/main/java/org/apache/atlas/server/common/errors/`:

| Class | Purpose |
|-------|---------|
| `AtlasBaseExceptionMapper` | Maps `AtlasBaseException` → JSON (403, 404, 400, etc.) |
| `AllExceptionMapper` | Catch-all for unexpected exceptions → HTTP 500 |
| `NotFoundExceptionMapper` | JAX-RS path-not-found → HTTP 404 |
| `ExceptionMapperUtil` | Shared response-building utilities |

**File:** `server-common/pom.xml`

Added `jersey-server` dependency (in addition to existing `jersey-core`) so mapper classes compile in `server-common` — they implement `javax.ws.rs.ext.ExceptionMapper` from `jersey-server`.

**File:** `webapp/src/test/java/org/apache/atlas/web/errors/*`

Updated imports to reference `org.apache.atlas.server.common.errors.*`. Tests remain in webapp module (existing Atlas pattern). Added `testUnauthorizedAccessResponse()` in `AtlasBaseExceptionMapperTest` for `ATLAS-403-00-001` coverage.

---

`ExceptionMapperUtil` methods changed from `protected` to `public` to allow cross-package test access from webapp tests.
## How was this patch tested?

### Build
mvn clean install -DskipITs=true
**Result:** BUILD SUCCESS. All modules including `server-common`, `webapp`, `rest-notification-webapp`.

### Unit tests
**Result:** Exception mapper unit tests in webapp pass with updated imports from `server-common`.

---

#### Security test results (Tests A–G)

| Test | Description | Expected | **Actual** | Pass? |
|------|-------------|----------|------------|-------|
| **A** | Read-only → rest POST `/notification/topic/ATLAS_HOOK` | **403 JSON** | **403** `ATLAS-403-00-001` |  Pass |
| **B** | Admin → rest POST | **204** | **204** |  Pass |
| **C** | Read-only → webapp POST | **403 JSON** | **403** `ATLAS-403-00-001` |  Pass |
| **D** | Entity absent after blocked POST (Test A) | **404 JSON** | **404** `ATLAS-404-00-009` |  Pass |
| **E** | Admin entity after allowed POST (Test B) | 200 or 404 | **404** (consumer timing) |  Pass |
| **F** | Unauthenticated → rest POST | **401** | **401** |  Pass |
| **G** | Invalid topic → rest POST | **400 JSON** | **400** `ATLAS-400-00-101` |  Pass |

---

## Related

- **JIRA:** ATLAS-5207
- **PR:** #622 (rest-notification infrastructure)
- **Security context:** Nixon CVE — missing authorization on rest-notification notification POST endpoint