### PR TITLE
ATLAS-5372: Prevent cross-user overwrite in saved search create API v…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityDiscoveryService.java
@@ -699,6 +699,12 @@ public class EntityDiscoveryService implements AtlasDiscoveryService {
 
             checkSavedSearchOwnership(currentUser, savedSearch);
 
+            if (StringUtils.isNotBlank(savedSearch.getGuid())) {
+                AtlasUserSavedSearch existingSavedSearch = userProfileService.getSavedSearch(savedSearch.getGuid());
+
+                checkSavedSearchOwnership(currentUser, existingSavedSearch);
+            }
+
             return userProfileService.addSavedSearch(savedSearch);
         } catch (AtlasBaseException e) {
             LOG.error("addSavedSearch({})", savedSearch, e);

--- a/repository/src/test/java/org/apache/atlas/discovery/EntityDiscoveryServiceTest.java
+++ b/repository/src/test/java/org/apache/atlas/discovery/EntityDiscoveryServiceTest.java
@@ -18,6 +18,7 @@
 package org.apache.atlas.discovery;
 
 import org.apache.atlas.AtlasConfiguration;
+import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.discovery.AtlasQuickSearchResult;
@@ -60,9 +61,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class EntityDiscoveryServiceTest {
     @Mock
@@ -147,6 +152,32 @@ public class EntityDiscoveryServiceTest {
         when(entityDiscoveryService.getSavedSearchByGuid(anyString(), anyString())).thenReturn(new AtlasUserSavedSearch());
         when(entityDiscoveryService.getSavedSearchByName(anyString(), anyString(), anyString())).thenReturn(new AtlasUserSavedSearch());
         when(entityDiscoveryService.searchGUIDsWithParameters(any(AtlasAuditAgingType.class), any(Set.class), any(SearchParameters.class))).thenReturn(new HashSet<>());
+    }
+
+    private EntityDiscoveryService createStrictServiceForSecurityTests() throws Exception {
+        /*
+         * Strict setup path for security-sensitive tests:
+         * always instantiate a real EntityDiscoveryService and never
+         * fallback to a mocked/spied service.
+         */
+        when(typeRegistry.getEntityTypeByName(anyString())).thenReturn(entityType);
+        when(entityType.getTypeAndAllSubTypesQryStr()).thenReturn("(TestType)");
+        when(entityType.getAttribute(anyString())).thenReturn(attribute);
+        when(entityType.getTypeName()).thenReturn("TestType");
+        when(attribute.getVertexPropertyName()).thenReturn("v.testAttr");
+        when(attribute.getAttributeType()).thenReturn(mock(org.apache.atlas.type.AtlasType.class));
+        when(indexer.getVertexIndexKeys()).thenReturn(Collections.emptySet());
+        when(indexer.getEdgeIndexKeys()).thenReturn(Collections.emptySet());
+        when(graph.indexQuery(anyString(), anyString())).thenReturn(indexQuery);
+        when(graph.query()).thenReturn(mock(org.apache.atlas.repository.graphdb.AtlasGraphQuery.class));
+        when(indexQuery.vertices()).thenReturn(Collections.emptyIterator());
+        when(indexQuery.vertexTotals()).thenReturn(0L);
+
+        RequestContext context = mock(RequestContext.class);
+        when(RequestContext.get()).thenReturn(context);
+        when(context.getUser()).thenReturn("testUser");
+
+        return new EntityDiscoveryService(typeRegistry, graph, indexer, searchTracker, userProfileService, taskManagement);
     }
 
     @AfterMethod
@@ -253,6 +284,54 @@ public class EntityDiscoveryServiceTest {
         } catch (Exception e) {
             assertTrue(true);
         }
+    }
+
+    @Test
+    public void testAddSavedSearchWithGuidFromAnotherUserIsRejectedStrict() throws Exception {
+        EntityDiscoveryService strictService = createStrictServiceForSecurityTests();
+        AtlasUserSavedSearch   savedSearch   = new AtlasUserSavedSearch();
+
+        savedSearch.setGuid("testGuid");
+        savedSearch.setOwnerName("testUser");
+        savedSearch.setName("testSearch");
+        savedSearch.setSearchType(AtlasUserSavedSearch.SavedSearchType.BASIC);
+
+        AtlasUserSavedSearch existingSavedSearch = new AtlasUserSavedSearch();
+        existingSavedSearch.setGuid("testGuid");
+        existingSavedSearch.setOwnerName("otherUser");
+
+        when(userProfileService.getSavedSearch("testGuid")).thenReturn(existingSavedSearch);
+
+        try {
+            strictService.addSavedSearch("testUser", savedSearch);
+            fail("Expected cross-user GUID reuse to be rejected");
+        } catch (AtlasBaseException e) {
+            assertEquals(e.getAtlasErrorCode(), AtlasErrorCode.BAD_REQUEST);
+            verify(userProfileService, never()).addSavedSearch(any(AtlasUserSavedSearch.class));
+        }
+    }
+
+    @Test
+    public void testAddSavedSearchWithOwnGuidIsAllowedStrict() throws Exception {
+        EntityDiscoveryService strictService = createStrictServiceForSecurityTests();
+        AtlasUserSavedSearch   savedSearch   = new AtlasUserSavedSearch();
+
+        savedSearch.setGuid("testGuid");
+        savedSearch.setOwnerName("testUser");
+        savedSearch.setName("testSearch");
+        savedSearch.setSearchType(AtlasUserSavedSearch.SavedSearchType.BASIC);
+
+        AtlasUserSavedSearch existingSavedSearch = new AtlasUserSavedSearch();
+        existingSavedSearch.setGuid("testGuid");
+        existingSavedSearch.setOwnerName("testUser");
+
+        when(userProfileService.getSavedSearch("testGuid")).thenReturn(existingSavedSearch);
+        when(userProfileService.addSavedSearch(savedSearch)).thenReturn(savedSearch);
+
+        AtlasUserSavedSearch result = strictService.addSavedSearch("testUser", savedSearch);
+
+        assertEquals(result, savedSearch);
+        verify(userProfileService).addSavedSearch(savedSearch);
     }
 
     @Test


### PR DESCRIPTION
…ia caller-supplied guid

## What changes were proposed in this pull request?

*PreRequisites*
Two authenticated users with permissions to use saved-search APIs (for example: userA, userB).

*Steps*
Login as userA and create a saved search using:

POST /api/atlas/v2/search/saved
capture the returned guid (call it G1).
Login as userB and send another create request to:

POST /api/atlas/v2/search/saved
include:
ownerName = userB
guid = G1
different name / searchParameters.

*Fetch saved searches for both users:*
GET /api/atlas/v2/search/saved?user=userB
GET /api/atlas/v2/search/saved?user=userA

*Observed Result*
The object with guid = G1 now appears under userB with updated content.
userA no longer has that saved search entry with G1.

*Expected Result*
Create API should not allow client-supplied guid to update an existing saved-search object owned by another user.
POST create should either reject non-empty guid or ignore it and always create a new object

## How was this patch tested?

Ran tests
ATLAS="http://localhost:21000/api/atlas/v2/search"
U1="admin:admin"
U2="bob:bob123"
TS=$(date +%s)

ADMIN_NAME="admin-search-$TS"
BOB_NAME="bob-search-$TS"

ADMIN_CREATE=$(curl -sS -u "$U1" -H "Content-Type: application/json" \
  -X POST "$ATLAS/saved" --data @- <<EOF
{
  "guid":"",
  "name":"$ADMIN_NAME",
  "ownerName":"admin",
  "searchType":"BASIC",
  "searchParameters":{"typeName":"hive_table","excludeDeletedEntities":true}
}
EOF
)

echo "$ADMIN_CREATE" | jq .
ADMIN_GUID=$(echo "$ADMIN_CREATE" | jq -r '.guid')
echo "ADMIN_GUID=$ADMIN_GUID"

BOB_OVERWRITE=$(curl -sS -u "$U2" -H "Content-Type: application/json" \
  -X POST "$ATLAS/saved" --data @- <<EOF
{
  "guid":"$ADMIN_GUID",
  "name":"$BOB_NAME",
  "ownerName":"bob",
  "searchType":"BASIC",
  "searchParameters":{"typeName":"hive_table","excludeDeletedEntities":true}
}
EOF
)

echo "$BOB_OVERWRITE" | jq .
{
  "guid": "6baabe6d-00c3-4e84-8481-4a67fa74f572",
  "ownerName": "admin",
  "name": "admin-search-1786438863",
  "searchType": "BASIC",
  "searchParameters": {
    "typeName": "hive_table",
    "excludeDeletedEntities": true,
    "includeClassificationAttributes": false,
    "includeSubTypes": true,
    "includeSubClassifications": true,
    "excludeHeaderAttributes": false,
    "limit": 0,
    "offset": 0
  }
}
ADMIN_GUID=6baabe6d-00c3-4e84-8481-4a67fa74f572
{
  "errorCode": "ATLAS-400-00-029",
  "errorMessage": "invalid data"
}