### PR TITLE
ATLAS-5366 - Exclude node_modules from source release tarball

### DIFF
--- a/distro/src/main/assemblies/src-package.xml
+++ b/distro/src/main/assemblies/src-package.xml
@@ -44,11 +44,11 @@
                 <exclude>**/${sys:atlas.data}/**</exclude>
                 <exclude>**/atlas.data/**</exclude>
                 <exclude>**/*.patch</exclude>
-                <exclude>dashboardv2/node_modules/**</exclude>
+                <exclude>**/node_modules/**</exclude>
+                <exclude>**/.frontend-toolchain/**</exclude>
                 <exclude>dev-support/atlas-docker/data/**</exclude>
                 <exclude>dev-support/atlas-docker/dist/**</exclude>
                 <exclude>dev-support/atlas-docker/downloads/**</exclude>
-                <exclude>docs/node_modules/**</exclude>
             </excludes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
## What changes were proposed in this pull request?

               Exclude node_modules from source release tarball


## How was this patch tested?

mvn package with -Pdist and verify the atlas source tar ball.