### PR TITLE
ATLAS-5367: Fix missing license headers in dist/n3 for WAR packaging

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -146,6 +146,7 @@
                 <configuration>
                     <excludes combine.children="append">
                         <exclude>**/atlas-lineage/dist/**</exclude>
+                        <exclude>**/.frontend-toolchain/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -15,14 +15,55 @@
  * limitations under the License.
  */
 
-import { defineConfig } from "vite";
+import { defineConfig, Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import fs from "fs";
 
 const proxyHost = "http://localhost:21000";
 
+let apacheLicense = "";
+let apacheHtmlLicense = "";
+try {
+  const viteConfigContent = fs.readFileSync(path.resolve(__dirname, "vite.config.ts"), "utf-8");
+  const extracted = viteConfigContent.substring(viteConfigContent.indexOf("/*"), viteConfigContent.indexOf("*/") + 2);
+  if (extracted.includes("Licensed to the Apache Software Foundation")) {
+    apacheLicense = extracted + "\n";
+    apacheHtmlLicense = `\n<!--\n${extracted.replace('/*', '').replace('*/', '').trim()}\n-->\n`;
+  } else {
+    console.warn("Warning: Could not safely extract the Apache License from vite.config.ts!");
+  }
+} catch (e) {
+  console.warn("Warning: Failed to read vite.config.ts for license extraction", e);
+}
+
+const addLicensePlugin = (): Plugin => {
+  return {
+    name: 'add-license',
+    apply: 'build' as const, // only run during build
+    generateBundle(_options: any, bundle: any) {
+      if (!apacheLicense) return;
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        if (fileName.endsWith('.js') || fileName.endsWith('.css')) {
+          if (chunk && typeof chunk === 'object') {
+            if ('type' in chunk && chunk.type === 'chunk' && 'code' in chunk) {
+              (chunk as any).code = apacheLicense + (chunk as any).code;
+            } else if ('type' in chunk && chunk.type === 'asset' && 'source' in chunk && typeof (chunk as any).source === 'string') {
+              (chunk as any).source = apacheLicense + (chunk as any).source;
+            }
+          }
+        }
+      }
+    },
+    transformIndexHtml(html: string) {
+      if (!apacheHtmlLicense) return html;
+      return html.replace('<head>', `<head>${apacheHtmlLicense}`);
+    }
+  };
+};
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), addLicensePlugin()],
   base: "",
   build: {
     chunkSizeWarningLimit: 2000,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch resolves the Apache RAT plugin license check failures that occur during the dashboard build process. The following changes were made:
1. **`dashboard/vite.config.ts`**: Added a custom Vite plugin that dynamically reads the Apache License header and automatically injects it into all generated minified `.js`, `.css`, and `index.html` assets in the `dist/n3` output directory.
2. **`dashboard/pom.xml`**: Added an exclusion for the `.frontend-toolchain/**` directory in the `apache-rat-plugin` configuration. This prevents the checker from scanning 3rd-party node/npm binaries downloaded by the frontend-maven-plugin.


## How was this patch tested?

- Manually verified by running `npm run build` in the `dashboard/` directory. Confirmed that all generated `.js`, `.css`, and `.html` assets inside `dist/n3/assets/` correctly contain the Apache License at the top of the files.
- Executed a successful full local Maven build (`mvn clean package -DskipTests -Pdist,embedded-hbase-solr`) to confirm that the `apache-rat-plugin` check passes without throwing any license missing errors.
