### PR TITLE
ATLAS-5014 : Basic Search : excludeHeaderAttributes is true, order of…

### DIFF
--- a/intg/src/main/java/org/apache/atlas/model/discovery/QuickSearchParameters.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/QuickSearchParameters.java
@@ -20,10 +20,13 @@ package org.apache.atlas.model.discovery;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.atlas.SortOrder;
 import org.apache.atlas.model.discovery.SearchParameters.FilterCriteria;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
@@ -45,6 +48,7 @@ public class QuickSearchParameters implements Serializable {
     private boolean        excludeDeletedEntities;
     private int            offset;
     private int            limit;
+    @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String>    attributes;
     private String         sortBy;
     private SortOrder      sortOrder;
@@ -56,7 +60,7 @@ public class QuickSearchParameters implements Serializable {
     public QuickSearchParameters() {
     }
 
-    public QuickSearchParameters(String query, String typeName, FilterCriteria entityFilters, boolean includeSubTypes, boolean excludeDeletedEntities, int offset, int limit, Set<String> attributes, String sortBy, SortOrder sortOrder) {
+    public QuickSearchParameters(String query, String typeName, FilterCriteria entityFilters, boolean includeSubTypes, boolean excludeDeletedEntities, int offset, int limit, Collection<String> attributes, String sortBy, SortOrder sortOrder) {
         this.query                  = query;
         this.typeName               = typeName;
         this.entityFilters          = entityFilters;
@@ -64,7 +68,7 @@ public class QuickSearchParameters implements Serializable {
         this.excludeDeletedEntities = excludeDeletedEntities;
         this.offset                 = offset;
         this.limit                  = limit;
-        this.attributes             = attributes;
+        this.attributes             = attributes == null ? null : new LinkedHashSet<>(attributes);
         this.sortBy                 = sortBy;
         this.sortOrder              = sortOrder;
     }
@@ -129,8 +133,8 @@ public class QuickSearchParameters implements Serializable {
         return attributes;
     }
 
-    public void setAttributes(Set<String> attributes) {
-        this.attributes = attributes;
+    public void setAttributes(Collection<String> attributes) {
+        this.attributes = attributes == null ? null : new LinkedHashSet<>(attributes);
     }
 
     public String getSortBy() {

--- a/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
+++ b/intg/src/main/java/org/apache/atlas/model/discovery/SearchParameters.java
@@ -22,10 +22,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.atlas.SortOrder;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -63,6 +66,7 @@ public class SearchParameters implements Serializable {
     private FilterCriteria entityFilters;
     private FilterCriteria tagFilters;
     private FilterCriteria relationshipFilters;
+    @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String>    attributes;
     private SortOrder      sortOrder;
 
@@ -319,11 +323,12 @@ public class SearchParameters implements Serializable {
 
     /**
      * Return these attributes in the result response
+     * Duplicate attribute names are ignored; the first occurrence determines position.
      *
      * @param attributes
      */
-    public void setAttributes(Set<String> attributes) {
-        this.attributes = attributes;
+    public void setAttributes(Collection<String> attributes) {
+        this.attributes = attributes == null ? null : new LinkedHashSet<>(attributes);
     }
 
     /**

--- a/intg/src/test/java/org/apache/atlas/model/discovery/TestQuickSearchParameters.java
+++ b/intg/src/test/java/org/apache/atlas/model/discovery/TestQuickSearchParameters.java
@@ -22,8 +22,9 @@ import org.apache.atlas.model.discovery.SearchParameters.FilterCriteria;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -66,7 +67,7 @@ public class TestQuickSearchParameters {
         boolean excludeDeletedEntities = true;
         int offset = 10;
         int limit = 100;
-        Set<String> attributes = new HashSet<>();
+        List<String> attributes = new ArrayList<>();
         attributes.add("attr1");
         String sortBy = "name";
         SortOrder sortOrder = SortOrder.ASCENDING;
@@ -82,7 +83,7 @@ public class TestQuickSearchParameters {
         assertTrue(params.getExcludeDeletedEntities());
         assertEquals(params.getOffset(), offset);
         assertEquals(params.getLimit(), limit);
-        assertSame(params.getAttributes(), attributes);
+        assertEquals(params.getAttributes(), new LinkedHashSet<>(attributes));
         assertEquals(params.getSortBy(), sortBy);
         assertEquals(params.getSortOrder(), sortOrder);
     }
@@ -183,13 +184,13 @@ public class TestQuickSearchParameters {
     public void testAttributesGetterSetter() {
         assertNull(searchParameters.getAttributes());
 
-        Set<String> attributes = new HashSet<>();
+        List<String> attributes = new ArrayList<>();
         attributes.add("name");
         attributes.add("description");
         attributes.add("owner");
 
         searchParameters.setAttributes(attributes);
-        assertSame(searchParameters.getAttributes(), attributes);
+        assertEquals(searchParameters.getAttributes(), new LinkedHashSet<>(attributes));
 
         searchParameters.setAttributes(null);
         assertNull(searchParameters.getAttributes());
@@ -244,7 +245,7 @@ public class TestQuickSearchParameters {
         boolean excludeDeletedEntities = true;
         int offset = 25;
         int limit = 500;
-        Set<String> attributes = new HashSet<>();
+        List<String> attributes = new ArrayList<>();
         attributes.add("name");
         attributes.add("qualifiedName");
         attributes.add("owner");
@@ -271,7 +272,7 @@ public class TestQuickSearchParameters {
         assertTrue(searchParameters.getExcludeDeletedEntities());
         assertEquals(searchParameters.getOffset(), offset);
         assertEquals(searchParameters.getLimit(), limit);
-        assertSame(searchParameters.getAttributes(), attributes);
+        assertEquals(searchParameters.getAttributes(), new LinkedHashSet<>(attributes));
         assertEquals(searchParameters.getSortBy(), sortBy);
         assertEquals(searchParameters.getSortOrder(), sortOrder);
         assertTrue(searchParameters.getExcludeHeaderAttributes());
@@ -296,7 +297,7 @@ public class TestQuickSearchParameters {
 
     @Test
     public void testEmptyAttributesSet() {
-        Set<String> emptyAttributes = new HashSet<>();
+        List<String> emptyAttributes = new ArrayList<>();
         searchParameters.setAttributes(emptyAttributes);
 
         assertNotNull(searchParameters.getAttributes());
@@ -306,15 +307,15 @@ public class TestQuickSearchParameters {
 
     @Test
     public void testAttributesSetModification() {
-        Set<String> attributes = new HashSet<>();
+        List<String> attributes = new ArrayList<>();
         attributes.add("initialAttribute");
         searchParameters.setAttributes(attributes);
 
         attributes.add("additionalAttribute");
 
-        assertEquals(searchParameters.getAttributes().size(), 2);
+        assertEquals(searchParameters.getAttributes().size(), 1);
         assertTrue(searchParameters.getAttributes().contains("initialAttribute"));
-        assertTrue(searchParameters.getAttributes().contains("additionalAttribute"));
+        assertFalse(searchParameters.getAttributes().contains("additionalAttribute"));
     }
 
     @Test
@@ -413,7 +414,7 @@ public class TestQuickSearchParameters {
 
     @Test
     public void testAttributesWithVariousTypes() {
-        Set<String> attributes = new HashSet<>();
+        List<String> attributes = new ArrayList<>();
         attributes.add("stringAttribute");
         attributes.add("numericAttribute");
         attributes.add("dateAttribute");
@@ -472,7 +473,7 @@ public class TestQuickSearchParameters {
         searchParameters.setOffset(0);
         searchParameters.setLimit(50);
 
-        Set<String> attributes = new HashSet<>();
+        List<String> attributes = new ArrayList<>();
         attributes.add("qualifiedName");
         attributes.add("owner");
         attributes.add("createTime");

--- a/intg/src/test/java/org/apache/atlas/model/discovery/TestQuickSearchParameters.java
+++ b/intg/src/test/java/org/apache/atlas/model/discovery/TestQuickSearchParameters.java
@@ -19,10 +19,12 @@ package org.apache.atlas.model.discovery;
 
 import org.apache.atlas.SortOrder;
 import org.apache.atlas.model.discovery.SearchParameters.FilterCriteria;
+import org.apache.atlas.utils.AtlasJson;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -500,5 +502,25 @@ public class TestQuickSearchParameters {
         assertEquals(searchParameters.getSortOrder(), SortOrder.DESCENDING);
         assertFalse(searchParameters.getExcludeHeaderAttributes());
         assertNotNull(searchParameters.getEntityFilters());
+    }
+
+    @Test
+    public void testAttributesJsonDeserializationPreservesOrder() {
+        String json = "{\"query\":\"*\",\"typeName\":\"hive_table\",\"attributes\":[\"qualifiedName\",\"createTime\"]}";
+
+        QuickSearchParameters params = AtlasJson.fromJson(json, QuickSearchParameters.class);
+
+        assertEquals(params.getAttributes(), new LinkedHashSet<>(Arrays.asList("qualifiedName", "createTime")));
+        assertEquals(new ArrayList<>(params.getAttributes()), Arrays.asList("qualifiedName", "createTime"));
+    }
+
+    @Test
+    public void testAttributesJsonDeserializationDedupes() {
+        String json = "{\"query\":\"*\",\"typeName\":\"hive_table\",\"attributes\":[\"qualifiedName\",\"createTime\",\"qualifiedName\"]}";
+
+        QuickSearchParameters params = AtlasJson.fromJson(json, QuickSearchParameters.class);
+
+        assertEquals(params.getAttributes(), new LinkedHashSet<>(Arrays.asList("qualifiedName", "createTime")));
+        assertEquals(new ArrayList<>(params.getAttributes()), Arrays.asList("qualifiedName", "createTime"));
     }
 }

--- a/intg/src/test/java/org/apache/atlas/model/discovery/TestSearchParameters.java
+++ b/intg/src/test/java/org/apache/atlas/model/discovery/TestSearchParameters.java
@@ -20,13 +20,14 @@ package org.apache.atlas.model.discovery;
 import org.apache.atlas.SortOrder;
 import org.apache.atlas.model.discovery.SearchParameters.FilterCriteria;
 import org.apache.atlas.model.discovery.SearchParameters.Operator;
+import org.apache.atlas.utils.AtlasJson;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -290,14 +291,22 @@ public class TestSearchParameters {
     public void testAttributesGetterSetter() {
         assertNull(searchParameters.getAttributes());
 
-        Set<String> attributes = new HashSet<>();
+        List<String> attributes = new ArrayList<>();
         attributes.add("name");
         attributes.add("description");
         searchParameters.setAttributes(attributes);
-        assertSame(searchParameters.getAttributes(), attributes);
+        assertEquals(searchParameters.getAttributes(), new LinkedHashSet<>(attributes));
 
         searchParameters.setAttributes(null);
         assertNull(searchParameters.getAttributes());
+    }
+
+    @Test
+    public void testAttributesDedupePreservesFirstOccurrenceOrder() {
+        searchParameters.setAttributes(Arrays.asList("qualifiedName", "createTime", "qualifiedName"));
+
+        assertEquals(searchParameters.getAttributes(), new LinkedHashSet<>(Arrays.asList("qualifiedName", "createTime")));
+        assertEquals(new ArrayList<>(searchParameters.getAttributes()), Arrays.asList("qualifiedName", "createTime"));
     }
 
     @Test
@@ -708,7 +717,7 @@ public class TestSearchParameters {
         searchParameters.setSortBy("createTime");
         searchParameters.setSortOrder(SortOrder.DESCENDING);
 
-        Set<String> attributes = new HashSet<>();
+        List<String> attributes = new ArrayList<>();
         attributes.add("qualifiedName");
         attributes.add("owner");
         searchParameters.setAttributes(attributes);
@@ -736,6 +745,26 @@ public class TestSearchParameters {
         assertEquals(searchParameters.getSortBy(), "createTime");
         assertEquals(searchParameters.getSortOrder(), SortOrder.DESCENDING);
         assertEquals(searchParameters.getAttributes().size(), 2);
+        assertEquals(new ArrayList<>(searchParameters.getAttributes()).get(0), "qualifiedName");
+        assertEquals(new ArrayList<>(searchParameters.getAttributes()).get(1), "owner");
         assertNotNull(searchParameters.getEntityFilters());
+    }
+
+    @Test
+    public void testAttributesJsonDeserializationPreservesOrder() {
+        String json = "{\"typeName\":\"hive_table\",\"attributes\":[\"qualifiedName\",\"createTime\"]}";
+
+        SearchParameters params = AtlasJson.fromJson(json, SearchParameters.class);
+
+        assertEquals(params.getAttributes(), new LinkedHashSet<>(Arrays.asList("qualifiedName", "createTime")));
+    }
+
+    @Test
+    public void testAttributesJsonDeserializationDedupes() {
+        String json = "{\"typeName\":\"hive_table\",\"attributes\":[\"qualifiedName\",\"createTime\",\"qualifiedName\"]}";
+
+        SearchParameters params = AtlasJson.fromJson(json, SearchParameters.class);
+
+        assertEquals(params.getAttributes(), new LinkedHashSet<>(Arrays.asList("qualifiedName", "createTime")));
     }
 }

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -101,6 +101,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -652,7 +653,10 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 AtlasVertex       vertex        = entityRetriever.getEntityVertex(endVertexGuid);
 
                 if (vertex != null) {
-                    AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(vertex, searchParameters.getAttributes());
+                    Set<String> requestedAttributes = CollectionUtils.isEmpty(searchParameters.getAttributes())
+                            ? Collections.emptySet()
+                            : searchParameters.getAttributes();
+                    AtlasEntityHeader entity = entityRetriever.toAtlasEntityHeader(vertex, requestedAttributes);
 
                     if (searchParameters.getIncludeClassificationAttributes()) {
                         entity.setClassifications(entityRetriever.getAllClassifications(vertex));
@@ -990,7 +994,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
                 Collection<List<Object>>                values                = new ArrayList<>();
                 AtlasSearchResult.AttributeSearchResult attributeSearchResult = new AtlasSearchResult.AttributeSearchResult();
 
-                attributeSearchResult.setName(new ArrayList<>(attributes));
+                attributeSearchResult.setName(attributes == null ? null : new ArrayList<>(attributes));
 
                 for (AtlasVertex vertex : resultList) {
                     List<Object> row = new ArrayList<>();
@@ -1016,7 +1020,7 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
             // By default any attribute that shows up in the search parameter should be sent back in the response
             // If additional values are requested then the entityAttributes will be a superset of the all search attributes
             // and the explicitly requested attribute(s)
-            Set<String> resultAttributes = new HashSet<>();
+            Set<String> resultAttributes = new LinkedHashSet<>();
             Set<String> entityAttributes = new HashSet<>();
 
             if (CollectionUtils.isNotEmpty(searchParameters.getAttributes())) {

--- a/repository/src/main/java/org/apache/atlas/repository/impexp/TableReplicationRequestProcessor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/impexp/TableReplicationRequestProcessor.java
@@ -170,7 +170,7 @@ public class TableReplicationRequestProcessor {
         parameters.setExcludeDeletedEntities(false);
         parameters.setTypeName(TYPE_HIVE_TABLE);
         parameters.setExcludeDeletedEntities(true);
-        parameters.setAttributes(new HashSet<>(Collections.singleton(AtlasImportRequest.OPTION_KEY_REPLICATED_FROM)));
+        parameters.setAttributes(Collections.singleton(AtlasImportRequest.OPTION_KEY_REPLICATED_FROM));
         parameters.setQuery(query);
 
         return parameters;

--- a/repository/src/test/java/org/apache/atlas/discovery/AtlasDiscoveryServiceTest.java
+++ b/repository/src/test/java/org/apache/atlas/discovery/AtlasDiscoveryServiceTest.java
@@ -45,10 +45,10 @@ import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -891,7 +891,7 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
         params.setExcludeHeaderAttributes(true);
         params.setEntityFilters(filterCriteria);
         params.setSortBy("name");
-        params.setAttributes(new HashSet<>(Collections.singletonList("name")));
+        params.setAttributes(Collections.singletonList("name"));
         params.setLimit(1);
 
         AtlasSearchResult                       searchResult = discoveryService.searchWithParameters(params);
@@ -904,6 +904,40 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
     }
 
     @Test
+    public void excludeHeaderAttributesPreservesAttributeOrder() throws AtlasBaseException {
+        SearchParameters params = new SearchParameters();
+
+        params.setTypeName(HIVE_TABLE_TYPE);
+        params.setExcludeHeaderAttributes(true);
+        params.setAttributes(Arrays.asList("qualifiedName", "createTime"));
+        params.setLimit(25);
+
+        AtlasSearchResult searchResult = discoveryService.searchWithParameters(params);
+
+        assertNotNull(searchResult.getAttributes());
+        assertEquals(searchResult.getAttributes().getName(), Arrays.asList("qualifiedName", "createTime"));
+        assertEquals(new ArrayList<>(searchResult.getSearchParameters().getAttributes()),
+                Arrays.asList("qualifiedName", "createTime"));
+    }
+
+    @Test
+    public void excludeHeaderAttributesDedupesAttributeNames() throws AtlasBaseException {
+        SearchParameters params = new SearchParameters();
+
+        params.setTypeName(HIVE_TABLE_TYPE);
+        params.setExcludeHeaderAttributes(true);
+        params.setAttributes(Arrays.asList("qualifiedName", "createTime", "qualifiedName"));
+        params.setLimit(25);
+
+        AtlasSearchResult searchResult = discoveryService.searchWithParameters(params);
+
+        assertNotNull(searchResult.getAttributes());
+        assertEquals(searchResult.getAttributes().getName(), Arrays.asList("qualifiedName", "createTime"));
+        assertEquals(new ArrayList<>(searchResult.getSearchParameters().getAttributes()),
+                Arrays.asList("qualifiedName", "createTime"));
+    }
+
+    @Test
     public void excludeHeaderAttributesRelationAttr() throws AtlasBaseException {
         SearchParameters.FilterCriteria filterCriteria = getSingleFilterCondition("name", Operator.EQ, "time_dim");
         SearchParameters                params         = new SearchParameters();
@@ -911,7 +945,7 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
         params.setTypeName(HIVE_TABLE_TYPE);
         params.setExcludeHeaderAttributes(true);
         params.setEntityFilters(filterCriteria);
-        params.setAttributes(new HashSet<>(Arrays.asList("name", "db")));
+        params.setAttributes(Arrays.asList("name", "db"));
         params.setLimit(1);
 
         AtlasSearchResult searchResult = discoveryService.searchWithParameters(params);
@@ -928,7 +962,7 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
 
         params.setTypeName(HIVE_TABLE_TYPE);
         params.setExcludeHeaderAttributes(true);
-        params.setAttributes(new HashSet<>(Arrays.asList("name", "__state")));
+        params.setAttributes(Arrays.asList("name", "__state"));
         params.setLimit(1);
         params.setEntityFilters(filterCriteria);
         params.setSortBy("name");
@@ -948,7 +982,7 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
 
         params.setTypeName(HIVE_TABLE_TYPE + "," + ALL_ENTITY_TYPES);
         params.setExcludeHeaderAttributes(true);
-        params.setAttributes(new HashSet<>(Collections.singletonList("__state")));
+        params.setAttributes(Collections.singletonList("__state"));
         params.setLimit(2);
 
         AtlasSearchResult                       searchResult = discoveryService.searchWithParameters(params);
@@ -966,7 +1000,7 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
 
         params.setTypeName(HIVE_TABLE_TYPE + "," + ALL_ENTITY_TYPES);
         params.setExcludeHeaderAttributes(true);
-        params.setAttributes(new HashSet<>(Arrays.asList("__state", "__guid")));
+        params.setAttributes(Arrays.asList("__state", "__guid"));
         params.setLimit(2);
 
         AtlasSearchResult searchResult = discoveryService.searchWithParameters(params);
@@ -979,7 +1013,7 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
 
         params.setTypeName(HIVE_TABLE_TYPE + "," + ALL_ENTITY_TYPES);
         params.setExcludeHeaderAttributes(true);
-        params.setAttributes(new HashSet<>(Collections.singletonList("name")));
+        params.setAttributes(Collections.singletonList("name"));
         params.setLimit(1);
 
         discoveryService.searchWithParameters(params);
@@ -991,7 +1025,7 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
 
         params.setTypeName(HIVE_TABLE_TYPE);
         params.setExcludeHeaderAttributes(true);
-        params.setAttributes(new HashSet<>(Collections.singletonList("name1")));
+        params.setAttributes(Collections.singletonList("name1"));
         params.setLimit(1);
 
         discoveryService.searchWithParameters(params);
@@ -1382,10 +1416,10 @@ public class AtlasDiscoveryServiceTest extends BasicTestSetup {
         assertNotNull(searchResult);
         AtlasSearchResult.AttributeSearchResult result = searchResult.getAttributes();
         assertNotNull(result);
-        assertTrue(result.getName().containsAll(expected.getName()));
+        assertEquals(result.getName(), expected.getName());
         int i = 0;
         for (List<Object> value : result.getValues()) {
-            assertTrue(value.containsAll(expected.getValues().get(i)));
+            assertEquals(value, expected.getValues().get(i));
             i++;
         }
     }

--- a/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
+++ b/webapp/src/main/java/org/apache/atlas/web/rest/DiscoveryREST.java
@@ -74,7 +74,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.apache.atlas.model.discovery.AtlasSearchResult.AtlasQueryType.BASIC;
 import static org.apache.atlas.model.discovery.AtlasSearchResult.AtlasQueryType.DSL;
@@ -535,7 +534,7 @@ public class DiscoveryREST {
     @Timed
     public AtlasSearchResult searchRelatedEntities(@QueryParam("guid") String guid,
             @QueryParam("relation") String relation,
-            @QueryParam("attributes") Set<String> attributes,
+            @QueryParam("attributes") List<String> attributes,
             @QueryParam("sortBy") String sortByAttribute,
             @QueryParam("sortOrder") SortOrder sortOrder,
             @QueryParam("excludeDeletedEntities") boolean excludeDeletedEntities,

--- a/webapp/src/test/java/org/apache/atlas/web/rest/DiscoveryRESTTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/rest/DiscoveryRESTTest.java
@@ -42,10 +42,8 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.apache.atlas.common.TestUtility.generateString;
 import static org.apache.atlas.model.discovery.AtlasSearchResult.AtlasQueryType.BASIC;
@@ -492,7 +490,7 @@ public class DiscoveryRESTTest {
     public void testSearchRelatedEntities_Success() throws Exception {
         String guid = "1234-5678";
         String relation = "relatedTo";
-        Set<String> attributes = new HashSet<>(Arrays.asList("name", "description"));
+        List<String> attributes = Arrays.asList("name", "description");
         String sortByAttribute = "name";
         SortOrder sortOrder = SortOrder.ASCENDING;
         boolean excludeDeletedEntities = true;
@@ -520,7 +518,7 @@ public class DiscoveryRESTTest {
         // Query Length exceeds the Configured Query Limit, Causes validation to Fail
         String guid = generateString(AtlasConfiguration.QUERY_PARAM_MAX_LENGTH.getInt() + 1, 'a'); // too long
         String relation = "relatedTo";
-        Set<String> attributes = new HashSet<>(Arrays.asList("name", "description"));
+        List<String> attributes = Arrays.asList("name", "description");
         String sortByAttribute = "name";
         SortOrder sortOrder = SortOrder.ASCENDING;
         boolean excludeDeletedEntities = true;


### PR DESCRIPTION
… attribute in the response changes

Store search attributes in LinkedHashSet so json array order is kept when building attributes.name and attributes.values. Duplicate attribute names are deduped using first-occurrence order. Fixes mismatched column order between request and response for POST /api/atlas/v2/search/basic.

## What changes were proposed in this pull request?

Basic search with excludeHeaderAttributes=true did not preserve the order of attributes from the client request. For example, a request with "attributes": ["qualifiedName", "createTime"] could return "attributes": { "name": ["createTime", "qualifiedName"], ... }, so column order in attributes.values did not match the request.

Root cause: SearchParameters.attributes was stored as Set<String>. Jackson deserialized the JSON array into a HashSet, which does not preserve insertion order. The response builder copied that set into attributes.name and used the same iteration order when building each row in attributes.values.

Fix:

Store attributes in a LinkedHashSet in SearchParameters and QuickSearchParameters
Use @JsonDeserialize(as = LinkedHashSet.class) so JSON deserialization keeps order
Update relationship search REST API to accept List<String> query params, which are normalized through the same setter



## How was this patch tested?

Unit tests
Manual testing
Started Atlas with PostgreSQL + Hive using docker compose
Created hive_table entities via Hive