### PR TITLE
ATLAS-5374: Remove Related Categories / Parent column from glossary AUDIT export (CSV/XLSX)

### DIFF
--- a/repository/src/main/java/org/apache/atlas/glossary/GlossaryExportWriter.java
+++ b/repository/src/main/java/org/apache/atlas/glossary/GlossaryExportWriter.java
@@ -37,8 +37,7 @@ public class GlossaryExportWriter {
 
     private static final String[] AUDIT_HEADERS = {
             "Record Type", "Name", "Glossary Name", "Short Description", "Long Description",
-            "Status", "Classifications", "Custom Attributes", "Related Categories / Parent",
-            "Qualified Name", "GUID"
+            "Status", "Classifications", "Custom Attributes", "Qualified Name", "GUID"
     };
 
     public void write(OutputStream outputStream, List<GlossaryExportRow> rows,
@@ -133,7 +132,6 @@ public class GlossaryExportWriter {
                 safe(row.getStatus()),
                 safe(row.getClassifications()),
                 safe(row.getCustomAttributes()),
-                safe(row.getRelatedCategoriesOrParent()),
                 safe(row.getQualifiedName()),
                 safe(row.getGuid())
         };

--- a/repository/src/test/java/org/apache/atlas/glossary/GlossaryExportWriterTest.java
+++ b/repository/src/test/java/org/apache/atlas/glossary/GlossaryExportWriterTest.java
@@ -53,6 +53,8 @@ public class GlossaryExportWriterTest {
         assertTrue(csv.contains("BankBranch"));
         assertTrue(csv.contains("testBankingGlossary"));
         assertTrue(csv.contains("Record Type"));
+        assertTrue(!csv.contains("Related Categories / Parent"));
+
     }
 
     @Test
@@ -71,6 +73,9 @@ public class GlossaryExportWriterTest {
             Row data    = sheet.getRow(1);
 
             assertEquals(header.getCell(0).getStringCellValue(), "Record Type");
+            assertEquals(header.getCell(8).getStringCellValue(), "Qualified Name");
+            assertEquals(header.getCell(9).getStringCellValue(), "GUID");
+            assertEquals(header.getLastCellNum(), (short) 10);
             assertEquals(data.getCell(1).getStringCellValue(), "BankBranch");
             assertEquals(data.getCell(2).getStringCellValue(), "testBankingGlossary");
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR removes the **"Related Categories / Parent"** column from glossary **AUDIT** mode export files (CSV and XLSX).

**Changes in this PR**

| File | Change |
|------|--------|
| `repository/.../GlossaryExportWriter.java` | Remove `"Related Categories / Parent"` from `AUDIT_HEADERS`; stop writing `relatedCategoriesOrParent` in `toAuditRow()` |
| `repository/.../GlossaryExportWriterTest.java` | Assert CSV output does not contain the removed header; assert XLSX AUDIT export has **10** columns (Qualified Name at index 8, GUID at index 9) |

**AUDIT export columns after this fix (10 total)**

1. Record Type  
2. Name  
3. Glossary Name  
4. Short Description  
5. Long Description  
6. Status  
7. Classifications  
8. Custom Attributes  
9. Qualified Name  
10. GUID  

---

## How was this patch tested?

### Unit tests

```bash
mvn install -pl intg -DskipTests -Dcheckstyle.skip=true -Drat.skip=true
mvn test -pl repository -Dtest=GlossaryExportWriterTest \
  -Dcheckstyle.skip=true -Drat.skip=true
```

**Results**

- `testWriteAuditCsv` — PASS; CSV output does not contain `"Related Categories / Parent"`.
- `testWriteAuditXlsx` — PASS; XLSX header has 10 columns; column 8 = `Qualified Name`, column 9 = `GUID`.

### Manual / integration tests (curl)

After `mvn install -pl intg,repository,webapp -am` and Atlas restart:


### UI

No UI code changes in this PR.

---
