### PR TITLE
ATLAS-5349: Ability to Export Apache Atlas Business Glossary to Excel/CSV from UI

### DIFF
--- a/dashboard/src/api/apiMethods/__tests__/glossaryApiMethod.test.ts
+++ b/dashboard/src/api/apiMethods/__tests__/glossaryApiMethod.test.ts
@@ -28,6 +28,11 @@
 import {
 	removeTerm,
 	getGlossary,
+	getGlossaryTermsForGlossary,
+	getGlossaryCategoriesForGlossary,
+	searchGlossary,
+	createGlossaryExportFile,
+	getGlossaryDownloadStatus,
 	getGlossaryImportTmpl,
 	getGlossaryImport,
 	getGlossaryType,
@@ -57,7 +62,10 @@ import {
 	assignTermtoEntitiesUrl,
 	assignTermtoCategoryUrl,
 	assignGlossaryTypeUrl,
-	removeTermorCatgeoryUrl
+	removeTermorCatgeoryUrl,
+	glossaryTermsUrl,
+	glossaryCategoriesUrl,
+	glossarySearchUrl
 } from '../../../api/apiUrlLinks/glossaryUrl'
 
 // Mock dependencies
@@ -81,6 +89,11 @@ const mockAssignTermtoEntitiesUrl = jest.fn((termId: string) => `/api/glossary/t
 const mockAssignTermtoCategoryUrl = jest.fn((categoryId: string) => `/api/glossary/category/${categoryId}`)
 const mockAssignGlossaryTypeUrl = jest.fn((guid: string) => `/api/glossary/type/${guid}`)
 const mockRemoveTermorCatgeoryUrl = jest.fn((guid: string, type: string) => `/api/glossary/${type}/${guid}`)
+const mockGlossaryTermsUrl = jest.fn((guid: string) => `/api/glossary/${guid}/terms`)
+const mockGlossaryCategoriesUrl = jest.fn((guid: string) => `/api/glossary/${guid}/categories`)
+const mockGlossarySearchUrl = jest.fn(() => '/api/glossary/search')
+const mockGlossaryCreateFileUrl = jest.fn(() => '/api/glossary/create_file')
+const mockGlossaryDownloadStatusUrl = jest.fn(() => '/api/glossary/download/status')
 
 jest.mock('../../../api/apiUrlLinks/glossaryUrl', () => ({
 	removeTermUrl: (...args: any[]) => mockRemoveTermUrl(...args),
@@ -95,7 +108,12 @@ jest.mock('../../../api/apiUrlLinks/glossaryUrl', () => ({
 	assignTermtoEntitiesUrl: (...args: any[]) => mockAssignTermtoEntitiesUrl(...args),
 	assignTermtoCategoryUrl: (...args: any[]) => mockAssignTermtoCategoryUrl(...args),
 	assignGlossaryTypeUrl: (...args: any[]) => mockAssignGlossaryTypeUrl(...args),
-	removeTermorCatgeoryUrl: (...args: any[]) => mockRemoveTermorCatgeoryUrl(...args)
+	removeTermorCatgeoryUrl: (...args: any[]) => mockRemoveTermorCatgeoryUrl(...args),
+	glossaryTermsUrl: (...args: any[]) => mockGlossaryTermsUrl(...args),
+	glossaryCategoriesUrl: (...args: any[]) => mockGlossaryCategoriesUrl(...args),
+	glossarySearchUrl: (...args: any[]) => mockGlossarySearchUrl(...args),
+	glossaryCreateFileUrl: (...args: any[]) => mockGlossaryCreateFileUrl(...args),
+	glossaryDownloadStatusUrl: (...args: any[]) => mockGlossaryDownloadStatusUrl(...args)
 }))
 
 describe('glossaryApiMethod', () => {
@@ -132,6 +150,8 @@ describe('glossaryApiMethod', () => {
 		mockAssignTermtoCategoryUrl.mockImplementation((categoryId: string) => `/api/glossary/category/${categoryId}`)
 		mockAssignGlossaryTypeUrl.mockImplementation((guid: string) => `/api/glossary/type/${guid}`)
 		mockRemoveTermorCatgeoryUrl.mockImplementation((guid: string, type: string) => `/api/glossary/${type}/${guid}`)
+		mockGlossaryTermsUrl.mockImplementation((guid: string) => `/api/glossary/${guid}/terms`)
+		mockGlossaryCategoriesUrl.mockImplementation((guid: string) => `/api/glossary/${guid}/categories`)
 	})
 
 	describe('removeTerm', () => {
@@ -156,6 +176,85 @@ describe('glossaryApiMethod', () => {
 
 			expect(mockGlossaryUrl).toHaveBeenCalled()
 			expect(mockGet).toHaveBeenCalledWith('/api/glossary', {
+				method: 'GET',
+				params: {}
+			})
+			expect(result).toEqual(mockResponse)
+		})
+	})
+
+	describe('getGlossaryTermsForGlossary', () => {
+		it('should call _get with terms URL and list params', async () => {
+			const result = await getGlossaryTermsForGlossary('g-1')
+
+			expect(mockGlossaryTermsUrl).toHaveBeenCalledWith('g-1')
+			expect(mockGet).toHaveBeenCalledWith('/api/glossary/g-1/terms', {
+				method: 'GET',
+				params: { limit: -1, offset: 0, sort: 'ASC' }
+			})
+			expect(result).toEqual(mockResponse)
+		})
+	})
+
+	describe('getGlossaryCategoriesForGlossary', () => {
+		it('should call _get with categories URL and list params', async () => {
+			const result = await getGlossaryCategoriesForGlossary('g-2')
+
+			expect(mockGlossaryCategoriesUrl).toHaveBeenCalledWith('g-2')
+			expect(mockGet).toHaveBeenCalledWith('/api/glossary/g-2/categories', {
+				method: 'GET',
+				params: { limit: -1, offset: 0, sort: 'ASC' }
+			})
+			expect(result).toEqual(mockResponse)
+		})
+	})
+
+	describe('searchGlossary', () => {
+		it('should POST search parameters to glossary search URL', async () => {
+			const params = {
+				limit: 25,
+				offset: 0,
+				sortBy: 'glossaryName',
+				sortOrder: 'ASCENDING'
+			}
+			const result = await searchGlossary(params)
+
+			expect(mockGlossarySearchUrl).toHaveBeenCalled()
+			expect(mockPost).toHaveBeenCalledWith('/api/glossary/search', {
+				method: 'POST',
+				params: {},
+				data: params
+			})
+			expect(result).toEqual(mockResponse)
+		})
+	})
+
+	describe('createGlossaryExportFile', () => {
+		it('should POST export parameters to glossary create_file URL', async () => {
+			const params = {
+				limit: 0,
+				offset: 0,
+				sortBy: 'glossaryName',
+				sortOrder: 'DESCENDING'
+			}
+			const result = await createGlossaryExportFile(params)
+
+			expect(mockGlossaryCreateFileUrl).toHaveBeenCalled()
+			expect(mockPost).toHaveBeenCalledWith('/api/glossary/create_file', {
+				method: 'POST',
+				params: {},
+				data: params
+			})
+			expect(result).toEqual(mockResponse)
+		})
+	})
+
+	describe('getGlossaryDownloadStatus', () => {
+		it('should GET glossary download status URL', async () => {
+			const result = await getGlossaryDownloadStatus({})
+
+			expect(mockGlossaryDownloadStatusUrl).toHaveBeenCalled()
+			expect(mockGet).toHaveBeenCalledWith('/api/glossary/download/status', {
 				method: 'GET',
 				params: {}
 			})

--- a/dashboard/src/api/apiMethods/glossaryApiMethod.ts
+++ b/dashboard/src/api/apiMethods/glossaryApiMethod.ts
@@ -27,6 +27,11 @@ import {
   glossaryImportUrl,
   glossaryTypeUrl,
   glossaryUrl,
+  glossaryTermsUrl,
+  glossaryCategoriesUrl,
+  glossarySearchUrl,
+  glossaryCreateFileUrl,
+  glossaryDownloadStatusUrl,
   removeTermorCatgeoryUrl,
   removeTermUrl
 } from "../apiUrlLinks/glossaryUrl";
@@ -91,6 +96,48 @@ const getGlossaryType = (glossaryType: string, guid: string) => {
     params: {}
   };
   return _get(glossaryTypeUrl(glossaryType, guid), config);
+};
+
+const getGlossaryTermsForGlossary = (glossaryGuid: string) => {
+  const config: configs = {
+    method: "GET",
+    params: { limit: -1, offset: 0, sort: "ASC" }
+  };
+  return _get(glossaryTermsUrl(glossaryGuid), config);
+};
+
+const getGlossaryCategoriesForGlossary = (glossaryGuid: string) => {
+  const config: configs = {
+    method: "GET",
+    params: { limit: -1, offset: 0, sort: "ASC" }
+  };
+  return _get(glossaryCategoriesUrl(glossaryGuid), config);
+};
+
+const searchGlossary = (params: object) => {
+  const config: importConfigs = {
+    method: "POST",
+    params: {},
+    data: params
+  };
+  return _post(glossarySearchUrl(), config);
+};
+
+const createGlossaryExportFile = (params: object) => {
+  const config: importConfigs = {
+    method: "POST",
+    params: {},
+    data: params
+  };
+  return _post(glossaryCreateFileUrl(), config);
+};
+
+const getGlossaryDownloadStatus = (params: object) => {
+  const config: configs = {
+    method: "GET",
+    params: params
+  };
+  return _get(glossaryDownloadStatusUrl(), config);
 };
 
 const createGlossary = (params: any) => {
@@ -182,6 +229,11 @@ const removeTermorCategory = (
 export {
   removeTerm,
   getGlossary,
+  getGlossaryTermsForGlossary,
+  getGlossaryCategoriesForGlossary,
+  searchGlossary,
+  createGlossaryExportFile,
+  getGlossaryDownloadStatus,
   getGlossaryImportTmpl,
   getGlossaryImport,
   getGlossaryType,

--- a/dashboard/src/api/apiUrlLinks/__tests__/glossaryUrl.test.ts
+++ b/dashboard/src/api/apiUrlLinks/__tests__/glossaryUrl.test.ts
@@ -47,7 +47,13 @@ import {
 	assignTermtoEntitiesUrl,
 	assignTermtoCategoryUrl,
 	assignGlossaryTypeUrl,
-	removeTermorCatgeoryUrl
+	removeTermorCatgeoryUrl,
+	glossaryTermsUrl,
+	glossaryCategoriesUrl,
+	glossarySearchUrl,
+	glossaryCreateFileUrl,
+	glossaryDownloadStatusUrl,
+	glossaryDownloadFileUrl
 } from '../glossaryUrl'
 import { getBaseApiUrl } from '../commonApiUrl'
 
@@ -286,6 +292,54 @@ describe('glossaryUrl', () => {
 		it('should handle empty guid', () => {
 			const result = assignGlossaryTypeUrl('')
 			expect(result).toBe('/mock-base-url/api/atlas/v2/glossary/term/')
+		})
+	})
+
+	describe('glossaryTermsUrl', () => {
+		it('should return terms URL for a glossary guid', () => {
+			const result = glossaryTermsUrl('glossary-guid-1')
+			expect(result).toBe(
+				'/mock-base-url/api/atlas/v2/glossary/glossary-guid-1/terms'
+			)
+		})
+	})
+
+	describe('glossaryCategoriesUrl', () => {
+		it('should return categories URL for a glossary guid', () => {
+			const result = glossaryCategoriesUrl('glossary-guid-2')
+			expect(result).toBe(
+				'/mock-base-url/api/atlas/v2/glossary/glossary-guid-2/categories'
+			)
+		})
+	})
+
+	describe('glossarySearchUrl', () => {
+		it('should return glossary search URL', () => {
+			const result = glossarySearchUrl()
+			expect(result).toBe('/mock-base-url/api/atlas/v2/glossary/search')
+		})
+	})
+
+	describe('glossaryCreateFileUrl', () => {
+		it('should return glossary create_file URL', () => {
+			const result = glossaryCreateFileUrl()
+			expect(result).toBe('/mock-base-url/api/atlas/v2/glossary/create_file')
+		})
+	})
+
+	describe('glossaryDownloadStatusUrl', () => {
+		it('should return glossary download status URL', () => {
+			const result = glossaryDownloadStatusUrl()
+			expect(result).toBe('/mock-base-url/api/atlas/v2/glossary/download/status')
+		})
+	})
+
+	describe('glossaryDownloadFileUrl', () => {
+		it('should return glossary download file URL', () => {
+			const result = glossaryDownloadFileUrl('glossary-export.csv')
+			expect(result).toBe(
+				'/mock-base-url/api/atlas/v2/glossary/download/glossary-export.csv'
+			)
 		})
 	})
 

--- a/dashboard/src/api/apiUrlLinks/glossaryUrl.ts
+++ b/dashboard/src/api/apiUrlLinks/glossaryUrl.ts
@@ -40,6 +40,30 @@ const glossaryTypeUrl = (glossaryType: string, guid: string) => {
   return `${glossaryUrl()}/${glossaryType}/${guid}`;
 };
 
+const glossaryTermsUrl = (glossaryGuid: string) => {
+  return `${glossaryUrl()}/${glossaryGuid}/terms`;
+};
+
+const glossaryCategoriesUrl = (glossaryGuid: string) => {
+  return `${glossaryUrl()}/${glossaryGuid}/categories`;
+};
+
+const glossarySearchUrl = () => {
+  return `${glossaryUrl()}/search`;
+};
+
+const glossaryCreateFileUrl = () => {
+  return `${glossaryUrl()}/create_file`;
+};
+
+const glossaryDownloadStatusUrl = () => {
+  return `${glossaryUrl()}/download/status`;
+};
+
+const glossaryDownloadFileUrl = (fileName: string) => {
+  return `${glossaryUrl()}/download/${fileName}`;
+};
+
 const editGlossaryUrl = (guid: string) => {
   return `${glossaryUrl()}/${guid}`;
 };
@@ -83,6 +107,12 @@ export {
   glossaryImportTempUrl,
   glossaryImportUrl,
   glossaryTypeUrl,
+  glossaryTermsUrl,
+  glossaryCategoriesUrl,
+  glossarySearchUrl,
+  glossaryCreateFileUrl,
+  glossaryDownloadStatusUrl,
+  glossaryDownloadFileUrl,
   editGlossaryUrl,
   deleteGlossaryorTermUrl,
   createTermorCategoryUrl,

--- a/dashboard/src/components/ImportDialog.tsx
+++ b/dashboard/src/components/ImportDialog.tsx
@@ -62,12 +62,14 @@ interface CustomModalProps {
   open: boolean;
   onClose: () => void;
   title: string;
+  onImportSuccess?: () => void;
 }
 
 export const ImportDialog: React.FC<CustomModalProps> = ({
   open,
   onClose,
-  title
+  title,
+  onImportSuccess
 }) => {
   const [fileData, setFileData] = useState<any>([]);
   const [progress, setProgress] = useState(0);
@@ -106,6 +108,7 @@ export const ImportDialog: React.FC<CustomModalProps> = ({
             `File: ${fileData.name} imported successfully`
           );
 
+          onImportSuccess?.();
           onClose();
           setErrorDetails(false);
           setFileData([]);

--- a/dashboard/src/components/__tests__/ImportDialog.test.tsx
+++ b/dashboard/src/components/__tests__/ImportDialog.test.tsx
@@ -85,9 +85,15 @@ describe('ImportDialog', () => {
 	it('uploads business metadata file successfully', async () => {
 		uploadMock.mockResolvedValue({ data: {} })
 		const onClose = jest.fn()
+		const onImportSuccess = jest.fn()
 
 		render(
-			<ImportDialog open={true} onClose={onClose} title="Import Business Metadata" />
+			<ImportDialog
+				open={true}
+				onClose={onClose}
+				onImportSuccess={onImportSuccess}
+				title="Import Business Metadata"
+			/>
 		)
 
 		fireEvent.click(screen.getByText('Select File'))
@@ -96,8 +102,32 @@ describe('ImportDialog', () => {
 		await waitFor(() => {
 			expect(uploadMock).toHaveBeenCalled()
 			expect(onClose).toHaveBeenCalled()
+			expect(onImportSuccess).toHaveBeenCalled()
 			expect(toastSuccess).toHaveBeenCalled()
 		})
+	})
+
+	it('does not call onImportSuccess when upload fails', async () => {
+		uploadMock.mockRejectedValue(new Error('fail'))
+		const onImportSuccess = jest.fn()
+
+		render(
+			<ImportDialog
+				open={true}
+				onClose={jest.fn()}
+				onImportSuccess={onImportSuccess}
+				title="Import Business Metadata"
+			/>
+		)
+
+		fireEvent.click(screen.getByText('Select File'))
+		fireEvent.click(screen.getByText('Upload'))
+
+		await waitFor(() => {
+			expect(toastError).toHaveBeenCalledWith('Invalid JSON response from server')
+		})
+
+		expect(onImportSuccess).not.toHaveBeenCalled()
 	})
 
 	it('shows error details when import returns failed info', async () => {

--- a/dashboard/src/index.scss
+++ b/dashboard/src/index.scss
@@ -35,6 +35,7 @@
 @use "@styles/errorPage.scss" as *;
 @use "@styles/customdatepPicker.scss" as *;
 @use "@styles/administration.scss" as *;
+@use "@styles/glossary.scss" as *;
 
 @font-face {
   font-family: "Source Sans 3";

--- a/dashboard/src/styles/glossary.scss
+++ b/dashboard/src/styles/glossary.scss
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.glossary-terms-list-page {
+  width: 100%;
+  text-align: left;
+
+  .glossary-terms-list-header {
+    padding: 16px 16px 0;
+    margin-bottom: 16px;
+  }
+
+  .glossary-terms-list-title {
+    margin: 0;
+  }
+
+  .glossary-terms-filters {
+    margin: 0 16px;
+    padding: 16px;
+    border: thin #e1e2e4 solid;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.6);
+  }
+
+  .glossary-terms-filters-label {
+    margin-bottom: 12px;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.87);
+  }
+
+  .glossary-terms-table {
+    padding: 0 16px 16px;
+    flex: 1;
+    min-height: 0;
+
+    .searchTableName .glossary-term-name-link {
+      width: unset !important;
+      white-space: nowrap;
+    }
+  }
+}

--- a/dashboard/src/utils/__tests__/downloadRecords.test.ts
+++ b/dashboard/src/utils/__tests__/downloadRecords.test.ts
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  dedupeDownloadRecordsByFileName,
+  extractDownloadRecords,
+  filterDownloadRecordsForToggle,
+  mergeDownloadRecords,
+  parseCreatedTime,
+  parseTimestampFromFileName,
+  resolveDownloadRecordTime,
+  sortDownloadRecordsByLatest
+} from "../downloadRecords";
+
+describe("downloadRecords utils", () => {
+  it("parseCreatedTime accepts epoch numbers", () => {
+    expect(parseCreatedTime(1_700_000_000_000)).toBe(1_700_000_000_000);
+  });
+
+  it("parseCreatedTime accepts ISO strings", () => {
+    const iso = "2026-08-12T15:36:29.000Z";
+    expect(parseCreatedTime(iso)).toBe(Date.parse(iso));
+  });
+
+  it("parseCreatedTime returns null for invalid values", () => {
+    expect(parseCreatedTime(undefined)).toBeNull();
+    expect(parseCreatedTime("not-a-date")).toBeNull();
+  });
+
+  it("parseTimestampFromFileName parses glossary export filenames", () => {
+    expect(
+      parseTimestampFromFileName(
+        "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx"
+      )
+    ).toBe(Date.parse("2026-08-12T15:36:29"));
+  });
+
+  it("parseTimestampFromFileName parses search export filenames", () => {
+    expect(
+      parseTimestampFromFileName(
+        "admin_basic_2026-08-12_12-47-19.123.csv"
+      )
+    ).toBe(Date.parse("2026-08-12T12:47:19.123"));
+  });
+
+  it("resolveDownloadRecordTime prefers API createdTime over filename", () => {
+    expect(
+      resolveDownloadRecordTime({
+        fileName: "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx",
+        createdTime: 1_700_000_000_000
+      })
+    ).toBe(1_700_000_000_000);
+  });
+
+  it("resolveDownloadRecordTime falls back to filename timestamp", () => {
+    expect(
+      resolveDownloadRecordTime({
+        fileName: "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx"
+      })
+    ).toBe(Date.parse("2026-08-12T15:36:29"));
+  });
+
+  it("sortDownloadRecordsByLatest orders newest first using createdTime", () => {
+    const sorted = sortDownloadRecordsByLatest([
+      {
+        fileName: "older.csv",
+        source: "search",
+        createdTime: 1_000
+      },
+      {
+        fileName: "newer.csv",
+        source: "search",
+        createdTime: 2_000
+      }
+    ]);
+
+    expect(sorted.map((record) => record.fileName)).toEqual([
+      "newer.csv",
+      "older.csv"
+    ]);
+  });
+
+  it("sortDownloadRecordsByLatest orders newest first using filename timestamps", () => {
+    const sorted = sortDownloadRecordsByLatest([
+      {
+        fileName: "admin_GLOSSARY_EXPORT_2026-08-12_12-11-41.csv",
+        source: "glossary"
+      },
+      {
+        fileName: "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx",
+        source: "glossary"
+      }
+    ]);
+
+    expect(sorted.map((record) => record.fileName)).toEqual([
+      "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx",
+      "admin_GLOSSARY_EXPORT_2026-08-12_12-11-41.csv"
+    ]);
+  });
+
+  it("extractDownloadRecords reads glossary records from searchDownloadRecords fallback", () => {
+    const records = extractDownloadRecords(
+      {
+        searchDownloadRecords: [
+          {
+            fileName: "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx",
+            createdTime: 100
+          }
+        ]
+      },
+      "glossary"
+    );
+
+    expect(records).toEqual([
+      {
+        fileName: "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx",
+        source: "glossary",
+        createdTime: 100,
+        status: undefined
+      }
+    ]);
+  });
+
+  it("mergeDownloadRecords combines and sorts search and glossary records", () => {
+    const merged = mergeDownloadRecords(
+      [
+        {
+          fileName: "admin_basic_2026-08-12_12-47-19.csv",
+          source: "search"
+        }
+      ],
+      [
+        {
+          fileName: "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx",
+          source: "glossary"
+        }
+      ]
+    );
+
+    expect(merged.map((record) => record.fileName)).toEqual([
+      "admin_GLOSSARY_EXPORT_2026-08-12_15-36-29.xlsx",
+      "admin_basic_2026-08-12_12-47-19.csv"
+    ]);
+  });
+
+  it("dedupeDownloadRecordsByFileName keeps the newest duplicate fileName", () => {
+    const deduped = dedupeDownloadRecordsByFileName([
+      {
+        fileName: "duplicate.csv",
+        source: "search",
+        createdTime: 100
+      },
+      {
+        fileName: "duplicate.csv",
+        source: "glossary",
+        createdTime: 200
+      }
+    ]);
+
+    expect(deduped).toEqual([
+      {
+        fileName: "duplicate.csv",
+        source: "glossary",
+        createdTime: 200
+      }
+    ]);
+  });
+
+  it("filterDownloadRecordsForToggle returns all files when showing all exports", () => {
+    const records = [
+      {
+        fileName: "ready.csv",
+        source: "search" as const,
+        status: "COMPLETE"
+      },
+      {
+        fileName: "pending.csv",
+        source: "search" as const,
+        status: "PENDING"
+      }
+    ];
+
+    expect(filterDownloadRecordsForToggle(records, true)).toEqual(records);
+  });
+
+  it("filterDownloadRecordsForToggle hides pending files when showing completed only", () => {
+    const records = [
+      {
+        fileName: "ready.csv",
+        source: "search" as const,
+        status: "COMPLETE"
+      },
+      {
+        fileName: "pending.csv",
+        source: "search" as const,
+        status: "PENDING"
+      }
+    ];
+
+    expect(filterDownloadRecordsForToggle(records, false)).toEqual([
+      {
+        fileName: "ready.csv",
+        source: "search",
+        status: "COMPLETE"
+      }
+    ]);
+  });
+});

--- a/dashboard/src/utils/__tests__/glossaryExport.test.ts
+++ b/dashboard/src/utils/__tests__/glossaryExport.test.ts
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createGlossaryExportFile,
+  searchGlossary
+} from "@api/apiMethods/glossaryApiMethod";
+import {
+  buildGlossarySearchExportRequest,
+  buildGlossarySearchRequest,
+  createDefaultGlossaryBrowseFilters,
+  fetchGlossarySearchPage,
+  formatCustomAttributesForDisplay,
+  formatCustomAttributesForTooltip,
+  GLOSSARY_STATUS_FILTER_OPTIONS,
+  mapGlossarySearchResultToTableRows,
+  mapRecordTypeToGlossaryType,
+  requestGlossaryExportDownload,
+  unwrapGlossarySearchResponse,
+  type GlossarySearchResponse
+} from "../glossaryExport";
+
+jest.mock("@api/apiMethods/glossaryApiMethod", () => ({
+  searchGlossary: jest.fn(),
+  createGlossaryExportFile: jest.fn()
+}));
+
+const mockSearchGlossary = searchGlossary as jest.MockedFunction<
+  typeof searchGlossary
+>;
+const mockCreateGlossaryExportFile =
+  createGlossaryExportFile as jest.MockedFunction<
+    typeof createGlossaryExportFile
+  >;
+
+describe("glossaryExport utilities", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("createDefaultGlossaryBrowseFilters returns empty filters", () => {
+    expect(createDefaultGlossaryBrowseFilters()).toEqual({
+      recordType: "all",
+      glossaryName: "",
+      statusFilter: "",
+      searchText: ""
+    });
+  });
+
+  it("mapRecordTypeToGlossaryType maps UI filters to API enum", () => {
+    expect(mapRecordTypeToGlossaryType("Term")).toBe("TERM");
+    expect(mapRecordTypeToGlossaryType("Category")).toBe("CATEGORY");
+    expect(mapRecordTypeToGlossaryType("all")).toBeUndefined();
+  });
+
+  it("buildGlossarySearchRequest applies defaults and filters", () => {
+    const request = buildGlossarySearchRequest(
+      {
+        ...createDefaultGlossaryBrowseFilters(),
+        recordType: "Term",
+        glossaryName: "Bank",
+        statusFilter: "DRAFT",
+        searchText: "capital"
+      },
+      1,
+      25,
+      { Bank: "guid-1" }
+    );
+    expect(request).toEqual({
+      limit: 25,
+      offset: 25,
+      sortBy: "glossaryName",
+      sortOrder: "DESCENDING",
+      excludeDeleted: true,
+      glossaryType: "TERM",
+      status: "DRAFT",
+      searchQuery: "capital",
+      glossary: { name: "Bank", guid: "guid-1" }
+    });
+  });
+
+  it("buildGlossarySearchExportRequest zeroes pagination for full export", () => {
+    const request = buildGlossarySearchExportRequest(
+      {
+        ...createDefaultGlossaryBrowseFilters(),
+        recordType: "Category",
+        glossaryName: "Bank",
+        statusFilter: "ACTIVE",
+        searchText: "branch"
+      },
+      { Bank: "guid-1" }
+    );
+
+    expect(request).toEqual({
+      limit: 0,
+      offset: 0,
+      sortBy: "glossaryName",
+      sortOrder: "DESCENDING",
+      excludeDeleted: true,
+      glossaryType: "CATEGORY",
+      status: "ACTIVE",
+      searchQuery: "branch",
+      glossary: { name: "Bank", guid: "guid-1" },
+      format: "CSV"
+    });
+  });
+
+  it("formatCustomAttributesForDisplay renders key-value string", () => {
+    expect(
+      formatCustomAttributesForDisplay({
+        department: "Retail",
+        status: "Active"
+      })
+    ).toBe("department: Retail, status: Active");
+  });
+
+  it("formatCustomAttributesForDisplay returns empty string for nullish values", () => {
+    expect(formatCustomAttributesForDisplay(null)).toBe("");
+    expect(formatCustomAttributesForDisplay(undefined)).toBe("");
+    expect(formatCustomAttributesForDisplay({})).toBe("");
+  });
+
+  it("formatCustomAttributesForTooltip renders JSON details", () => {
+    expect(
+      formatCustomAttributesForTooltip({
+        department: "Retail",
+        status: "Active"
+      })
+    ).toContain('"department": "Retail"');
+  });
+
+  it("exposes glossary status filter dropdown options", () => {
+    expect(GLOSSARY_STATUS_FILTER_OPTIONS).toEqual([
+      { label: "All", value: "" },
+      { label: "Draft", value: "DRAFT" },
+      { label: "Active", value: "ACTIVE" },
+      { label: "Deprecated", value: "DEPRECATED" }
+    ]);
+  });
+
+  it("mapGlossarySearchResultToTableRows maps terms and categories with guids", () => {
+    const response: GlossarySearchResponse = {
+      approximateCount: 2,
+      glossary: [
+        {
+          name: "testBankingGlossary",
+          guid: "glossary-guid-1",
+          terms: [
+            {
+              name: "CapitalTerm075",
+              guid: "term-guid-1",
+              qualifiedName: "CapitalTerm075@testBankingGlossary",
+              status: "ACTIVE",
+              classifications: [{ typeName: "class3" }],
+              customAttributes: { department: "Retail", status: "Active" }
+            }
+          ],
+          categories: [
+            {
+              name: "BranchCategory",
+              guid: "category-guid-1",
+              status: "ACTIVE"
+            }
+          ]
+        }
+      ]
+    };
+    const rows = mapGlossarySearchResultToTableRows(response);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      recordType: "Term",
+      name: "CapitalTerm075",
+      guid: "term-guid-1",
+      glossaryGuid: "glossary-guid-1",
+      classifications: [{ typeName: "class3" }],
+      customAttributes: { department: "Retail", status: "Active" }
+    });
+    expect(rows[1]).toMatchObject({
+      recordType: "Category",
+      name: "BranchCategory",
+      guid: "category-guid-1",
+      glossaryGuid: "glossary-guid-1",
+      customAttributes: {}
+    });
+  });
+
+  it("mapGlossarySearchResultToTableRows returns empty array for invalid responses", () => {
+    expect(mapGlossarySearchResultToTableRows(null)).toEqual([]);
+    expect(mapGlossarySearchResultToTableRows(undefined)).toEqual([]);
+    expect(
+      mapGlossarySearchResultToTableRows({
+        glossary: "not-array" as unknown as GlossarySearchResponse["glossary"]
+      })
+    ).toEqual([]);
+  });
+
+  it("unwrapGlossarySearchResponse reads axios data wrapper", () => {
+    const body: GlossarySearchResponse = {
+      approximateCount: 1,
+      glossary: [{ name: "G1", guid: "guid-1", terms: [{ name: "T1" }] }]
+    };
+    expect(unwrapGlossarySearchResponse({ data: body })).toEqual(body);
+    expect(unwrapGlossarySearchResponse(body)).toEqual(body);
+  });
+
+  it("fetchGlossarySearchPage maps API response to rows and total count", async () => {
+    mockSearchGlossary.mockResolvedValue({
+      data: {
+        approximateCount: 1,
+        glossary: [
+          {
+            name: "G1",
+            guid: "g-1",
+            terms: [{ name: "Term1", guid: "t-1" }]
+          }
+        ]
+      }
+    });
+
+    const result = await fetchGlossarySearchPage({
+      limit: 25,
+      offset: 0,
+      sortBy: "glossaryName",
+      sortOrder: "DESCENDING"
+    });
+
+    expect(mockSearchGlossary).toHaveBeenCalled();
+    expect(result.rows).toHaveLength(1);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it("fetchGlossarySearchPage rejects when searchGlossary fails", async () => {
+    const error = new Error("search failed");
+    mockSearchGlossary.mockRejectedValue(error);
+
+    await expect(
+      fetchGlossarySearchPage({
+        limit: 25,
+        offset: 0,
+        sortBy: "glossaryName",
+        sortOrder: "DESCENDING"
+      })
+    ).rejects.toThrow("search failed");
+  });
+
+  it("requestGlossaryExportDownload enqueues export via create_file API", async () => {
+    mockCreateGlossaryExportFile.mockResolvedValue(undefined);
+
+    await requestGlossaryExportDownload(
+      createDefaultGlossaryBrowseFilters(),
+      { Bank: "guid-1" }
+    );
+
+    expect(mockCreateGlossaryExportFile).toHaveBeenCalledWith({
+      limit: 0,
+      offset: 0,
+      sortBy: "glossaryName",
+      sortOrder: "DESCENDING",
+      excludeDeleted: true,
+      format: "CSV"
+    });
+  });
+
+  it("requestGlossaryExportDownload sends selected XLSX format", async () => {
+    mockCreateGlossaryExportFile.mockResolvedValue(undefined);
+
+    await requestGlossaryExportDownload(
+      createDefaultGlossaryBrowseFilters(),
+      { Bank: "guid-1" },
+      "XLSX"
+    );
+
+    expect(mockCreateGlossaryExportFile).toHaveBeenCalledWith(
+      expect.objectContaining({ format: "XLSX" })
+    );
+  });
+
+  it("requestGlossaryExportDownload rejects when createGlossaryExportFile fails", async () => {
+    const error = new Error("export failed");
+    mockCreateGlossaryExportFile.mockRejectedValue(error);
+
+    await expect(
+      requestGlossaryExportDownload(createDefaultGlossaryBrowseFilters())
+    ).rejects.toThrow("export failed");
+  });
+});

--- a/dashboard/src/utils/__tests__/glossaryStatus.test.ts
+++ b/dashboard/src/utils/__tests__/glossaryStatus.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getGlossaryStatusMeta,
+  GLOSSARY_STATUS_META,
+  normalizeGlossaryStatus
+} from "@utils/glossaryStatus";
+
+describe("glossaryStatus", () => {
+  it("normalizes glossary status values", () => {
+    expect(normalizeGlossaryStatus("active")).toBe("ACTIVE");
+    expect(normalizeGlossaryStatus("DRAFT")).toBe("DRAFT");
+    expect(normalizeGlossaryStatus("Deprecated")).toBe("DEPRECATED");
+    expect(normalizeGlossaryStatus("")).toBe("UNKNOWN");
+    expect(normalizeGlossaryStatus(undefined)).toBe("UNKNOWN");
+  });
+
+  it("returns display metadata for each status", () => {
+    expect(getGlossaryStatusMeta("ACTIVE")).toEqual(
+      GLOSSARY_STATUS_META.ACTIVE
+    );
+    expect(getGlossaryStatusMeta("DRAFT").muiColor).toBe("warning");
+    expect(getGlossaryStatusMeta("DEPRECATED").muiColor).toBe("error");
+    expect(getGlossaryStatusMeta("invalid").muiColor).toBe("default");
+  });
+});

--- a/dashboard/src/utils/downloadRecords.ts
+++ b/dashboard/src/utils/downloadRecords.ts
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type DownloadSource = "search" | "glossary";
+
+export type DownloadRecord = {
+  fileName: string;
+  source: DownloadSource;
+  createdTime?: number | string;
+  status?: string;
+};
+
+type RawDownloadRecord = {
+  fileName?: string;
+  createdTime?: number | string;
+  status?: string;
+};
+
+const FILE_NAME_TIMESTAMP_PATTERN =
+  /(\d{4}-\d{2}-\d{2})_(\d{2})-(\d{2})-(\d{2}(?:\.\d{3})?)/;
+
+export const parseCreatedTime = (
+  createdTime?: number | string
+): number | null => {
+  if (createdTime === undefined || createdTime === null || createdTime === "") {
+    return null;
+  }
+
+  if (typeof createdTime === "number" && Number.isFinite(createdTime)) {
+    return createdTime;
+  }
+
+  const parsed = Date.parse(String(createdTime));
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const parseTimestampFromFileName = (fileName: string): number | null => {
+  const match = fileName.match(FILE_NAME_TIMESTAMP_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  const normalized = `${match[1]}T${match[2]}:${match[3]}:${match[4]}`;
+  const parsed = Date.parse(normalized);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const resolveDownloadRecordTime = (record: {
+  fileName: string;
+  createdTime?: number | string;
+}): number => {
+  const fromApi = parseCreatedTime(record.createdTime);
+  if (fromApi !== null) {
+    return fromApi;
+  }
+
+  const fromFileName = parseTimestampFromFileName(record.fileName);
+  return fromFileName ?? 0;
+};
+
+export const sortDownloadRecordsByLatest = <T extends DownloadRecord>(
+  records: T[]
+): T[] => {
+  return [...records].sort(
+    (left, right) =>
+      resolveDownloadRecordTime(right) - resolveDownloadRecordTime(left)
+  );
+};
+
+export const dedupeDownloadRecordsByFileName = (
+  records: DownloadRecord[]
+): DownloadRecord[] => {
+  const byFileName = new Map<string, DownloadRecord>();
+
+  records.forEach((record) => {
+    const existing = byFileName.get(record.fileName);
+    if (
+      !existing ||
+      resolveDownloadRecordTime(record) > resolveDownloadRecordTime(existing)
+    ) {
+      byFileName.set(record.fileName, record);
+    }
+  });
+
+  return sortDownloadRecordsByLatest(Array.from(byFileName.values()));
+};
+
+export const filterDownloadRecordsForToggle = (
+  records: DownloadRecord[],
+  showAllFiles: boolean
+): DownloadRecord[] => {
+  if (showAllFiles) {
+    return records;
+  }
+
+  return records.filter((record) => record.status !== "PENDING");
+};
+
+export const isPendingDownloadRecord = (record: DownloadRecord): boolean =>
+  record.status === "PENDING";
+
+export const extractDownloadRecords = (
+  data: Record<string, unknown> | undefined,
+  source: DownloadSource
+): DownloadRecord[] => {
+  const records =
+    source === "glossary"
+      ? ((data?.glossaryDownloadRecords ??
+          data?.searchDownloadRecords ??
+          []) as RawDownloadRecord[])
+      : ((data?.searchDownloadRecords ?? []) as RawDownloadRecord[]);
+
+  return records
+    .filter((record) => Boolean(record?.fileName))
+    .map((record) => ({
+      fileName: record.fileName as string,
+      source,
+      createdTime: record.createdTime,
+      status: record.status
+    }));
+};
+
+export const mergeDownloadRecords = (
+  searchRecords: DownloadRecord[],
+  glossaryRecords: DownloadRecord[]
+): DownloadRecord[] => {
+  return dedupeDownloadRecordsByFileName([
+    ...searchRecords,
+    ...glossaryRecords
+  ]);
+};

--- a/dashboard/src/utils/glossaryExport.ts
+++ b/dashboard/src/utils/glossaryExport.ts
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createGlossaryExportFile,
+  searchGlossary
+} from "@api/apiMethods/glossaryApiMethod";
+
+export const GLOSSARY_SEARCH_DEFAULTS = {
+  limit: 25,
+  offset: 0,
+  sortBy: "glossaryName",
+  sortOrder: "DESCENDING"
+} as const;
+
+export type GlossarySearchSortOrder = "ASCENDING" | "DESCENDING";
+
+export type GlossarySearchGlossaryType = "ALL" | "TERM" | "CATEGORY";
+
+export interface GlossarySearchRequest {
+  limit: number;
+  offset: number;
+  sortBy: string;
+  sortOrder: GlossarySearchSortOrder;
+  glossaryType?: GlossarySearchGlossaryType;
+  status?: string;
+  searchQuery?: string;
+  glossary?: { name?: string; guid?: string };
+  excludeDeleted?: boolean;
+}
+
+export interface GlossarySearchClassification {
+  typeName?: string;
+  entityGuid?: string;
+  attributes?: Record<string, unknown>;
+}
+
+export interface GlossarySearchTermDetail {
+  name?: string;
+  qualifiedName?: string;
+  guid?: string;
+  shortDescription?: string;
+  longDescription?: string;
+  status?: string;
+  classifications?: GlossarySearchClassification[];
+  customAttributes?: Record<string, unknown>;
+}
+
+export interface GlossarySearchCategoryDetail {
+  name?: string;
+  qualifiedName?: string;
+  guid?: string;
+  shortDescription?: string;
+  longDescription?: string;
+  status?: string;
+  classifications?: GlossarySearchClassification[];
+  customAttributes?: Record<string, unknown>;
+}
+
+export interface GlossarySearchGlossaryDetail {
+  name?: string;
+  guid?: string;
+  terms?: GlossarySearchTermDetail[];
+  categories?: GlossarySearchCategoryDetail[];
+}
+
+export interface GlossarySearchResponse {
+  glossary?: GlossarySearchGlossaryDetail[];
+  approximateCount?: number;
+}
+
+export interface GlossaryBrowseFilters {
+  recordType: "all" | "Term" | "Category";
+  glossaryName: string;
+  statusFilter: string;
+  searchText: string;
+}
+
+export type GlossaryExportFormat = "CSV" | "XLSX";
+
+export const GLOSSARY_EXPORT_FORMAT_OPTIONS = [
+  { label: "CSV", value: "CSV" as const },
+  { label: "XLSX", value: "XLSX" as const }
+] as const;
+
+export const GLOSSARY_STATUS_FILTER_OPTIONS = [
+  { label: "All", value: "" },
+  { label: "Draft", value: "DRAFT" },
+  { label: "Active", value: "ACTIVE" },
+  { label: "Deprecated", value: "DEPRECATED" }
+] as const;
+
+export type GlossaryTableRow = {
+  id: string;
+  recordType: "Term" | "Category";
+  name: string;
+  guid: string;
+  qualifiedName: string;
+  glossaryName: string;
+  glossaryGuid: string;
+  shortDescription: string;
+  longDescription: string;
+  status: string;
+  classifications: GlossarySearchClassification[];
+  customAttributes: Record<string, unknown>;
+};
+
+export const createDefaultGlossaryBrowseFilters = (): GlossaryBrowseFilters => ({
+  recordType: "all",
+  glossaryName: "",
+  statusFilter: "",
+  searchText: ""
+});
+
+export const mapRecordTypeToGlossaryType = (
+  recordType: GlossaryBrowseFilters["recordType"]
+): GlossarySearchGlossaryType | undefined => {
+  if (recordType === "Term") {
+    return "TERM";
+  }
+  if (recordType === "Category") {
+    return "CATEGORY";
+  }
+  return undefined;
+};
+
+export const buildGlossarySearchRequest = (
+  filters: GlossaryBrowseFilters,
+  page: number,
+  rowsPerPage: number,
+  glossaryGuidByName: Record<string, string> = {}
+): GlossarySearchRequest => {
+  const request: GlossarySearchRequest = {
+    limit: rowsPerPage,
+    offset: page * rowsPerPage,
+    sortBy: GLOSSARY_SEARCH_DEFAULTS.sortBy,
+    sortOrder: GLOSSARY_SEARCH_DEFAULTS.sortOrder,
+    excludeDeleted: true
+  };
+
+  const glossaryType = mapRecordTypeToGlossaryType(filters.recordType);
+  if (glossaryType) {
+    request.glossaryType = glossaryType;
+  }
+
+  const status = filters.statusFilter.trim();
+  if (status) {
+    request.status = status;
+  }
+
+  const searchQuery = filters.searchText.trim();
+  if (searchQuery) {
+    request.searchQuery = searchQuery;
+  }
+
+  const glossaryName = filters.glossaryName.trim();
+  if (glossaryName) {
+    request.glossary = {
+      name: glossaryName,
+      guid: glossaryGuidByName[glossaryName]
+    };
+  }
+
+  return request;
+};
+
+export const buildGlossarySearchExportRequest = (
+  filters: GlossaryBrowseFilters,
+  glossaryGuidByName: Record<string, string> = {},
+  format: GlossaryExportFormat = "CSV"
+): GlossarySearchRequest & { format: GlossaryExportFormat } => ({
+  ...buildGlossarySearchRequest(filters, 0, 0, glossaryGuidByName),
+  limit: 0,
+  offset: 0,
+  format
+});
+
+const empty = (v: unknown): string =>
+  v === null || v === undefined ? "" : String(v);
+
+export const formatCustomAttributesForDisplay = (
+  attrs: Record<string, unknown> | null | undefined
+): string => {
+  if (!attrs || typeof attrs !== "object" || Object.keys(attrs).length === 0) {
+    return "";
+  }
+  return Object.entries(attrs)
+    .map(([key, value]) => `${key}: ${empty(value)}`)
+    .join(", ");
+};
+
+export const formatCustomAttributesForTooltip = (
+  attrs: Record<string, unknown> | null | undefined
+): string => {
+  if (!attrs || typeof attrs !== "object" || Object.keys(attrs).length === 0) {
+    return "";
+  }
+  try {
+    return JSON.stringify(attrs, null, 2);
+  } catch {
+    return formatCustomAttributesForDisplay(attrs);
+  }
+};
+
+const mapDetailToTableRow = (
+  detail: GlossarySearchTermDetail | GlossarySearchCategoryDetail,
+  recordType: GlossaryTableRow["recordType"],
+  glossaryName: string,
+  glossaryGuid: string
+): GlossaryTableRow => ({
+  id: `${recordType.toLowerCase()}-${empty(detail.guid) || empty(detail.name)}`,
+  recordType,
+  name: empty(detail.name),
+  guid: empty(detail.guid),
+  qualifiedName: empty(detail.qualifiedName),
+  glossaryName,
+  glossaryGuid,
+  shortDescription: empty(detail.shortDescription),
+  longDescription: empty(detail.longDescription),
+  status: empty(detail.status),
+  classifications: detail.classifications ?? [],
+  customAttributes: detail.customAttributes ?? {}
+});
+
+export const mapGlossarySearchResultToTableRows = (
+  response: GlossarySearchResponse | null | undefined
+): GlossaryTableRow[] => {
+  const glossaries = response?.glossary;
+  if (!Array.isArray(glossaries)) {
+    return [];
+  }
+
+  const rows: GlossaryTableRow[] = [];
+  glossaries.forEach((glossary) => {
+    const glossaryName = empty(glossary?.name);
+    const glossaryGuid = empty(glossary?.guid);
+    (glossary?.terms ?? []).forEach((term) => {
+      rows.push(mapDetailToTableRow(term, "Term", glossaryName, glossaryGuid));
+    });
+    (glossary?.categories ?? []).forEach((category) => {
+      rows.push(
+        mapDetailToTableRow(category, "Category", glossaryName, glossaryGuid)
+      );
+    });
+  });
+
+  return rows;
+};
+
+/** Axios returns { data }; unwrap to GlossarySearchResponse body. */
+export const unwrapGlossarySearchResponse = (
+  response: unknown
+): GlossarySearchResponse => {
+  if (
+    response &&
+    typeof response === "object" &&
+    "data" in response &&
+    (response as { data: unknown }).data &&
+    typeof (response as { data: unknown }).data === "object"
+  ) {
+    return (response as { data: GlossarySearchResponse }).data;
+  }
+  return (response as GlossarySearchResponse) ?? {};
+};
+
+export async function fetchGlossarySearchPage(
+  request: GlossarySearchRequest
+): Promise<{
+  rows: GlossaryTableRow[];
+  totalCount: number;
+}> {
+  const raw = await searchGlossary(request);
+  const response = unwrapGlossarySearchResponse(raw);
+  const rows = mapGlossarySearchResultToTableRows(response);
+  const totalCount =
+    typeof response?.approximateCount === "number"
+      ? response.approximateCount
+      : rows.length;
+
+  return { rows, totalCount };
+}
+
+export async function requestGlossaryExportDownload(
+  filters: GlossaryBrowseFilters,
+  glossaryGuidByName: Record<string, string> = {},
+  format: GlossaryExportFormat = "CSV"
+): Promise<void> {
+  const request = buildGlossarySearchExportRequest(
+    filters,
+    glossaryGuidByName,
+    format
+  );
+  await createGlossaryExportFile(request);
+}

--- a/dashboard/src/utils/glossaryStatus.ts
+++ b/dashboard/src/utils/glossaryStatus.ts
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type GlossaryStatusKey = "ACTIVE" | "DRAFT" | "DEPRECATED" | "UNKNOWN";
+
+export type GlossaryStatusMeta = {
+  label: string;
+  shortLabel: string;
+  muiColor: "success" | "warning" | "error" | "default";
+  ariaLabel: string;
+};
+
+export const GLOSSARY_STATUS_META: Record<GlossaryStatusKey, GlossaryStatusMeta> = {
+  ACTIVE: {
+    label: "Active",
+    shortLabel: "Active",
+    muiColor: "success",
+    ariaLabel: "Active status"
+  },
+  DRAFT: {
+    label: "Draft",
+    shortLabel: "Draft",
+    muiColor: "warning",
+    ariaLabel: "Draft status"
+  },
+  DEPRECATED: {
+    label: "Deprecated",
+    shortLabel: "Depr.",
+    muiColor: "error",
+    ariaLabel: "Deprecated status"
+  },
+  UNKNOWN: {
+    label: "Unknown",
+    shortLabel: "—",
+    muiColor: "default",
+    ariaLabel: "Unknown status"
+  }
+};
+
+export const normalizeGlossaryStatus = (status?: string): GlossaryStatusKey => {
+  if (!status) {
+    return "UNKNOWN";
+  }
+
+  const normalized = status.trim().toUpperCase();
+  if (normalized === "ACTIVE") {
+    return "ACTIVE";
+  }
+  if (normalized === "DRAFT") {
+    return "DRAFT";
+  }
+  if (normalized === "DEPRECATED") {
+    return "DEPRECATED";
+  }
+
+  return "UNKNOWN";
+};
+
+export const getGlossaryStatusMeta = (status?: string): GlossaryStatusMeta => {
+  const key = normalizeGlossaryStatus(status);
+  return GLOSSARY_STATUS_META[key];
+};

--- a/dashboard/src/views/Glossary/GlossaryStatusBadge.tsx
+++ b/dashboard/src/views/Glossary/GlossaryStatusBadge.tsx
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LightTooltip } from "@components/muiComponents";
+import { Chip } from "@mui/material";
+import { getGlossaryStatusMeta } from "@utils/glossaryStatus";
+
+type GlossaryStatusBadgeProps = {
+  status?: string;
+};
+
+const GlossaryStatusBadge = ({ status }: GlossaryStatusBadgeProps) => {
+  const meta = getGlossaryStatusMeta(status);
+
+  return (
+    <LightTooltip title={`Status: ${meta.label}`}>
+      <Chip
+        size="small"
+        variant="outlined"
+        color={meta.muiColor}
+        label={meta.shortLabel}
+        aria-label={meta.ariaLabel}
+        data-cy="glossaryStatusBadge"
+        sx={{
+          maxWidth: "100%",
+          height: 22,
+          "& .MuiChip-label": {
+            px: 0.75,
+            fontSize: "0.7rem",
+            lineHeight: 1.2
+          }
+        }}
+      />
+    </LightTooltip>
+  );
+};
+
+export default GlossaryStatusBadge;

--- a/dashboard/src/views/Glossary/GlossaryTermsListPage.tsx
+++ b/dashboard/src/views/Glossary/GlossaryTermsListPage.tsx
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TableLayout } from "@components/Table/TableLayout";
+import { CustomButton, LightTooltip } from "@components/muiComponents";
+import { useAppDispatch, useAppSelector } from "@hooks/reducerHook";
+import { fetchGlossaryData } from "@redux/slice/glossarySlice";
+import {
+  buildGlossarySearchRequest,
+  createDefaultGlossaryBrowseFilters,
+  fetchGlossarySearchPage,
+  GLOSSARY_EXPORT_FORMAT_OPTIONS,
+  GLOSSARY_STATUS_FILTER_OPTIONS,
+  requestGlossaryExportDownload,
+  type GlossaryBrowseFilters,
+  type GlossaryExportFormat,
+  type GlossaryTableRow
+} from "@utils/glossaryExport";
+import { Item } from "@utils/Muiutils";
+import { serverError } from "@utils/Utils";
+import Autocomplete from "@mui/material/Autocomplete";
+import DownloadOutlinedIcon from "@mui/icons-material/DownloadOutlined";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import TextSnippetOutlinedIcon from "@mui/icons-material/TextSnippetOutlined";
+import {
+  CircularProgress,
+  FormControl,
+  Grid,
+  InputLabel,
+  Menu,
+  MenuItem,
+  Select,
+  type SelectChangeEvent,
+  Stack,
+  TextField,
+  Typography
+} from "@mui/material";
+import moment from "moment-timezone";
+import {
+  ChangeEvent,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import { toast } from "react-toastify";
+import { createGlossaryTermsListColumns } from "./glossaryTermsListColumns";
+
+const FILTER_DEBOUNCE_MS = 400;
+
+const GlossaryTermsListPage = () => {
+  const toastRef = useRef<string | number | undefined>(undefined);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const filtersRef = useRef<GlossaryBrowseFilters>(
+    createDefaultGlossaryBrowseFilters()
+  );
+  const glossaryGuidByNameRef = useRef<Record<string, string>>({});
+  const dispatch = useAppDispatch();
+  const { glossaryData, loading: glossaryLoading } = useAppSelector(
+    (state) => state.glossary
+  );
+
+  const [loading, setLoading] = useState(true);
+  const [downloading, setDownloading] = useState(false);
+  const [tableRows, setTableRows] = useState<GlossaryTableRow[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [pageCount, setPageCount] = useState(0);
+  const [filters, setFilters] = useState<GlossaryBrowseFilters>(
+    createDefaultGlossaryBrowseFilters()
+  );
+  const [downloadMenuAnchor, setDownloadMenuAnchor] =
+    useState<null | HTMLElement>(null);
+  const [tableKey, setTableKey] = useState(0);
+  const [updateTable, setUpdateTable] = useState(moment.now());
+
+  filtersRef.current = filters;
+
+  useEffect(() => {
+    if (!glossaryData && !glossaryLoading) {
+      void dispatch(fetchGlossaryData());
+    }
+  }, [dispatch, glossaryData, glossaryLoading]);
+
+  const glossaryGuidByName = useMemo(() => {
+    const map: Record<string, string> = {};
+    const glossaries = Array.isArray(glossaryData) ? glossaryData : [];
+    glossaries.forEach((g: { name?: string; guid?: string }) => {
+      if (g?.name && g?.guid) {
+        map[g.name] = g.guid;
+      }
+    });
+    return map;
+  }, [glossaryData]);
+
+  glossaryGuidByNameRef.current = glossaryGuidByName;
+
+  const glossaryOptions = useMemo(() => {
+    const glossaries = Array.isArray(glossaryData) ? glossaryData : [];
+    return glossaries
+      .map((g: { name?: string }) => g?.name ?? "")
+      .filter((name) => name !== "")
+      .sort((a, b) => a.localeCompare(b));
+  }, [glossaryData]);
+
+  const scheduleFilterRefresh = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = setTimeout(() => {
+      setTableKey((k) => k + 1);
+    }, FILTER_DEBOUNCE_MS);
+  }, []);
+
+  const fetchGlossaryTableData = useCallback(
+    async ({
+      pagination
+    }: {
+      pagination: { pageIndex: number; pageSize: number };
+    }) => {
+      setLoading(true);
+      try {
+        const request = buildGlossarySearchRequest(
+          filtersRef.current,
+          pagination.pageIndex,
+          pagination.pageSize,
+          glossaryGuidByNameRef.current
+        );
+        const { rows, totalCount: count } = await fetchGlossarySearchPage(
+          request
+        );
+        setTableRows(rows);
+        setTotalCount(count);
+        setPageCount(
+          Math.ceil(count / (pagination.pageSize || 25)) || 0
+        );
+      } catch (e) {
+        serverError(e, toastRef);
+        setTableRows([]);
+        setTotalCount(0);
+        setPageCount(0);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [updateTable]
+  );
+
+  const handleRefresh = () => {
+    setUpdateTable(moment.now());
+  };
+
+  const handleDownloadMenuOpen = (event: MouseEvent<HTMLButtonElement>) => {
+    setDownloadMenuAnchor(event.currentTarget);
+  };
+
+  const handleDownloadMenuClose = () => {
+    setDownloadMenuAnchor(null);
+  };
+
+  const handleDownload = async (format: GlossaryExportFormat) => {
+    handleDownloadMenuClose();
+    try {
+      setDownloading(true);
+      await requestGlossaryExportDownload(
+        filtersRef.current,
+        glossaryGuidByNameRef.current,
+        format
+      );
+      toast.dismiss(toastRef.current);
+      toastRef.current = toast.success(
+        "The current glossary export has been enqueued for download. You can access the file by clicking the download icon at the top of the page."
+      );
+    } catch (e) {
+      serverError(e, toastRef);
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const handleSearchTextChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const v = e.target.value;
+    setFilters((f) => ({ ...f, searchText: v }));
+    scheduleFilterRefresh();
+  };
+
+  const handleRecordTypeChange = (e: SelectChangeEvent<string>) => {
+    setFilters((f) => ({
+      ...f,
+      recordType: e.target.value as GlossaryBrowseFilters["recordType"]
+    }));
+    setTableKey((k) => k + 1);
+  };
+
+  const handleStatusFilterChange = (e: SelectChangeEvent<string>) => {
+    setFilters((f) => ({ ...f, statusFilter: e.target.value }));
+    setTableKey((k) => k + 1);
+  };
+
+  const downloadDisabled = loading || downloading || totalCount === 0;
+
+  const columns = useMemo(
+    () => createGlossaryTermsListColumns(setUpdateTable),
+    [setUpdateTable]
+  );
+
+  return (
+    <Item
+      variant="outlined"
+      className="glossary-terms-list-page"
+      sx={{ background: "white", width: "100%", textAlign: "left" }}
+    >
+      <Stack spacing={0} sx={{ height: "100%", overflow: "hidden" }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          flexWrap="wrap"
+          gap={1}
+          className="glossary-terms-list-header"
+        >
+          <Stack direction="row" alignItems="center" gap={1}>
+            <TextSnippetOutlinedIcon color="primary" />
+            <Typography
+              variant="h6"
+              component="h1"
+              className="glossary-terms-list-title"
+            >
+              Glossary terms &amp; categories
+            </Typography>
+          </Stack>
+          <Stack direction="row" gap={1} flexWrap="wrap" alignItems="center">
+            <LightTooltip title="Reload from server">
+              <span>
+                <CustomButton
+                  variant="outlined"
+                  size="small"
+                  disabled={loading}
+                  onClick={handleRefresh}
+                  startIcon={<RefreshIcon />}
+                  data-cy="glossaryTermsListRefresh"
+                >
+                  Refresh
+                </CustomButton>
+              </span>
+            </LightTooltip>
+            <CustomButton
+              variant="outlined"
+              size="small"
+              onClick={handleDownloadMenuOpen}
+              disabled={downloadDisabled}
+              startIcon={
+                downloading ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : (
+                  <DownloadOutlinedIcon />
+                )
+              }
+              endIcon={downloading ? undefined : <ArrowDropDownIcon />}
+              aria-haspopup="true"
+              aria-expanded={Boolean(downloadMenuAnchor)}
+              aria-controls={
+                downloadMenuAnchor ? "glossary-download-menu" : undefined
+              }
+              data-cy="glossaryTermsListDownload"
+            >
+              Download
+            </CustomButton>
+            <Menu
+              id="glossary-download-menu"
+              anchorEl={downloadMenuAnchor}
+              open={Boolean(downloadMenuAnchor)}
+              onClose={handleDownloadMenuClose}
+              anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+              transformOrigin={{ vertical: "top", horizontal: "right" }}
+            >
+              {GLOSSARY_EXPORT_FORMAT_OPTIONS.map((option) => (
+                <MenuItem
+                  key={option.value}
+                  onClick={() => void handleDownload(option.value)}
+                  data-cy={`glossaryTermsListDownload${option.value}`}
+                >
+                  {option.label}
+                </MenuItem>
+              ))}
+            </Menu>
+          </Stack>
+        </Stack>
+
+        <div className="glossary-terms-filters">
+          <Typography
+            variant="subtitle2"
+            className="glossary-terms-filters-label"
+          >
+            Filters
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} md={3}>
+              <Autocomplete
+                size="small"
+                fullWidth
+                options={glossaryOptions}
+                value={filters.glossaryName || null}
+                onChange={(_e, v) => {
+                  setFilters((f) => ({ ...f, glossaryName: v ?? "" }));
+                  setTableKey((k) => k + 1);
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Glossary"
+                    placeholder="All glossaries"
+                  />
+                )}
+                data-cy="glossaryTermsFilterGlossary"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <FormControl size="small" fullWidth>
+                <InputLabel id="glossary-record-type-label">
+                  Record type
+                </InputLabel>
+                <Select
+                  labelId="glossary-record-type-label"
+                  label="Record type"
+                  value={filters.recordType}
+                  onChange={handleRecordTypeChange}
+                  data-cy="glossaryTermsFilterRecordType"
+                >
+                  <MenuItem value="all">All</MenuItem>
+                  <MenuItem value="Term">Terms only</MenuItem>
+                  <MenuItem value="Category">Categories only</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <FormControl size="small" fullWidth>
+                <InputLabel id="glossary-status-filter-label">Status</InputLabel>
+                <Select
+                  labelId="glossary-status-filter-label"
+                  label="Status"
+                  value={filters.statusFilter}
+                  onChange={handleStatusFilterChange}
+                  data-cy="glossaryTermsFilterStatus"
+                >
+                  {GLOSSARY_STATUS_FILTER_OPTIONS.map((option) => (
+                    <MenuItem key={option.label} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <TextField
+                size="small"
+                fullWidth
+                label="Search all columns"
+                value={filters.searchText}
+                onChange={handleSearchTextChange}
+                data-cy="glossaryTermsFilterSearch"
+              />
+            </Grid>
+          </Grid>
+        </div>
+
+        <div className="glossary-terms-table search-result-table-wrapper">
+          <TableLayout
+            key={`glossary-terms-table-${tableKey}`}
+            fetchData={fetchGlossaryTableData}
+            data={tableRows}
+            columns={columns}
+            emptyText="No rows match the current filters."
+            isFetching={loading}
+            pageCount={pageCount}
+            totalCount={totalCount}
+            isClientSidePagination={false}
+            clientSideSorting={true}
+            showPagination={true}
+            showGoToPage={true}
+            showRowSelection={false}
+            columnVisibility={false}
+            columnSort={true}
+            tableFilters={false}
+            queryBuilder={false}
+            allTableFilters={false}
+            isfilterQuery={false}
+            setUpdateTable={setUpdateTable}
+          />
+        </div>
+      </Stack>
+    </Item>
+  );
+};
+
+export default GlossaryTermsListPage;

--- a/dashboard/src/views/Glossary/__tests__/GlossaryStatusBadge.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/GlossaryStatusBadge.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from "@testing-library/react";
+import GlossaryStatusBadge from "../GlossaryStatusBadge";
+
+describe("GlossaryStatusBadge", () => {
+  it("renders active status with success color only", () => {
+    render(<GlossaryStatusBadge status="ACTIVE" />);
+    const badge = screen.getByLabelText("Active status");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("Active");
+    expect(badge).toHaveClass("MuiChip-colorSuccess");
+    expect(badge.querySelector(".MuiChip-icon")).not.toBeInTheDocument();
+  });
+
+  it("renders draft status with warning color only", () => {
+    render(<GlossaryStatusBadge status="draft" />);
+    const badge = screen.getByLabelText("Draft status");
+    expect(badge).toHaveClass("MuiChip-colorWarning");
+    expect(badge).toHaveTextContent("Draft");
+    expect(badge.querySelector(".MuiChip-icon")).not.toBeInTheDocument();
+  });
+
+  it("renders deprecated status with error color and short label", () => {
+    render(<GlossaryStatusBadge status="DEPRECATED" />);
+    const badge = screen.getByLabelText("Deprecated status");
+    expect(badge).toHaveClass("MuiChip-colorError");
+    expect(badge).toHaveTextContent("Depr.");
+    expect(badge.querySelector(".MuiChip-icon")).not.toBeInTheDocument();
+  });
+
+  it("renders unknown status with default color and em dash label", () => {
+    render(<GlossaryStatusBadge status="INVALID" />);
+    const badge = screen.getByLabelText("Unknown status");
+    expect(badge).toHaveClass("MuiChip-colorDefault");
+    expect(badge).toHaveTextContent("—");
+    expect(badge.querySelector(".MuiChip-icon")).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/views/Glossary/__tests__/GlossaryTermsListPage.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/GlossaryTermsListPage.test.tsx
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import GlossaryTermsListPage from "../GlossaryTermsListPage";
+
+const mockFetchGlossarySearchPage = jest.fn();
+const mockRequestGlossaryExportDownload = jest.fn();
+const mockFetchGlossaryData = jest.fn(() => ({ type: "glossary/fetch" }));
+const mockServerError = jest.fn();
+
+jest.mock("@utils/glossaryExport", () => ({
+  buildGlossarySearchRequest: jest.fn(() => ({})),
+  createDefaultGlossaryBrowseFilters: jest.fn(() => ({
+    recordType: "all",
+    glossaryName: "",
+    statusFilter: "",
+    searchText: ""
+  })),
+  fetchGlossarySearchPage: (...args: unknown[]) =>
+    mockFetchGlossarySearchPage(...args),
+  GLOSSARY_STATUS_FILTER_OPTIONS: [
+    { label: "All", value: "" },
+    { label: "Draft", value: "DRAFT" },
+    { label: "Active", value: "ACTIVE" },
+    { label: "Deprecated", value: "DEPRECATED" }
+  ],
+  GLOSSARY_EXPORT_FORMAT_OPTIONS: [
+    { label: "CSV", value: "CSV" },
+    { label: "XLSX", value: "XLSX" }
+  ],
+  requestGlossaryExportDownload: (...args: unknown[]) =>
+    mockRequestGlossaryExportDownload(...args)
+}));
+
+jest.mock("@redux/slice/glossarySlice", () => ({
+  fetchGlossaryData: (...args: unknown[]) => mockFetchGlossaryData(...args)
+}));
+
+jest.mock("@utils/Utils", () => ({
+  serverError: (...args: unknown[]) => mockServerError(...args)
+}));
+
+jest.mock("../glossaryTermsListColumns", () => ({
+  createGlossaryTermsListColumns: jest.fn(() => [
+    { accessorKey: "name", header: "Name" }
+  ])
+}));
+
+jest.mock("@components/Table/TableLayout", () => ({
+  TableLayout: ({ fetchData }: { fetchData: (args: unknown) => void }) => {
+    React.useEffect(() => {
+      void fetchData({ pagination: { pageIndex: 0, pageSize: 25 } });
+    }, [fetchData]);
+    return <div data-testid="table-layout">Table</div>;
+  }
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: jest.fn(),
+    dismiss: jest.fn()
+  }
+}));
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      glossary: () => ({
+        glossaryData: [{ name: "testGlossary", guid: "g-1" }],
+        loading: false
+      })
+    }
+  });
+
+const openDownloadMenu = async () => {
+  const downloadButton = await screen.findByRole("button", { name: /download/i });
+  await waitFor(() => {
+    expect(downloadButton).not.toBeDisabled();
+  });
+  fireEvent.click(downloadButton);
+};
+
+describe("GlossaryTermsListPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchGlossarySearchPage.mockResolvedValue({
+      rows: [{ id: "term-1", name: "Term1" }],
+      totalCount: 1
+    });
+    mockRequestGlossaryExportDownload.mockResolvedValue(undefined);
+  });
+
+  it("renders page layout with aligned wrapper and filters", async () => {
+    const { container } = render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    expect(
+      container.querySelector(".glossary-terms-list-page")
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(".glossary-terms-filters")
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(".glossary-terms-table")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /glossary terms & categories/i })
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("table-layout")).toBeInTheDocument();
+    });
+  });
+
+  it("does not enqueue export when only opening the download menu", async () => {
+    render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalled();
+    });
+
+    await openDownloadMenu();
+
+    expect(await screen.findByRole("menuitem", { name: /^CSV$/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /^XLSX$/i })).toBeInTheDocument();
+    expect(mockRequestGlossaryExportDownload).not.toHaveBeenCalled();
+  });
+
+  it("enqueues glossary export as CSV from the download menu", async () => {
+    render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalled();
+    });
+
+    await openDownloadMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: /^CSV$/i }));
+
+    await waitFor(() => {
+      expect(mockRequestGlossaryExportDownload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recordType: "all",
+          glossaryName: "",
+          statusFilter: "",
+          searchText: ""
+        }),
+        expect.objectContaining({ testGlossary: "g-1" }),
+        "CSV"
+      );
+    });
+  });
+
+  it("enqueues glossary export as XLSX from the download menu", async () => {
+    render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalled();
+    });
+
+    await openDownloadMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: /^XLSX$/i }));
+
+    await waitFor(() => {
+      expect(mockRequestGlossaryExportDownload).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        "XLSX"
+      );
+    });
+  });
+
+  it("disables download when table has no rows", async () => {
+    mockFetchGlossarySearchPage.mockResolvedValue({
+      rows: [],
+      totalCount: 0
+    });
+
+    render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalled();
+    });
+
+    expect(screen.getByRole("button", { name: /download/i })).toBeDisabled();
+  });
+
+  it("shows serverError when glossary search fetch fails", async () => {
+    const fetchError = new Error("search failed");
+    mockFetchGlossarySearchPage.mockRejectedValue(fetchError);
+
+    render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockServerError).toHaveBeenCalledWith(
+        fetchError,
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("shows serverError and re-enables download when export fails", async () => {
+    const exportError = new Error("export failed");
+    mockRequestGlossaryExportDownload.mockRejectedValue(exportError);
+
+    render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalled();
+    });
+
+    const downloadButton = await screen.findByRole("button", { name: /download/i });
+    await waitFor(() => {
+      expect(downloadButton).not.toBeDisabled();
+    });
+    await openDownloadMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: /^CSV$/i }));
+
+    await waitFor(() => {
+      expect(mockServerError).toHaveBeenCalledWith(
+        exportError,
+        expect.any(Object)
+      );
+    });
+
+    expect(downloadButton).not.toBeDisabled();
+  });
+
+  it("refetches table data when record type filter changes", async () => {
+    render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.mouseDown(screen.getByLabelText(/record type/i));
+    fireEvent.click(await screen.findByRole("option", { name: /terms only/i }));
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("debounces search text filter refresh before refetching", async () => {
+    jest.useFakeTimers();
+
+    render(
+      <Provider store={createStore()}>
+        <GlossaryTermsListPage />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(screen.getByLabelText(/search all columns/i), {
+      target: { value: "capital" }
+    });
+
+    expect(mockFetchGlossarySearchPage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(mockFetchGlossarySearchPage).toHaveBeenCalledTimes(2);
+    });
+
+    jest.useRealTimers();
+  });
+});

--- a/dashboard/src/views/Glossary/__tests__/glossaryTermsListColumns.test.tsx
+++ b/dashboard/src/views/Glossary/__tests__/glossaryTermsListColumns.test.tsx
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { createGlossaryTermsListColumns } from "../glossaryTermsListColumns";
+import type { GlossaryTableRow } from "@utils/glossaryExport";
+
+jest.mock("@components/DialogShowMoreLess", () => ({
+  __esModule: true,
+  default: ({ value }: { value: { classifications?: Array<{ typeName?: string }> } }) => (
+    <div data-testid="dialog-show-more-less">
+      {(value.classifications ?? []).map((item) => item.typeName).join(",")}
+    </div>
+  )
+}));
+
+const sampleRow: GlossaryTableRow = {
+  id: "term-1",
+  recordType: "Term",
+  name: "MetricTerm015",
+  guid: "term-guid-1",
+  qualifiedName: "MetricTerm015@testBankingGlossary",
+  glossaryName: "testBankingGlossary",
+  glossaryGuid: "glossary-guid-1",
+  shortDescription: "Short desc text",
+  longDescription: "Long desc text",
+  status: "ACTIVE",
+  classifications: [{ typeName: "class3" }],
+  customAttributes: { department: "Retail", status: "Active" }
+};
+
+const glossaryTermsListColumns = createGlossaryTermsListColumns(jest.fn());
+
+const renderColumnCell = (
+  accessorKey: keyof GlossaryTableRow,
+  row: GlossaryTableRow = sampleRow
+) => {
+  const column = glossaryTermsListColumns.find(
+    (c) => "accessorKey" in c && c.accessorKey === accessorKey
+  );
+  if (!column || !column.cell || typeof column.cell !== "function") {
+    throw new Error(`Column ${accessorKey} not found`);
+  }
+
+  const cellFn = column.cell as (ctx: {
+    getValue: () => unknown;
+    row: { original: GlossaryTableRow };
+  }) => React.ReactNode;
+
+  return render(
+    <MemoryRouter>
+      {cellFn({
+        getValue: () => row[accessorKey],
+        row: { original: row }
+      })}
+    </MemoryRouter>
+  );
+};
+
+describe("glossaryTermsListColumns", () => {
+  it("orders glossary name before name and omits related categories column", () => {
+    const keys = glossaryTermsListColumns
+      .map((column) =>
+        "accessorKey" in column ? column.accessorKey : undefined
+      )
+      .filter(Boolean);
+    expect(keys).toEqual([
+      "glossaryName",
+      "name",
+      "recordType",
+      "shortDescription",
+      "longDescription",
+      "classifications",
+      "customAttributes",
+      "status"
+    ]);
+  });
+
+  it("renders name as a plain search-result style link", () => {
+    renderColumnCell("name");
+    const link = screen.getByRole("link", { name: "MetricTerm015" });
+    expect(link).toHaveClass("entity-name");
+    expect(link).toHaveAttribute(
+      "href",
+      "/glossary/term-guid-1?gid=glossary-guid-1&gtype=term&viewType=term&fromView=entity&term=MetricTerm015%40testBankingGlossary"
+    );
+  });
+
+  it("renders glossary name with tooltip text", () => {
+    renderColumnCell("glossaryName");
+    expect(screen.getByText("testBankingGlossary")).toBeInTheDocument();
+  });
+
+  it("renders short and long descriptions as plain text", () => {
+    renderColumnCell("shortDescription");
+    expect(screen.getByText("Short desc text")).toBeInTheDocument();
+
+    renderColumnCell("longDescription");
+    expect(screen.getByText("Long desc text")).toBeInTheDocument();
+  });
+
+  it("renders classifications for terms", () => {
+    renderColumnCell("classifications");
+    expect(screen.getByTestId("dialog-show-more-less")).toHaveTextContent(
+      "class3"
+    );
+  });
+
+  it("renders custom attributes as readable string", () => {
+    renderColumnCell("customAttributes");
+    expect(
+      screen.getByText("department: Retail, status: Active")
+    ).toBeInTheDocument();
+  });
+
+  it("renders status as a colored badge without icons", () => {
+    renderColumnCell("status");
+    const badge = screen.getByLabelText("Active status");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("Active");
+    expect(badge).toHaveClass("MuiChip-colorSuccess");
+    expect(badge.querySelector(".MuiChip-icon")).not.toBeInTheDocument();
+  });
+
+  it("uses a narrower status column width", () => {
+    const statusColumn = glossaryTermsListColumns.find(
+      (column) => "accessorKey" in column && column.accessorKey === "status"
+    );
+    expect(statusColumn?.size).toBe(76);
+  });
+
+  it("renders name as plain text when guid is missing", () => {
+    renderColumnCell("name", { ...sampleRow, guid: "" });
+    expect(screen.getByText("MetricTerm015")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "MetricTerm015" })).not.toBeInTheDocument();
+  });
+
+  it("renders empty custom attributes as null", () => {
+    const { container } = renderColumnCell("customAttributes", {
+      ...sampleRow,
+      customAttributes: {}
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders empty classifications for category rows", () => {
+    renderColumnCell("classifications", {
+      ...sampleRow,
+      recordType: "Category",
+      classifications: []
+    });
+    expect(screen.getByTestId("dialog-show-more-less")).toHaveTextContent("");
+  });
+});

--- a/dashboard/src/views/Glossary/glossaryTermsListColumns.tsx
+++ b/dashboard/src/views/Glossary/glossaryTermsListColumns.tsx
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { removeClassification } from "@api/apiMethods/classificationApiMethod";
+import DialogShowMoreLess from "@components/DialogShowMoreLess";
+import { LightTooltip } from "@components/muiComponents";
+import GlossaryStatusBadge from "@views/Glossary/GlossaryStatusBadge";
+import { entityStateReadOnly } from "@utils/Enum";
+import {
+  formatCustomAttributesForDisplay,
+  formatCustomAttributesForTooltip,
+  type GlossaryTableRow
+} from "@utils/glossaryExport";
+import type { CSSProperties } from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { Link } from "react-router-dom";
+
+const COL_WIDTH_NAME = 200;
+const COL_WIDTH_DESCRIPTION = 220;
+const COL_WIDTH_STATUS = 76;
+
+const ellipsisCellStyle: CSSProperties = {
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  display: "block",
+  maxWidth: "100%"
+};
+
+const buildGlossaryDetailSearch = (row: GlossaryTableRow): string => {
+  const params = new URLSearchParams();
+  const gtype = row.recordType === "Term" ? "term" : "category";
+  params.set("gid", row.glossaryGuid);
+  params.set("gtype", gtype);
+  params.set("viewType", gtype);
+  params.set("fromView", "entity");
+  if (row.recordType === "Term" && row.qualifiedName) {
+    params.set("term", row.qualifiedName);
+  }
+  return params.toString();
+};
+
+const buildClassificationRowValue = (row: GlossaryTableRow) => ({
+  guid: row.guid,
+  status: row.status,
+  classifications: (row.classifications ?? []).map((classification) => ({
+    ...classification,
+    entityGuid: classification.entityGuid ?? row.guid
+  }))
+});
+
+const renderEllipsisText = (value: string, tooltip = value) => (
+  <LightTooltip title={tooltip}>
+    <span className="entity-name" style={ellipsisCellStyle}>
+      {value}
+    </span>
+  </LightTooltip>
+);
+
+export const createGlossaryTermsListColumns = (
+  setUpdateTable: (value: number) => void
+): ColumnDef<GlossaryTableRow>[] => [
+  {
+    accessorKey: "glossaryName",
+    header: "Glossary Name",
+    cell: (info) => {
+      const value = info.getValue() as string;
+      if (!value) {
+        return null;
+      }
+      return renderEllipsisText(value);
+    },
+    size: COL_WIDTH_NAME
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+    cell: (info) => {
+      const row = info.row.original;
+      const name = row.name;
+      if (!row.guid) {
+        return <span>{name}</span>;
+      }
+      return (
+        <div className="searchTableName">
+          <LightTooltip title={name}>
+            <Link
+              className="entity-name nav-link text-decoration-none text-blue glossary-term-name-link"
+              to={{
+                pathname: `/glossary/${row.guid}`,
+                search: `?${buildGlossaryDetailSearch(row)}`
+              }}
+              data-cy="glossaryTermNameLink"
+            >
+              {name}
+            </Link>
+          </LightTooltip>
+        </div>
+      );
+    },
+    size: COL_WIDTH_NAME,
+    sortingFn: "alphanumeric"
+  },
+  {
+    accessorKey: "recordType",
+    header: "Record Type",
+    cell: (info) => <span>{info.getValue() as string}</span>,
+    size: 110
+  },
+  {
+    accessorKey: "shortDescription",
+    header: "Short Description",
+    cell: (info) => {
+      const value = info.getValue() as string;
+      return value ? renderEllipsisText(value) : null;
+    },
+    size: COL_WIDTH_DESCRIPTION,
+    enableSorting: false
+  },
+  {
+    accessorKey: "longDescription",
+    header: "Long Description",
+    cell: (info) => {
+      const value = info.getValue() as string;
+      return value ? renderEllipsisText(value) : null;
+    },
+    size: COL_WIDTH_DESCRIPTION,
+    enableSorting: false
+  },
+  {
+    accessorKey: "classifications",
+    header: "Classifications",
+    cell: (info) => {
+      const row = info.row.original;
+      if (!row.guid) {
+        return null;
+      }
+
+      const classificationValue = buildClassificationRowValue(row);
+      const isTerm = row.recordType === "Term";
+      const isReadOnly =
+        !isTerm ||
+        Boolean(row.status && entityStateReadOnly[row.status]);
+
+      return (
+        <DialogShowMoreLess
+          value={classificationValue}
+          readOnly={isReadOnly}
+          setUpdateTable={setUpdateTable}
+          columnVal="classifications"
+          colName="Classification"
+          displayText="typeName"
+          removeApiMethod={isTerm ? removeClassification : undefined}
+          isShowMoreLess={true}
+        />
+      );
+    },
+    enableSorting: false
+  },
+  {
+    accessorKey: "customAttributes",
+    header: "Custom Attributes",
+    cell: (info) => {
+      const value = info.row.original.customAttributes;
+      if (!value || Object.keys(value).length === 0) {
+        return null;
+      }
+      const displayText = formatCustomAttributesForDisplay(value);
+      if (!displayText) {
+        return null;
+      }
+      return renderEllipsisText(
+        displayText,
+        formatCustomAttributesForTooltip(value)
+      );
+    },
+    size: 160,
+    enableSorting: false
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: (info) => (
+      <GlossaryStatusBadge status={info.getValue() as string} />
+    ),
+    size: COL_WIDTH_STATUS
+  }
+];
+
+export default createGlossaryTermsListColumns;

--- a/dashboard/src/views/Layout/Header.tsx
+++ b/dashboard/src/views/Layout/Header.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   Divider,
   IconButton,
@@ -44,12 +44,14 @@ import {
   ListItemText,
   Popover,
   Skeleton,
-  Stack
+  Stack,
+  CircularProgress
 } from "@mui/material";
 import DownloadIcon from "@mui/icons-material/Download";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import CloseOutlinedIcon from "@mui/icons-material/CloseOutlined";
 import { getDownloadStatus } from "@api/apiMethods/downloadApiMethod";
+import { getGlossaryDownloadStatus } from "@api/apiMethods/glossaryApiMethod";
 import {
   getBaseUrl,
   getNavigate,
@@ -57,12 +59,30 @@ import {
   serverError,
   setNavigate
 } from "@utils/Utils";
-import { toast } from "react-toastify";
+import { toast, type Id } from "react-toastify";
 import { apiDocUrl } from "@api/apiUrlLinks/headerUrl";
 import { globalSessionData } from "@utils/Enum";
 import { downloadSearchResultsFileUrl } from "@api/apiUrlLinks/downloadApiUrl";
+import { glossaryDownloadFileUrl } from "@api/apiUrlLinks/glossaryUrl";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { AntSwitch } from "@utils/Muiutils";
+import {
+  type DownloadRecord,
+  extractDownloadRecords,
+  filterDownloadRecordsForToggle,
+  isPendingDownloadRecord,
+  mergeDownloadRecords
+} from "@utils/downloadRecords";
+
+interface HeaderSessionState {
+  session: {
+    sessionObj: {
+      loading: boolean;
+      data: { userName?: string } | null;
+      error: string | null;
+    };
+  };
+}
 
 interface Header {
   handleOpenModal: () => void;
@@ -75,11 +95,11 @@ const Header: React.FC<Header> = ({
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const toastId: any = useRef(null);
-  const { sessionObj = "" }: any = useAppSelector(
-    (state: any) => state.session
+  const toastId = useRef<Id | undefined>(undefined);
+  const sessionObj = useAppSelector(
+    (state: HeaderSessionState) => state.session.sessionObj
   );
-  const { userName } = sessionObj.data || {};
+  const userName = sessionObj?.data?.userName;
   const { debugMetrics = {} } = globalSessionData || {};
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -92,26 +112,65 @@ const Header: React.FC<Header> = ({
   const [downloadAnchorEl, setDownloadAnchorEl] = useState<null | HTMLElement>(
     null
   );
-  const [searchDownloadsList, setSearchDownList] = useState([]);
+  const [searchDownloadsList, setSearchDownList] = useState<DownloadRecord[]>(
+    []
+  );
   const [downloadLoader, setDownloadLoader] = useState<boolean>(false);
-  const [checked, setChecked] = useState(false);
+  const [checked, setChecked] = useState(true);
 
-  if (location.pathname == "/search/searchResult") {
-    setNavigate(location.pathname + location.search);
-  }
+  const displayedDownloadsList = useMemo(
+    () => filterDownloadRecordsForToggle(searchDownloadsList, checked),
+    [checked, searchDownloadsList]
+  );
+
+  useEffect(() => {
+    if (location.pathname === "/search/searchResult") {
+      setNavigate(location.pathname + location.search);
+    }
+  }, [location.pathname, location.search, setNavigate]);
 
   const fetchDownloadStatus = async () => {
-    try {
-      setDownloadLoader(true);
-      const downListResp = await getDownloadStatus({});
-      const { searchDownloadRecords } = downListResp.data;
-      setSearchDownList(searchDownloadRecords);
-      setDownloadLoader(false);
-    } catch (error) {
-      setDownloadLoader(false);
-      console.error(`Error occur while fetching searchResult records`, error);
-      serverError(error, toastId);
+    setDownloadLoader(true);
+
+    const [searchResult, glossaryResult] = await Promise.allSettled([
+      getDownloadStatus({}),
+      getGlossaryDownloadStatus({})
+    ]);
+
+    const searchRecords =
+      searchResult.status === "fulfilled"
+        ? extractDownloadRecords(searchResult.value.data, "search")
+        : [];
+    const glossaryRecords =
+      glossaryResult.status === "fulfilled"
+        ? extractDownloadRecords(glossaryResult.value.data, "glossary")
+        : [];
+
+    if (searchResult.status === "rejected") {
+      console.error(
+        "Error occurred while fetching search download records",
+        searchResult.reason
+      );
     }
+
+    if (glossaryResult.status === "rejected") {
+      console.error(
+        "Error occurred while fetching glossary download records",
+        glossaryResult.reason
+      );
+    }
+
+    if (
+      searchResult.status === "rejected" &&
+      glossaryResult.status === "rejected"
+    ) {
+      setDownloadLoader(false);
+      serverError(searchResult.reason, toastId);
+      return;
+    }
+
+    setSearchDownList(mergeDownloadRecords(searchRecords, glossaryRecords));
+    setDownloadLoader(false);
   };
 
   const handleClickDownload = (event: React.MouseEvent<HTMLElement>) => {
@@ -133,11 +192,15 @@ const Header: React.FC<Header> = ({
     setAnchorEl(event.currentTarget);
   };
 
-  const handleFileDownload = async (file: any) => {
-    const { fileName } = file;
+  const handleFileDownload = async (file: DownloadRecord) => {
+    const { fileName, source } = file;
     let path = getBaseUrl(window.location.pathname);
-    window.location.href = path + downloadSearchResultsFileUrl(fileName);
-    toast.success("File download succesfully");
+    const downloadUrl =
+      source === "glossary"
+        ? glossaryDownloadFileUrl(fileName)
+        : downloadSearchResultsFileUrl(fileName);
+    window.location.href = path + downloadUrl;
+    toast.success("File downloaded successfully");
   };
 
   const handleNestedMenuClick = () => {
@@ -191,7 +254,10 @@ const Header: React.FC<Header> = ({
       {(location.pathname === "/" || location.pathname === "/search") && (
         <div style={{ flex: "1" }} />
       )}
-      <div className="header-menu" style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+      <div
+        className="header-menu"
+        style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}
+      >
         <CreateDropdown />
         <LightTooltip title="Downloads">
           <IconButton
@@ -383,7 +449,9 @@ const Header: React.FC<Header> = ({
             <Stack direction="row" alignItems="center" gap="0.25rem">
               <LightTooltip
                 title={
-                  checked ? "Display All Files" : "Display Available Files"
+                  checked
+                    ? "Showing all files (including in progress)"
+                    : "Showing completed files only"
                 }
               >
                 <AntSwitch
@@ -434,10 +502,11 @@ const Header: React.FC<Header> = ({
                   </ListItem>
                 ))}
               </List>
-            ) : !isEmpty(searchDownloadsList) ? (
-              searchDownloadsList?.map((file: { fileName: string }, index) => {
+            ) : !isEmpty(displayedDownloadsList) ? (
+              displayedDownloadsList.map((file: DownloadRecord, index) => {
+                const isPending = isPendingDownloadRecord(file);
                 return (
-                  <List dense disablePadding>
+                  <List dense disablePadding key={`${file.source}-${file.fileName}`}>
                     <ListItem dense disablePadding>
                       <Stack
                         direction="row"
@@ -450,15 +519,19 @@ const Header: React.FC<Header> = ({
                           aria-hidden="true"
                         ></i>
                         <ListItemText primary={file.fileName} />
-                        <IconButton
-                          color="success"
-                          onClick={() => handleFileDownload(file)}
-                        >
-                          <DownloadIcon />
-                        </IconButton>
+                        {isPending ? (
+                          <CircularProgress size={20} color="success" />
+                        ) : (
+                          <IconButton
+                            color="success"
+                            onClick={() => handleFileDownload(file)}
+                          >
+                            <DownloadIcon />
+                          </IconButton>
+                        )}
                       </Stack>
                     </ListItem>
-                    {index != searchDownloadsList?.length - 1 && <Divider />}
+                    {index != displayedDownloadsList.length - 1 && <Divider />}
                   </List>
                 );
               })

--- a/dashboard/src/views/Layout/__tests__/Header.test.tsx
+++ b/dashboard/src/views/Layout/__tests__/Header.test.tsx
@@ -64,6 +64,12 @@ jest.mock('@api/apiMethods/downloadApiMethod', () => ({
 	getDownloadStatus: (...args: any[]) => mockGetDownloadStatus(...args)
 }));
 
+const mockGetGlossaryDownloadStatus = jest.fn();
+jest.mock('@api/apiMethods/glossaryApiMethod', () => ({
+	getGlossaryDownloadStatus: (...args: any[]) =>
+		mockGetGlossaryDownloadStatus(...args)
+}));
+
 // Mock Utils (factory must not close over const mocks — hoisting runs factory first)
 jest.mock('@utils/Utils', () => ({
 	getBaseUrl: jest.fn((url: string) => '/base'),
@@ -112,6 +118,13 @@ jest.mock('@api/apiUrlLinks/headerUrl', () => ({
 const mockDownloadSearchResultsFileUrl = jest.fn((fileName: string) => `/download/${fileName}`);
 jest.mock('@api/apiUrlLinks/downloadApiUrl', () => ({
 	downloadSearchResultsFileUrl: (...args: any[]) => mockDownloadSearchResultsFileUrl(...args)
+}));
+
+const mockGlossaryDownloadFileUrl = jest.fn(
+	(fileName: string) => `/glossary-download/${fileName}`
+);
+jest.mock('@api/apiUrlLinks/glossaryUrl', () => ({
+	glossaryDownloadFileUrl: (...args: any[]) => mockGlossaryDownloadFileUrl(...args)
 }));
 
 // Mock globalSessionData
@@ -204,16 +217,17 @@ jest.mock('@mui/material', () => {
 	};
 });
 
-// Mock AntSwitch
+// Mock AntSwitch — forwards change events so controlled Header toggle updates in tests
 jest.mock('@utils/Muiutils', () => ({
-	AntSwitch: ({ checked, onChange, onClick, ...props }: any) => (
+	AntSwitch: ({ checked, onChange, onClick, inputProps, sx: _sx, size: _size, ...rest }: any) => (
 		<input
 			type="checkbox"
 			data-testid="ant-switch"
 			checked={checked}
 			onChange={onChange}
 			onClick={onClick}
-			{...props}
+			{...inputProps}
+			{...rest}
 		/>
 	)
 }));
@@ -234,6 +248,11 @@ describe('Header Component', () => {
 		mockGetDownloadStatus.mockResolvedValue({
 			data: {
 				searchDownloadRecords: []
+			}
+		});
+		mockGetGlossaryDownloadStatus.mockResolvedValue({
+			data: {
+				glossaryDownloadRecords: []
 			}
 		});
 		mockGetBaseUrl.mockReturnValue('/base');
@@ -641,11 +660,17 @@ describe('Header Component', () => {
 					]
 				}
 			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					glossaryDownloadRecords: []
+				}
+			});
 			const { container } = renderHeader();
 			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
 			fireEvent.click(downloadButton);
 			await waitFor(() => {
 				expect(mockGetDownloadStatus).toHaveBeenCalledWith({});
+				expect(mockGetGlossaryDownloadStatus).toHaveBeenCalledWith({});
 			});
 		});
 
@@ -680,6 +705,11 @@ describe('Header Component', () => {
 					]
 				}
 			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					glossaryDownloadRecords: [{ fileName: 'glossary-file.csv' }]
+				}
+			});
 			mockIsEmpty.mockReturnValue(false);
 			const { container } = renderHeader();
 			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
@@ -689,6 +719,50 @@ describe('Header Component', () => {
 			await waitFor(() => {
 				expect(screen.getByText('file1.csv')).toBeInTheDocument();
 				expect(screen.getByText('file2.csv')).toBeInTheDocument();
+				expect(screen.getByText('glossary-file.csv')).toBeInTheDocument();
+			}, { timeout: 15000 });
+		}, 30000);
+
+		it('should sort download list with newest files first', async () => {
+			mockGetDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: [
+						{
+							fileName: 'admin_basic_2026-08-12_12-11-41.csv',
+							createdTime: Date.parse('2026-08-12T12:11:41')
+						},
+						{
+							fileName: 'admin_basic_2026-08-12_15-36-29.csv',
+							createdTime: Date.parse('2026-08-12T15:36:29')
+						}
+					]
+				}
+			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: [
+						{
+							fileName: 'admin_GLOSSARY_EXPORT_2026-08-12_15-30-14.csv',
+							createdTime: Date.parse('2026-08-12T15:30:14')
+						}
+					]
+				}
+			});
+			mockIsEmpty.mockReturnValue(false);
+			const { container } = renderHeader();
+			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
+			await act(async () => {
+				fireEvent.click(downloadButton);
+			});
+			await waitFor(() => {
+				const fileNames = screen
+					.getAllByText(/admin_(basic|GLOSSARY_EXPORT)_2026-08-12_/i)
+					.map((element) => element.textContent);
+				expect(fileNames).toEqual([
+					'admin_basic_2026-08-12_15-36-29.csv',
+					'admin_GLOSSARY_EXPORT_2026-08-12_15-30-14.csv',
+					'admin_basic_2026-08-12_12-11-41.csv'
+				]);
 			}, { timeout: 15000 });
 		}, 30000);
 
@@ -715,6 +789,11 @@ describe('Header Component', () => {
 					searchDownloadRecords: [{ fileName: 'test-file.csv' }]
 				}
 			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					glossaryDownloadRecords: []
+				}
+			});
 			mockIsEmpty.mockReturnValue(false);
 			const { container } = renderHeader();
 			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
@@ -734,8 +813,67 @@ describe('Header Component', () => {
 				});
 				expect(mockGetBaseUrl).toHaveBeenCalled();
 				expect(mockDownloadSearchResultsFileUrl).toHaveBeenCalledWith('test-file.csv');
-				expect(mockToastSuccess).toHaveBeenCalledWith('File download succesfully');
+				expect(mockToastSuccess).toHaveBeenCalledWith('File downloaded successfully');
 			}
+		}, 30000);
+
+		it('should use glossary download URL for glossary export files', async () => {
+			mockGetDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: []
+				}
+			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					glossaryDownloadRecords: [{ fileName: 'glossary-export.csv' }]
+				}
+			});
+			mockIsEmpty.mockReturnValue(false);
+			const { container } = renderHeader();
+			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
+			await act(async () => {
+				fireEvent.click(downloadButton);
+			});
+			await waitFor(() => {
+				expect(screen.getByText('glossary-export.csv')).toBeInTheDocument();
+			}, { timeout: 15000 });
+			const downloadIcons = screen.getAllByRole('button');
+			const fileDownloadButton = downloadIcons.find((btn) =>
+				btn.querySelector('svg[data-testid="DownloadIcon"]')
+			);
+			if (fileDownloadButton) {
+				await act(async () => {
+					fireEvent.click(fileDownloadButton);
+				});
+				expect(mockGlossaryDownloadFileUrl).toHaveBeenCalledWith(
+					'glossary-export.csv'
+				);
+			}
+		}, 30000);
+
+		it('should not show source labels in download list items', async () => {
+			mockGetDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: [{ fileName: 'search-export.csv' }]
+				}
+			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: [{ fileName: 'glossary-from-api.csv' }]
+				}
+			});
+			mockIsEmpty.mockReturnValue(false);
+			const { container } = renderHeader();
+			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
+			await act(async () => {
+				fireEvent.click(downloadButton);
+			});
+			await waitFor(() => {
+				expect(screen.getByText('glossary-from-api.csv')).toBeInTheDocument();
+				expect(screen.getByText('search-export.csv')).toBeInTheDocument();
+				expect(screen.queryByText('Glossary export')).not.toBeInTheDocument();
+				expect(screen.queryByText('Search export')).not.toBeInTheDocument();
+			}, { timeout: 15000 });
 		}, 30000);
 
 		it('should refresh download list when clicking refresh button', async () => {
@@ -751,6 +889,7 @@ describe('Header Component', () => {
 			});
 			await waitFor(() => {
 				expect(mockGetDownloadStatus).toHaveBeenCalledTimes(1);
+				expect(mockGetGlossaryDownloadStatus).toHaveBeenCalledTimes(1);
 			}, { timeout: 15000 });
 			// Find refresh button by looking for RefreshIcon
 			await waitFor(() => {
@@ -764,11 +903,12 @@ describe('Header Component', () => {
 				});
 				await waitFor(() => {
 					expect(mockGetDownloadStatus).toHaveBeenCalledTimes(2);
+					expect(mockGetGlossaryDownloadStatus).toHaveBeenCalledTimes(2);
 				}, { timeout: 15000 });
 			}
 		}, 30000);
 
-		it('should handle download status fetch error', async () => {
+		it('should handle download status fetch error when both APIs fail', async () => {
 			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 			const mockError = {
 				response: {
@@ -778,12 +918,17 @@ describe('Header Component', () => {
 				}
 			};
 			mockGetDownloadStatus.mockRejectedValue(mockError);
+			mockGetGlossaryDownloadStatus.mockRejectedValue(mockError);
 			const { container } = renderHeader();
 			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
 			fireEvent.click(downloadButton);
 			await waitFor(() => {
 				expect(consoleErrorSpy).toHaveBeenCalledWith(
-					'Error occur while fetching searchResult records',
+					'Error occurred while fetching search download records',
+					mockError
+				);
+				expect(consoleErrorSpy).toHaveBeenCalledWith(
+					'Error occurred while fetching glossary download records',
 					mockError
 				);
 				expect(mockServerError).toHaveBeenCalled();
@@ -791,25 +936,115 @@ describe('Header Component', () => {
 			consoleErrorSpy.mockRestore();
 		});
 
-		it('should toggle switch to filter downloads', async () => {
-			mockGetDownloadStatus.mockResolvedValue({
+		it('should still show downloads when one status API fails', async () => {
+			mockGetDownloadStatus.mockRejectedValue(new Error('search failed'));
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
 				data: {
-					searchDownloadRecords: [{ fileName: 'file1.csv' }]
+					glossaryDownloadRecords: [{ fileName: 'glossary-only.csv' }]
 				}
 			});
 			mockIsEmpty.mockReturnValue(false);
 			const { container } = renderHeader();
 			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
-			fireEvent.click(downloadButton);
-			await waitFor(() => {
-				expect(screen.getByText('Downloads')).toBeInTheDocument();
+			await act(async () => {
+				fireEvent.click(downloadButton);
 			});
-			const switchElement = screen.getByTestId('ant-switch');
-			expect(switchElement).toBeInTheDocument();
-			expect(switchElement).toHaveProperty('checked', false);
-			fireEvent.change(switchElement, { target: { checked: true } });
-			expect(switchElement).toHaveProperty('checked', true);
-		});
+			await waitFor(() => {
+				expect(screen.getByText('glossary-only.csv')).toBeInTheDocument();
+			}, { timeout: 15000 });
+			expect(mockServerError).not.toHaveBeenCalled();
+		}, 30000);
+
+		it('should show all downloads by default including pending files', async () => {
+			mockGetDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: [
+						{ fileName: 'ready.csv', status: 'COMPLETE' },
+						{ fileName: 'pending.csv', status: 'PENDING' }
+					]
+				}
+			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: []
+				}
+			});
+			const { container } = renderHeader();
+			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
+			await act(async () => {
+				fireEvent.click(downloadButton);
+			});
+			await waitFor(() => {
+				expect(screen.getByText('ready.csv')).toBeInTheDocument();
+				expect(screen.getByText('pending.csv')).toBeInTheDocument();
+				expect(screen.getByTestId('ant-switch')).toHaveProperty('checked', true);
+			}, { timeout: 15000 });
+		}, 30000);
+
+		it('should hide pending downloads when toggle shows completed files only', async () => {
+			mockGetDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: [
+						{ fileName: 'ready.csv', status: 'COMPLETE' },
+						{ fileName: 'pending.csv', status: 'PENDING' }
+					]
+				}
+			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: []
+				}
+			});
+			const { container } = renderHeader();
+			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
+			await act(async () => {
+				fireEvent.click(downloadButton);
+			});
+			await waitFor(() => {
+				expect(screen.getByText('pending.csv')).toBeInTheDocument();
+			}, { timeout: 15000 });
+
+			await act(async () => {
+				fireEvent.click(screen.getByTestId('ant-switch'));
+			});
+
+			await waitFor(() => {
+				expect(screen.queryByText('pending.csv')).not.toBeInTheDocument();
+				expect(screen.getByText('ready.csv')).toBeInTheDocument();
+			}, { timeout: 15000 });
+		}, 30000);
+
+		it('should show No Data Found when only pending files exist and toggle is off', async () => {
+			mockGetDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: [
+						{ fileName: 'pending-only.csv', status: 'PENDING' }
+					]
+				}
+			});
+			mockGetGlossaryDownloadStatus.mockResolvedValue({
+				data: {
+					searchDownloadRecords: []
+				}
+			});
+			const { container } = renderHeader();
+			const downloadButton = container.querySelector('[data-cy="showDownloads"]') as HTMLElement;
+			await act(async () => {
+				fireEvent.click(downloadButton);
+			});
+			await waitFor(() => {
+				expect(screen.getByText('pending-only.csv')).toBeInTheDocument();
+			}, { timeout: 15000 });
+
+			await act(async () => {
+				fireEvent.click(screen.getByTestId('ant-switch'));
+			});
+
+			await waitFor(() => {
+				expect(screen.queryByText('pending-only.csv')).not.toBeInTheDocument();
+				expect(screen.getByText('No Data Found')).toBeInTheDocument();
+			}, { timeout: 15000 });
+		}, 30000);
 
 		it('should stop propagation when clicking switch', async () => {
 			mockGetDownloadStatus.mockResolvedValue({
@@ -1071,6 +1306,9 @@ describe('Header Component', () => {
 			expect(container.querySelector('[data-cy="showDownloads"]')).toBeInTheDocument();
 			expect(container.querySelector('[data-cy="showStats"]')).toBeInTheDocument();
 			expect(container.querySelector('[data-cy="user-account"]')).toBeInTheDocument();
+			expect(
+				container.querySelector('[data-cy="glossaryTermsListNavigate"]')
+			).not.toBeInTheDocument();
 		});
 	});
 });

--- a/dashboard/src/views/Router.tsx
+++ b/dashboard/src/views/Router.tsx
@@ -34,6 +34,9 @@ const ClassificationDetailsLayout = lazy(
 const GlossaryDetailLayout = lazy(
   () => import("@views/DetailPage/GlossaryDetails/GlossaryDetailsLayout")
 );
+const GlossaryTermsListPage = lazy(
+  () => import("@views/Glossary/GlossaryTermsListPage")
+);
 const AdministratiorLayout = lazy(
   () => import("@views/Administrator/AdministratorLayout")
 );
@@ -70,6 +73,10 @@ const Router = () => {
           <Route
             path="/administrator/businessMetadata/:bmguid"
             element={<BusinessMetadataDetailsLayout />}
+          />
+          <Route
+            path="/glossary/terms-list"
+            element={<GlossaryTermsListPage />}
           />
           <Route path="/glossary/:guid" element={<GlossaryDetailLayout />} />
           <Route

--- a/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
@@ -51,7 +51,6 @@ import {
   Typography,
 } from "@components/muiComponents";
 import AddIcon from "@mui/icons-material/Add";
-import TableRowsOutlinedIcon from "@mui/icons-material/TableRowsOutlined";
 import { getBusinessMetadataImportTmpl } from "@api/apiMethods/entitiesApiMethods";
 import {
   NavigateFunction,
@@ -1240,7 +1239,7 @@ const BarTreeView: FC<{
                       className="sidebar-menu-item"
                     >
                       <ListItemIcon sx={{ minWidth: "28px !important" }}>
-                        <TableRowsOutlinedIcon
+                        <FileDownloadIcon
                           fontSize="small"
                           className="menuitem-icon"
                         />

--- a/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/SideBarTree.tsx
@@ -51,6 +51,7 @@ import {
   Typography,
 } from "@components/muiComponents";
 import AddIcon from "@mui/icons-material/Add";
+import TableRowsOutlinedIcon from "@mui/icons-material/TableRowsOutlined";
 import { getBusinessMetadataImportTmpl } from "@api/apiMethods/entitiesApiMethods";
 import {
   NavigateFunction,
@@ -69,7 +70,8 @@ import { toast } from "react-toastify";
 import { EnumTypeDefData, TreeNode } from "@models/treeStructureType";
 import ImportDialog from "@components/ImportDialog";
 import TreeIcons from "@components/Treeicons";
-import { useAppSelector } from "@hooks/reducerHook";
+import { useAppDispatch, useAppSelector } from "@hooks/reducerHook";
+import { fetchGlossaryData } from "@redux/slice/glossarySlice";
 import TreeNodeIcons from "@components/TreeNodeIcons";
 import ClassificationForm from "@views/Classification/ClassificationForm";
 import AddUpdateGlossaryForm from "@views/Glossary/AddUpdateGlossaryForm";
@@ -287,6 +289,7 @@ const BarTreeView: FC<{
   searchTerm,
   loader,
 }) => {
+  const dispatch = useAppDispatch();
   const { savedSearchData }: any = useAppSelector(
     (state: any) => state.savedSearch
   );
@@ -1189,11 +1192,6 @@ const BarTreeView: FC<{
                         handleClose();
                       }}
                       data-cy="downloadBusinessMetadata"
-                      disabled={
-                        treeName == "Glossary" && !isEmptyServicetype
-                          ? true
-                          : false
-                      }
                       className="sidebar-menu-item"
                     >
                       <ListItemIcon sx={{ minWidth: "28px !important" }}>
@@ -1215,11 +1213,6 @@ const BarTreeView: FC<{
                         handleClose();
                       }}
                       data-cy="importBusinessMetadata"
-                      disabled={
-                        treeName == "Glossary" && !isEmptyServicetype
-                          ? true
-                          : false
-                      }
                       className="sidebar-menu-item"
                     >
                       <ListItemIcon sx={{ minWidth: "28px !important" }}>
@@ -1233,6 +1226,27 @@ const BarTreeView: FC<{
                         {treeName == "Entities"
                           ? "Import Business Metadata"
                           : "Import Glossary Term"}
+                      </Typography>
+                    </MenuItem>
+                  )}
+                  {treeName == "Glossary" && (
+                    <MenuItem
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate("/glossary/terms-list");
+                        handleClose();
+                      }}
+                      data-cy="glossaryTermsListNavigate"
+                      className="sidebar-menu-item"
+                    >
+                      <ListItemIcon sx={{ minWidth: "28px !important" }}>
+                        <TableRowsOutlinedIcon
+                          fontSize="small"
+                          className="menuitem-icon"
+                        />
+                      </ListItemIcon>
+                      <Typography className="menuitem-label">
+                        Export Glossary
                       </Typography>
                     </MenuItem>
                   )}
@@ -1266,6 +1280,13 @@ const BarTreeView: FC<{
               treeName == "Entities"
                 ? "Import Business Metadata"
                 : "Import Glossary Term"
+            }
+            onImportSuccess={
+              treeName == "Glossary"
+                ? () => {
+                    void dispatch(fetchGlossaryData());
+                  }
+                : undefined
             }
           />
         </SimpleTreeView>

--- a/dashboard/src/views/SideBar/SideBarTree/__tests__/SideBarTree.test.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/__tests__/SideBarTree.test.tsx
@@ -30,10 +30,11 @@ import React from 'react'
 import { render, screen, waitFor, fireEvent, act, cleanup } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
-import { BrowserRouter, MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import SideBarTree from '../SideBarTree'
 import { getBusinessMetadataImportTmpl } from '@api/apiMethods/entitiesApiMethods'
 import { getGlossaryImportTmpl } from '@api/apiMethods/glossaryApiMethod'
+import { fetchGlossaryData } from '@redux/slice/glossarySlice'
 
 // Mock dependencies
 jest.mock('@api/apiMethods/entitiesApiMethods', () => ({
@@ -68,9 +69,23 @@ jest.mock('@utils/Helper', () => ({
 	cloneDeep: jest.fn((obj) => JSON.parse(JSON.stringify(obj)))
 }))
 
+jest.mock('@redux/slice/glossarySlice', () => ({
+	fetchGlossaryData: jest.fn(() => ({ type: 'glossary/fetchGlossaryData' }))
+}))
+
 jest.mock('@components/ImportDialog', () => {
 	return function MockImportDialog(props: any) {
-		return props.open ? <div data-testid="import-dialog">Import Dialog</div> : null
+		return props.open ? (
+			<div data-testid="import-dialog">
+				<button
+					type="button"
+					data-testid="import-success-trigger"
+					onClick={() => props.onImportSuccess?.()}
+				>
+					Import Success
+				</button>
+			</div>
+		) : null
 	}
 })
 
@@ -161,8 +176,13 @@ jest.mock('@components/muiComponents', () => ({
 	Menu: ({ children, open, onClose, anchorEl }: any) => (
 		open ? <div data-testid="menu" onClick={onClose}>{children}</div> : null
 	),
-	MenuItem: ({ children, onClick, disabled }: any) => (
-		<div data-testid="menu-item" onClick={disabled ? undefined : onClick} data-disabled={disabled}>
+	MenuItem: ({ children, onClick, disabled, ...props }: any) => (
+		<div
+			data-testid="menu-item"
+			onClick={disabled ? undefined : onClick}
+			data-disabled={disabled}
+			{...props}
+		>
 			{children}
 		</div>
 	),
@@ -196,6 +216,11 @@ jest.mock('@mui/icons-material/LaunchOutlined', () => ({
 	default: ({ onClick }: any) => <div data-testid="launch-icon" onClick={onClick}>Launch</div>
 }))
 
+jest.mock('@mui/icons-material/TableRowsOutlined', () => ({
+	__esModule: true,
+	default: () => <div data-testid="table-rows-icon">Export</div>
+}))
+
 jest.mock('@mui/material/Stack', () => ({
 	__esModule: true,
 	default: ({ children, className, sx }: any) => (
@@ -205,6 +230,7 @@ jest.mock('@mui/material/Stack', () => ({
 
 describe('SideBarTree', () => {
 	const mockDispatch = jest.fn()
+	const mockFetchGlossaryData = fetchGlossaryData as jest.MockedFunction<typeof fetchGlossaryData>
 	const mockGetBusinessMetadataImportTmpl = getBusinessMetadataImportTmpl as jest.MockedFunction<typeof getBusinessMetadataImportTmpl>
 	const mockGetGlossaryImportTmpl = getGlossaryImportTmpl as jest.MockedFunction<typeof getGlossaryImportTmpl>
 
@@ -258,6 +284,7 @@ describe('SideBarTree', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks()
+		mockFetchGlossaryData.mockReturnValue({ type: 'glossary/fetchGlossaryData' } as any)
 		global.URL.createObjectURL = jest.fn(() => 'blob:url')
 		global.URL.revokeObjectURL = jest.fn()
 		
@@ -633,7 +660,7 @@ describe('SideBarTree', () => {
 			document.createElement = originalCreateElement
 		})
 
-		it('should disable download for Glossary when isEmptyServicetype is false', async () => {
+		it('should keep download enabled for Glossary when isEmptyServicetype is false', async () => {
 			renderComponent({
 				treeName: 'Glossary',
 				isEmptyServicetype: false
@@ -651,7 +678,7 @@ describe('SideBarTree', () => {
 				const downloadItem = menuItems.find(item => item.textContent?.includes('Download'))
 				
 				if (downloadItem) {
-					expect(downloadItem).toHaveAttribute('data-disabled', 'true')
+					expect(downloadItem).not.toHaveAttribute('data-disabled', 'true')
 				}
 			})
 		})
@@ -781,6 +808,88 @@ describe('SideBarTree', () => {
 			await waitFor(() => {
 				expect(screen.getByTestId('glossary-form')).toBeInTheDocument()
 			})
+		})
+
+		it('should show Export Glossary menu item for Glossary tree', async () => {
+			renderComponent({ treeName: 'Glossary' })
+
+			await waitFor(() => {
+				expect(screen.getByTestId('simple-tree-view')).toBeInTheDocument()
+			})
+
+			fireEvent.click(screen.getByTestId('more-vert-icon'))
+
+			await waitFor(() => {
+				expect(screen.getByTestId('menu')).toBeInTheDocument()
+			})
+
+			expect(screen.getByText('Export Glossary')).toBeInTheDocument()
+			expect(screen.getByTestId('table-rows-icon')).toBeInTheDocument()
+			expect(
+				document.querySelector('[data-cy="glossaryTermsListNavigate"]')
+			).toBeInTheDocument()
+		})
+
+		it('should navigate to glossary terms list when Export Glossary is clicked', async () => {
+			const LocationWatcher = () => {
+				const location = useLocation()
+				return <div data-testid="current-path">{location.pathname}</div>
+			}
+			const store = createMockStore()
+
+			render(
+				<Provider store={store}>
+					<MemoryRouter initialEntries={['/']}>
+						<LocationWatcher />
+						<SideBarTree
+							treeData={defaultTreeData}
+							treeName="Glossary"
+							refreshData={jest.fn()}
+							sideBarOpen={true}
+							searchTerm=""
+						/>
+					</MemoryRouter>
+				</Provider>
+			)
+
+			await waitFor(() => {
+				expect(screen.getByTestId('simple-tree-view')).toBeInTheDocument()
+			})
+
+			fireEvent.click(screen.getByTestId('more-vert-icon'))
+
+			await waitFor(() => {
+				expect(screen.getByTestId('menu')).toBeInTheDocument()
+			})
+
+			const exportItem = screen
+				.getAllByTestId('menu-item')
+				.find((item) => item.textContent?.includes('Export Glossary'))
+
+			expect(exportItem).toBeTruthy()
+			fireEvent.click(exportItem as HTMLElement)
+
+			await waitFor(() => {
+				expect(screen.getByTestId('current-path')).toHaveTextContent(
+					'/glossary/terms-list'
+				)
+			})
+		})
+
+		it('should not show Export Glossary menu item for Entities tree', async () => {
+			renderComponent({ treeName: 'Entities' })
+
+			await waitFor(() => {
+				expect(screen.getByTestId('simple-tree-view')).toBeInTheDocument()
+			})
+
+			fireEvent.click(screen.getByTestId('more-vert-icon'))
+
+			await waitFor(() => {
+				expect(screen.getByTestId('menu')).toBeInTheDocument()
+			})
+
+			expect(screen.queryByText('Export Glossary')).not.toBeInTheDocument()
 		})
 	})
 
@@ -1948,7 +2057,7 @@ describe('SideBarTree', () => {
 			}
 		})
 
-		it('should disable import for Glossary when isEmptyServicetype is false', async () => {
+		it('should keep import enabled for Glossary when isEmptyServicetype is false', async () => {
 			renderComponent({
 				treeName: 'Glossary',
 				isEmptyServicetype: false
@@ -1969,8 +2078,42 @@ describe('SideBarTree', () => {
 			const importItem = menuItems.find(item => item.textContent?.includes('Import'))
 			
 			if (importItem) {
-				expect(importItem).toHaveAttribute('data-disabled', 'true')
+				expect(importItem).not.toHaveAttribute('data-disabled', 'true')
 			}
+		})
+
+		it('should refresh glossary sidebar after successful glossary import', async () => {
+			renderComponent({
+				treeName: 'Glossary',
+				isEmptyServicetype: false
+			})
+
+			await waitFor(() => {
+				expect(screen.getByTestId('simple-tree-view')).toBeInTheDocument()
+			})
+
+			fireEvent.click(screen.getByTestId('more-vert-icon'))
+
+			await waitFor(() => {
+				expect(screen.getByTestId('menu')).toBeInTheDocument()
+			})
+
+			const importItem = screen
+				.getAllByTestId('menu-item')
+				.find(item => item.textContent?.includes('Import Glossary Term'))
+
+			expect(importItem).toBeTruthy()
+			fireEvent.click(importItem!)
+
+			await waitFor(() => {
+				expect(screen.getByTestId('import-dialog')).toBeInTheDocument()
+			})
+
+			fireEvent.click(screen.getByTestId('import-success-trigger'))
+
+			await waitFor(() => {
+				expect(mockFetchGlossaryData).toHaveBeenCalled()
+			})
 		})
 	})
 

--- a/dashboard/src/views/SideBar/SideBarTree/__tests__/SideBarTree.test.tsx
+++ b/dashboard/src/views/SideBar/SideBarTree/__tests__/SideBarTree.test.tsx
@@ -216,10 +216,6 @@ jest.mock('@mui/icons-material/LaunchOutlined', () => ({
 	default: ({ onClick }: any) => <div data-testid="launch-icon" onClick={onClick}>Launch</div>
 }))
 
-jest.mock('@mui/icons-material/TableRowsOutlined', () => ({
-	__esModule: true,
-	default: () => <div data-testid="table-rows-icon">Export</div>
-}))
 
 jest.mock('@mui/material/Stack', () => ({
 	__esModule: true,
@@ -824,7 +820,7 @@ describe('SideBarTree', () => {
 			})
 
 			expect(screen.getByText('Export Glossary')).toBeInTheDocument()
-			expect(screen.getByTestId('table-rows-icon')).toBeInTheDocument()
+			expect(screen.getAllByTestId('file-download-icon').length).toBeGreaterThanOrEqual(2)
 			expect(
 				document.querySelector('[data-cy="glossaryTermsListNavigate"]')
 			).toBeInTheDocument()

--- a/dashboardv2/public/css/scss/common.scss
+++ b/dashboardv2/public/css/scss/common.scss
@@ -332,6 +332,42 @@ pre {
     float: left;
 }
 
+.glossary-actions-dropdown {
+    .dropdown-menu {
+        min-width: 220px;
+        padding: 4px 0;
+
+        > li > a.glossary-sidebar-menu-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 16px;
+            color: $color_ironside_gray_approx;
+            white-space: nowrap;
+
+            .menuitem-icon {
+                color: $color_jungle_green_approx;
+                width: 16px;
+                min-width: 16px;
+                text-align: center;
+                flex-shrink: 0;
+                font-size: 14px;
+            }
+
+            .menuitem-label {
+                color: inherit;
+            }
+
+            &:hover,
+            &:focus {
+                color: $color_jungle_green_approx;
+                background-color: transparent;
+                text-decoration: none;
+            }
+        }
+    }
+}
+
 .glossary-terms-list-page {
     padding: 10px 10px;
 

--- a/dashboardv2/public/css/scss/common.scss
+++ b/dashboardv2/public/css/scss/common.scss
@@ -329,8 +329,93 @@ pre {
     font-size: 12px;
     font-weight: normal;
     margin-bottom: 5px;
-    margin-left: 5px;
     float: left;
+}
+
+.glossary-terms-list-page {
+    padding: 10px 10px;
+
+    .glossary-terms-list-actions {
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-end;
+        flex-wrap: nowrap;
+        gap: 8px;
+        max-width: 100%;
+
+        .btn {
+            flex-shrink: 0;
+            white-space: nowrap;
+        }
+
+        .glossary-download-dropdown {
+            flex-shrink: 0;
+
+            .dropdown-menu {
+                z-index: 1050;
+            }
+        }
+    }
+
+    .glossary-terms-table {
+        margin-top: 10px;
+
+        .table-responsive {
+            min-height: 140px;
+        }
+
+        .backgrid {
+            width: 100%;
+            margin-bottom: 0;
+        }
+
+        .banded.pagination-box {
+            margin-top: 10px;
+        }
+    }
+}
+
+.glossary-terms-list-title {
+    margin-top: 0;
+}
+
+.glossary-terms-filters {
+    margin-bottom: 15px;
+
+    &.is-loading {
+        opacity: 0.65;
+        pointer-events: none;
+    }
+}
+
+.glossary-status-badge {
+    display: inline-block;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    font-size: 11px;
+    line-height: 1.2;
+    padding: 2px 6px;
+    white-space: nowrap;
+}
+
+.glossary-status-active {
+    border-color: #37bb9b;
+    color: #1f7f67;
+}
+
+.glossary-status-draft {
+    border-color: #f0ad4e;
+    color: #9a6700;
+}
+
+.glossary-status-deprecated {
+    border-color: #bb5838;
+    color: #8f3f24;
+}
+
+.glossary-status-unknown {
+    border-color: #bdbdbd;
+    color: #686868;
 }
 
 .errorValidate {

--- a/dashboardv2/public/css/scss/downloads.scss
+++ b/dashboardv2/public/css/scss/downloads.scss
@@ -34,6 +34,7 @@
         padding: 10px;
         display: flex;
         align-items: center;
+        justify-content: space-between;
         color: #686868;
         border-bottom: 1px solid #ccc;
         background-color: #eee;
@@ -41,8 +42,33 @@
         border-top-right-radius: 10px;
 
         .download-header-actions {
-            position: absolute;
-            right: 15px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-shrink: 0;
+            margin-left: 12px;
+        }
+
+        .download-header-toggle-wrap {
+            display: inline-flex;
+            align-items: center;
+            flex-shrink: 0;
+            margin-right: 4px;
+        }
+
+        .download-header-toggle {
+            margin: 0;
+            display: inline-flex;
+            align-items: center;
+            flex-shrink: 0;
+            min-width: 3.5em;
+        }
+
+        .download-header-btn {
+            margin: 0;
+            flex-shrink: 0;
+            min-width: 32px;
+            padding: 5px 8px;
         }
 
         .pretty.p-switch.p-fill input:checked~.state.p-primary:before {
@@ -55,7 +81,7 @@
         position: absolute;
         left: 50%;
         top: 50%;
-        transform: translateX(-50%, -50%);
+        transform: translate(-50%, -50%);
 
         i {
             color: #37bb9b;
@@ -76,8 +102,16 @@
                 border-bottom: 1px solid #ccc;
                 display: flex;
                 align-items: center;
-                position: relative;
+                gap: 16px;
                 color: #686868;
+
+                &.download-list-empty {
+                    border-bottom: none;
+                }
+
+                > i.fa-file-excel-o {
+                    flex-shrink: 0;
+                }
 
                 i {
                     color: #37bb9b;
@@ -85,18 +119,17 @@
 
                 a {
                     color: #686868 !important;
-                    width: 100%;
                 }
 
                 .file-name {
-                    padding: 0 10px 0 10px;
                     word-wrap: break-word;
-                    width: 90%;
+                    flex: 1;
+                    min-width: 0;
                 }
 
                 .download-state {
-                    position: absolute;
-                    right: 15px;
+                    flex-shrink: 0;
+                    margin-left: auto;
                 }
             }
         }

--- a/dashboardv2/public/js/collection/VDownloadList.js
+++ b/dashboardv2/public/js/collection/VDownloadList.js
@@ -58,6 +58,16 @@ define(['require',
 
                 return this.constructor.nonCrudOperation.call(this, url, 'GET', options);
             },
+            getGlossaryDownloadsList: function(options) {
+                var url = UrlLinks.getGlossaryDownloadsList();
+
+                options = _.extend({
+                    contentType: 'application/json',
+                    dataType: 'json'
+                }, options);
+
+                return this.constructor.nonCrudOperation.call(this, url, 'GET', options);
+            },
             startDownloading: function(options) {
                 var queryParams = Utils.getUrlState.getQueryParams(),
                     url = queryParams.searchType === "basic" ? UrlLinks.downloadBasicSearchResultsCSV() : UrlLinks.downloadAdvanceSearchResultsCSV(),

--- a/dashboardv2/public/js/router/Router.js
+++ b/dashboardv2/public/js/router/Router.js
@@ -43,6 +43,7 @@ define([
             "!/tag/tagAttribute/(*name)": "tagAttributePageLoad",
             // Glossary
             "!/glossary": "commonAction",
+            "!/glossary/terms-list": "glossaryTermsList",
             "!/glossary/:id": "glossaryDetailPage",
             // Details
             "!/detailPage/:id": "detailPage",
@@ -270,8 +271,38 @@ define([
                 }
             });
         },
+        glossaryTermsList: function() {
+            var that = this;
+            require([
+                'views/site/Header',
+                'views/site/SideNavLayoutView',
+                'views/glossary/GlossaryTermsListLayoutView'
+            ], function(Header, SideNavLayoutView, GlossaryTermsListLayoutView) {
+                Utils.updateInternalTabState();
+                var paramObj = Utils.getUrlState.getQueryParams(),
+                    options = _.extend({}, that.preFetchedCollectionLists, that.sharedObj, that.ventObj);
+                that.renderViewIfNotExists(that.getHeaderOptions(Header));
+                that.renderViewIfNotExists({
+                    view: App.rSideNav,
+                    manualRender: function() {
+                        this.view.currentView.selectTab();
+                    },
+                    render: function() {
+                        return new SideNavLayoutView(options);
+                    }
+                });
+                if (App.rNContent.currentView && App.rNContent.currentView.destroy) {
+                    App.rNContent.currentView.destroy();
+                }
+                App.rNContent.show(new GlossaryTermsListLayoutView(options));
+            });
+        },
         glossaryDetailPage: function(id) {
             var that = this;
+            if (id === 'terms-list') {
+                this.glossaryTermsList();
+                return;
+            }
             if (id) {
                 require([
                     'views/site/Header',

--- a/dashboardv2/public/js/templates/glossary/GlossaryLayoutView_tmpl.html
+++ b/dashboardv2/public/js/templates/glossary/GlossaryLayoutView_tmpl.html
@@ -33,6 +33,8 @@
                 <ul class="dropdown-menu">
                     <li><a href="{{importTmplUrl}}">Download Import template</a></li>
                     <li><a href="javascript:void(0)" data-id="importGlossary">Import Glossary Term</a></li>
+                    <li class="divider"></li>
+                    <li><a href="#!/glossary/terms-list" data-id="exportGlossary"><i class="fa fa-table"></i> Export Glossary</a></li>
                 </ul>
             </div>
             <!--  -->

--- a/dashboardv2/public/js/templates/glossary/GlossaryLayoutView_tmpl.html
+++ b/dashboardv2/public/js/templates/glossary/GlossaryLayoutView_tmpl.html
@@ -28,13 +28,13 @@
         <div class="{{#if isAssignView}}col-sm-2{{else}}col-sm-5{{/if}} no-padding-right">
             <button type="button" class="btn btn-action btn-md pull-right" title="Refresh" data-id="refreshGlossary" onclick="this.blur();" type="button"><i class="fa fa-refresh"></i></button>
             <button type="button" class="btn btn-action btn-md pull-right" data-id="createGlossary" type="button"><i class="fa fa-plus"></i></button>
-            <div class="dropdown pull-right">
+            <div class="dropdown pull-right glossary-actions-dropdown">
                 <button type="button" data-toggle="dropdown" class="btn btn-action btn-md dropdown-toggle" type="button"><i class="fa fa-paperclip"></i></button>
                 <ul class="dropdown-menu">
-                    <li><a href="{{importTmplUrl}}">Download Import template</a></li>
-                    <li><a href="javascript:void(0)" data-id="importGlossary">Import Glossary Term</a></li>
+                    <li><a href="{{importTmplUrl}}" class="glossary-sidebar-menu-item"><i class="fa fa-download menuitem-icon" aria-hidden="true"></i><span class="menuitem-label">Download Import template</span></a></li>
+                    <li><a href="javascript:void(0)" data-id="importGlossary" class="glossary-sidebar-menu-item"><i class="fa fa-upload menuitem-icon" aria-hidden="true"></i><span class="menuitem-label">Import Glossary Term</span></a></li>
                     <li class="divider"></li>
-                    <li><a href="#!/glossary/terms-list" data-id="exportGlossary"><i class="fa fa-table"></i> Export Glossary</a></li>
+                    <li><a href="#!/glossary/terms-list" data-id="exportGlossary" class="glossary-sidebar-menu-item"><i class="fa fa-download menuitem-icon" aria-hidden="true"></i><span class="menuitem-label">Export Glossary</span></a></li>
                 </ul>
             </div>
             <!--  -->

--- a/dashboardv2/public/js/templates/glossary/GlossaryTermsListLayoutView_tmpl.html
+++ b/dashboardv2/public/js/templates/glossary/GlossaryTermsListLayoutView_tmpl.html
@@ -1,0 +1,83 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<div class="glossary-terms-list-page">
+    <div class="row form-group">
+        <div class="col-sm-8">
+            <h4 class="glossary-terms-list-title">
+                <i class="fa fa-list-alt text-green" aria-hidden="true"></i>
+                Glossary terms &amp; categories
+            </h4>
+        </div>
+        <div class="col-sm-4 text-right">
+            <div class="glossary-terms-list-actions">
+                <button type="button" class="btn btn-action btn-sm" data-id="refreshGlossaryTermsList" title="Reload from server">
+                    <i class="fa fa-refresh" aria-hidden="true"></i>&nbsp;Refresh
+                </button>
+                <div class="btn-group glossary-download-dropdown">
+                    <button type="button" class="btn btn-action btn-sm dropdown-toggle" data-id="downloadGlossaryTermsList" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Download glossary export">
+                        <i class="fa fa-download" aria-hidden="true"></i>&nbsp;Download&nbsp;<span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-right" role="menu">
+                        <li role="presentation">
+                            <a href="javascript:void(0)" role="menuitem" data-id="downloadGlossaryCsv">CSV</a>
+                        </li>
+                        <li role="presentation">
+                            <a href="javascript:void(0)" role="menuitem" data-id="downloadGlossaryXlsx">XLSX</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="panel panel-default glossary-terms-filters">
+        <div class="panel-heading"><strong>Filters</strong></div>
+        <div class="panel-body">
+            <div class="row">
+                <div class="col-sm-3 form-group">
+                    <label for="glossaryTermsFilterGlossary">Glossary</label>
+                    <select class="form-control" data-id="filterGlossary" id="glossaryTermsFilterGlossary">
+                        <option value="">All glossaries</option>
+                    </select>
+                </div>
+                <div class="col-sm-3 form-group">
+                    <label for="glossaryTermsFilterRecordType">Record type</label>
+                    <select class="form-control" data-id="filterRecordType" id="glossaryTermsFilterRecordType">
+                        <option value="all">All</option>
+                        <option value="Term">Terms only</option>
+                        <option value="Category">Categories only</option>
+                    </select>
+                </div>
+                <div class="col-sm-3 form-group">
+                    <label for="glossaryTermsFilterStatus">Status</label>
+                    <select class="form-control" data-id="filterStatus" id="glossaryTermsFilterStatus">
+                        <option value="">All</option>
+                        <option value="DRAFT">Draft</option>
+                        <option value="ACTIVE">Active</option>
+                        <option value="DEPRECATED">Deprecated</option>
+                    </select>
+                </div>
+                <div class="col-sm-3 form-group">
+                    <label for="glossaryTermsFilterSearch">Search all columns</label>
+                    <input type="text" class="form-control" data-id="filterSearchText" id="glossaryTermsFilterSearch" placeholder="Search all columns" />
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="r_glossaryTermsTableLayoutView" class="glossary-terms-table searchTable"></div>
+</div>

--- a/dashboardv2/public/js/templates/site/DownloadSearchResultLayoutView_tmpl.html
+++ b/dashboardv2/public/js/templates/site/DownloadSearchResultLayoutView_tmpl.html
@@ -18,12 +18,20 @@
     <div id="download-header" class="download-header">
         <span data-id="downloadtitle">Downloads</span>
         <div class="download-header-actions">
-            <div class="pretty p-switch p-fill" style="margin-right: 20px">
-                <input type="checkbox" data-id="toggleDownloads" title="" />
-                <div class="state p-primary">
-                    <label></label>
+            <span class="download-header-toggle-wrap">
+                <div class="pretty p-switch p-fill download-header-toggle">
+                    <input type="checkbox" data-id="toggleDownloads" title="" />
+                    <div class="state p-primary">
+                        <label></label>
+                    </div>
                 </div>
-            </div><button data-id="refreshDownloads" class="btn btn-action btn-sm"><i class="fa fa-refresh" aria-hidden="true"></i></button>&nbsp;<button data-id="closeDownloads" class="btn btn-action btn-sm"><i class="fa fa-times" aria-hidden="true"></i></button>
+            </span>
+            <button data-id="refreshDownloads" class="btn btn-action btn-sm download-header-btn" type="button" aria-label="Refresh downloads">
+                <i class="fa fa-refresh" aria-hidden="true"></i>
+            </button>
+            <button data-id="closeDownloads" class="btn btn-action btn-sm download-header-btn" type="button" aria-label="Close downloads">
+                <i class="fa fa-times" aria-hidden="true"></i>
+            </button>
         </div>
     </div>
     <div id="download-body" class="download-body">

--- a/dashboardv2/public/js/utils/GlossaryExport.js
+++ b/dashboardv2/public/js/utils/GlossaryExport.js
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define(['require', 'jquery', 'underscore', 'utils/UrlLinks', 'utils/CommonViewFunction'], function(require, $, _, UrlLinks, CommonViewFunction) {
+    'use strict';
+
+    var SEARCH_DEFAULTS = {
+        limit: 25,
+        offset: 0,
+        sortBy: 'glossaryName',
+        sortOrder: 'DESCENDING'
+    };
+
+    var STATUS_FILTER_OPTIONS = [
+        { label: 'All', value: '' },
+        { label: 'Draft', value: 'DRAFT' },
+        { label: 'Active', value: 'ACTIVE' },
+        { label: 'Deprecated', value: 'DEPRECATED' }
+    ];
+
+    var STATUS_META = {
+        ACTIVE: { label: 'Active', shortLabel: 'Active', cssClass: 'glossary-status-badge glossary-status-active' },
+        DRAFT: { label: 'Draft', shortLabel: 'Draft', cssClass: 'glossary-status-badge glossary-status-draft' },
+        DEPRECATED: { label: 'Deprecated', shortLabel: 'Depr.', cssClass: 'glossary-status-badge glossary-status-deprecated' },
+        UNKNOWN: { label: 'Unknown', shortLabel: '—', cssClass: 'glossary-status-badge glossary-status-unknown' }
+    };
+
+    var empty = function(v) {
+        return v === null || v === undefined ? '' : String(v);
+    };
+
+    var normalizeStatus = function(status) {
+        if (!status) {
+            return 'UNKNOWN';
+        }
+        var normalized = String(status).trim().toUpperCase();
+        if (normalized === 'ACTIVE' || normalized === 'DRAFT' || normalized === 'DEPRECATED') {
+            return normalized;
+        }
+        return 'UNKNOWN';
+    };
+
+    var getStatusMeta = function(status) {
+        return STATUS_META[normalizeStatus(status)];
+    };
+
+    var createDefaultFilters = function() {
+        return {
+            recordType: 'all',
+            glossaryName: '',
+            statusFilter: '',
+            searchText: ''
+        };
+    };
+
+    var mapRecordTypeToGlossaryType = function(recordType) {
+        if (recordType === 'Term') {
+            return 'TERM';
+        }
+        if (recordType === 'Category') {
+            return 'CATEGORY';
+        }
+        return undefined;
+    };
+
+    var buildGlossaryGuidByName = function(glossaryCollection) {
+        var map = {};
+        if (!glossaryCollection || !glossaryCollection.fullCollection) {
+            return map;
+        }
+        glossaryCollection.fullCollection.each(function(model) {
+            var name = model.get('name');
+            var guid = model.get('guid');
+            if (name && guid) {
+                map[name] = guid;
+            }
+        });
+        return map;
+    };
+
+    var buildSearchRequest = function(filters, pageIndex, rowsPerPage, glossaryGuidByName, sortOptions) {
+        glossaryGuidByName = glossaryGuidByName || {};
+        sortOptions = sortOptions || {};
+        var request = {
+            limit: rowsPerPage,
+            offset: pageIndex * rowsPerPage,
+            sortBy: sortOptions.sortBy || SEARCH_DEFAULTS.sortBy,
+            sortOrder: sortOptions.sortOrder || SEARCH_DEFAULTS.sortOrder,
+            excludeDeleted: true
+        };
+        var glossaryType = mapRecordTypeToGlossaryType(filters.recordType);
+        if (glossaryType) {
+            request.glossaryType = glossaryType;
+        }
+        if (filters.statusFilter && String(filters.statusFilter).trim()) {
+            request.status = String(filters.statusFilter).trim();
+        }
+        if (filters.searchText && String(filters.searchText).trim()) {
+            request.searchQuery = String(filters.searchText).trim();
+        }
+        if (filters.glossaryName && String(filters.glossaryName).trim()) {
+            var glossaryName = String(filters.glossaryName).trim();
+            request.glossary = {
+                name: glossaryName,
+                guid: glossaryGuidByName[glossaryName]
+            };
+        }
+        return request;
+    };
+
+    var formatCustomAttributesForDisplay = function(attrs) {
+        if (!attrs || typeof attrs !== 'object' || _.isEmpty(attrs)) {
+            return '';
+        }
+        return _.map(attrs, function(value, key) {
+            return key + ': ' + empty(value);
+        }).join(', ');
+    };
+
+    var formatCustomAttributesForTooltip = function(attrs) {
+        if (!attrs || typeof attrs !== 'object' || _.isEmpty(attrs)) {
+            return '';
+        }
+        try {
+            return JSON.stringify(attrs, null, 2);
+        } catch (e) {
+            return formatCustomAttributesForDisplay(attrs);
+        }
+    };
+
+    var mapDetailToRow = function(detail, recordType, glossaryName, glossaryGuid) {
+        return {
+            id: recordType.toLowerCase() + '-' + (empty(detail.guid) || empty(detail.name)),
+            recordType: recordType,
+            name: empty(detail.name),
+            guid: empty(detail.guid),
+            qualifiedName: empty(detail.qualifiedName),
+            glossaryName: glossaryName,
+            glossaryGuid: glossaryGuid,
+            shortDescription: empty(detail.shortDescription),
+            longDescription: empty(detail.longDescription),
+            status: empty(detail.status),
+            classifications: detail.classifications || [],
+            customAttributes: detail.customAttributes || {}
+        };
+    };
+
+    var mapSearchResponseToRows = function(response) {
+        var glossaries = response && response.glossary;
+        if (!_.isArray(glossaries)) {
+            return [];
+        }
+        var rows = [];
+        _.each(glossaries, function(glossary) {
+            var glossaryName = empty(glossary && glossary.name);
+            var glossaryGuid = empty(glossary && glossary.guid);
+            _.each(glossary.terms || [], function(term) {
+                rows.push(mapDetailToRow(term, 'Term', glossaryName, glossaryGuid));
+            });
+            _.each(glossary.categories || [], function(category) {
+                rows.push(mapDetailToRow(category, 'Category', glossaryName, glossaryGuid));
+            });
+        });
+        return rows;
+    };
+
+    var unwrapSearchResponse = function(response) {
+        if (response && response.glossary) {
+            return response;
+        }
+        if (response && response.data && response.data.glossary) {
+            return response.data;
+        }
+        return response || {};
+    };
+
+    var parseApproximateCount = function(value, fallback) {
+        var parsed = Number(value);
+        if (_.isFinite(parsed) && parsed >= 0) {
+            return parsed;
+        }
+        return fallback;
+    };
+
+    var postJson = function(url, data) {
+        return $.ajax({
+            url: url,
+            type: 'POST',
+            contentType: 'application/json',
+            dataType: 'json',
+            data: JSON.stringify(data),
+            beforeSend: CommonViewFunction.addRestCsrfCustomHeader
+        });
+    };
+
+    var fetchSearchPage = function(request) {
+        var deferred = $.Deferred();
+        postJson(UrlLinks.glossarySearchUrl(), request).done(function(response) {
+            var body = unwrapSearchResponse(response);
+            var rows = mapSearchResponseToRows(body);
+            var totalCount = parseApproximateCount(body.approximateCount, rows.length);
+            deferred.resolve({
+                rows: rows,
+                totalCount: totalCount
+            });
+        }).fail(function(xhr) {
+            deferred.reject(xhr);
+        });
+        return deferred.promise();
+    };
+
+    var buildSearchExportRequest = function(filters, glossaryGuidByName, format) {
+        var request = buildSearchRequest(filters, 0, 0, glossaryGuidByName, {});
+        request.limit = 0;
+        request.offset = 0;
+        if (format) {
+            request.format = format;
+        }
+        return request;
+    };
+
+    var requestExportDownload = function(filters, glossaryGuidByName, format) {
+        var deferred = $.Deferred();
+        postJson(
+            UrlLinks.glossaryCreateFileUrl(),
+            buildSearchExportRequest(filters, glossaryGuidByName, format || 'CSV')
+        ).done(function() {
+            deferred.resolve();
+        }).fail(function(xhr) {
+            deferred.reject(xhr);
+        });
+        return deferred.promise();
+    };
+
+    var formatStatusHtml = function(status) {
+        var meta = getStatusMeta(status);
+        return '<span class="' + meta.cssClass + '" title="Status: ' + _.escape(meta.label) + '">' +
+            _.escape(meta.shortLabel) + '</span>';
+    };
+
+    var formatClassificationsHtml = function(classifications) {
+        if (!_.isArray(classifications) || classifications.length === 0) {
+            return '';
+        }
+        return _.map(classifications, function(classification) {
+            if (!classification || !classification.typeName) {
+                return '';
+            }
+            var typeName = _.escape(classification.typeName);
+            return '<a href="#!/tag/tagAttribute/' + typeName + '" class="btn btn-action btn-sm btn-blue">' +
+                typeName + '</a>';
+        }).join(' ');
+    };
+
+    var buildGlossaryDetailUrl = function(row) {
+        var gType = row.recordType === 'Term' ? 'term' : 'category';
+        var params = {
+            gId: row.glossaryGuid,
+            gType: gType,
+            viewType: gType,
+            fromView: 'entity'
+        };
+        if (row.recordType === 'Term' && row.qualifiedName) {
+            params.term = row.qualifiedName;
+        }
+        var query = _.map(params, function(value, key) {
+            return encodeURIComponent(key) + '=' + encodeURIComponent(value);
+        }).join('&');
+        return '#!/glossary/' + row.guid + (query ? '?' + query : '');
+    };
+
+    var formatNameHtml = function(row) {
+        var name = _.escape(row.name);
+        if (!row.guid) {
+            return name;
+        }
+        return '<a href="' + buildGlossaryDetailUrl(row) + '" class="entity-name nav-link">' + name + '</a>';
+    };
+
+    return {
+        SEARCH_DEFAULTS: SEARCH_DEFAULTS,
+        STATUS_FILTER_OPTIONS: STATUS_FILTER_OPTIONS,
+        createDefaultFilters: createDefaultFilters,
+        buildGlossaryGuidByName: buildGlossaryGuidByName,
+        buildSearchRequest: buildSearchRequest,
+        buildSearchExportRequest: buildSearchExportRequest,
+        formatCustomAttributesForDisplay: formatCustomAttributesForDisplay,
+        formatCustomAttributesForTooltip: formatCustomAttributesForTooltip,
+        mapSearchResponseToRows: mapSearchResponseToRows,
+        fetchSearchPage: fetchSearchPage,
+        requestExportDownload: requestExportDownload,
+        formatStatusHtml: formatStatusHtml,
+        formatClassificationsHtml: formatClassificationsHtml,
+        formatNameHtml: formatNameHtml,
+        getStatusMeta: getStatusMeta
+    };
+});

--- a/dashboardv2/public/js/utils/UrlLinks.js
+++ b/dashboardv2/public/js/utils/UrlLinks.js
@@ -310,6 +310,21 @@ define(['require', 'utils/Enums', 'utils/Utils', 'underscore'], function(require
         },
         downloadSearchResultsFileUrl: function(fileName) {
             return this.baseUrlV2 + '/search/download/' + fileName;
+        },
+        glossarySearchUrl: function() {
+            return this.glossaryApiUrl() + '/search';
+        },
+        glossaryExportUrl: function() {
+            return this.glossaryApiUrl() + '/export';
+        },
+        glossaryCreateFileUrl: function() {
+            return this.glossaryApiUrl() + '/create_file';
+        },
+        getGlossaryDownloadsList: function() {
+            return this.glossaryApiUrl() + '/download/status';
+        },
+        glossaryDownloadFileUrl: function(fileName) {
+            return this.glossaryApiUrl() + '/download/' + fileName;
         }
     });
 

--- a/dashboardv2/public/js/utils/Utils.js
+++ b/dashboardv2/public/js/utils/Utils.js
@@ -413,6 +413,14 @@ define(['require', 'utils/Globals', 'pnotify', 'utils/Messages', 'utils/Enums', 
                 matchString: "glossary"
             });
         },
+        isGlossaryTermsListPage: function(url) {
+            var query = this.getQueryUrl(url),
+                lastValue = query.lastValue || '';
+            if (lastValue.indexOf('?') > -1) {
+                lastValue = lastValue.split('?')[0];
+            }
+            return query.firstValue === 'glossary' && lastValue === 'terms-list';
+        },
         isDetailPage: function(url) {
             return this.checkTabUrl({
                 url: url,

--- a/dashboardv2/public/js/views/glossary/GlossaryLayoutView.js
+++ b/dashboardv2/public/js/views/glossary/GlossaryLayoutView.js
@@ -55,6 +55,7 @@ define(['require',
                 termTree: "[data-id='termTree']",
                 categoryTree: "[data-id='categoryTree']",
                 importGlossary: "[data-id='importGlossary']",
+                exportGlossary: "[data-id='exportGlossary']",
                 glossaryTreeLoader: "[data-id='glossaryTreeLoader']",
                 glossaryTreeView: "[data-id='glossaryTreeView']"
             },
@@ -86,6 +87,7 @@ define(['require',
                     this.getGlossary();
                 };
                 events["click " + this.ui.importGlossary] = 'onClickImportGlossary';
+                events["click " + this.ui.exportGlossary] = 'onExportGlossary';
                 events["keyup " + this.ui.searchTerm] = function() {
                     this.ui.termTree.jstree("search", _.escape(this.ui.searchTerm.val()));
                 };
@@ -189,12 +191,10 @@ define(['require',
                     this.$('.category-view').show();
                     this.$('.term-view').hide();
                     this.viewType = "category";
-                    this.$('.dropdown-toggle').attr('disabled', 'disabled');
                 } else {
                     this.$('.term-view').show();
                     this.$('.category-view').hide();
                     this.viewType = "term";
-                    this.$('.dropdown-toggle').removeAttr('disabled');
                 }
                 var setDefaultSelector = function() {
                     if (!that.value) {
@@ -216,7 +216,7 @@ define(['require',
                         gType: "glossary"
                     }
                 }
-                if (Utils.getUrlState.isGlossaryTab()) {
+                if (Utils.getUrlState.isGlossaryTab() && !Utils.getUrlState.isGlossaryTermsListPage()) {
                     var obj = this.query[this.viewType],
                         $tree = this.ui[(this.viewType == "term" ? "termTree" : "categoryTree")];
                     obj["gId"] = that.value ? that.value.gId : null; //this Property added, Because when we toggle the GlossaryViewButton it does not adds the gId which is required for selection.
@@ -479,7 +479,7 @@ define(['require',
                         }
                     }
                 }
-                if (options.isTrigger) {
+                if (options.isTrigger && !Utils.getUrlState.isGlossaryTermsListPage()) {
                     this.triggerUrl();
                 }
             },
@@ -590,7 +590,16 @@ define(['require',
                                     } else if (type == that.viewType) {
                                         if (data && data.event && data.event.skipTrigger) {
                                             return;
-                                        } else if (that.glossary.selectedItem.guid !== data.node.original.guid) {
+                                        }
+                                        var onTermsListPage = Utils.getUrlState.isGlossaryTermsListPage();
+                                        var isUserSelection = !!(data && data.event);
+                                        if (onTermsListPage && !isUserSelection) {
+                                            that.glossary.selectedItem = data.node.original;
+                                            return;
+                                        }
+                                        var selectedGuid = that.glossary.selectedItem && that.glossary.selectedItem.guid;
+                                        var clickedGuid = data.node.original.guid;
+                                        if (onTermsListPage || selectedGuid !== clickedGuid) {
                                             that.glossary.selectedItem = data.node.original;
                                             that.triggerUrl();
                                         }
@@ -639,7 +648,7 @@ define(['require',
                 }
 
 
-                if (Utils.getUrlState.isGlossaryTab()) {
+                if (Utils.getUrlState.isGlossaryTab() && !Utils.getUrlState.isGlossaryTermsListPage()) {
                     this.triggerUrl();
                 }
                 this.glossaryCollection.trigger("render:done");
@@ -876,6 +885,28 @@ define(['require',
                         },
                         isGlossary: true
                     });
+                });
+            },
+            closeGlossaryActionsDropdown: function(e) {
+                var $dropdown = e && e.currentTarget
+                    ? $(e.currentTarget).closest('.dropdown')
+                    : this.$('.dropdown');
+                $dropdown.removeClass('open');
+                $dropdown.find('.dropdown-toggle').attr('aria-expanded', 'false');
+            },
+            onExportGlossary: function(e) {
+                if (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+                this.closeGlossaryActionsDropdown(e);
+                if (Utils.getUrlState.isGlossaryTermsListPage()) {
+                    return;
+                }
+                Utils.setUrl({
+                    url: '#!/glossary/terms-list',
+                    trigger: true,
+                    updateTabState: true
                 });
             }
         });

--- a/dashboardv2/public/js/views/glossary/GlossaryTermsListLayoutView.js
+++ b/dashboardv2/public/js/views/glossary/GlossaryTermsListLayoutView.js
@@ -1,0 +1,582 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define(['require',
+    'backbone',
+    'hbs!tmpl/glossary/GlossaryTermsListLayoutView_tmpl',
+    'utils/GlossaryExport',
+    'utils/CommonViewFunction',
+    'utils/Enums',
+    'utils/Messages',
+    'utils/Utils'
+], function(require, Backbone, GlossaryTermsListLayoutViewTmpl, GlossaryExport, CommonViewFunction, Enums, Messages, Utils) {
+    'use strict';
+
+    var FILTER_DEBOUNCE_MS = 400;
+
+    var GlossaryTermsListLayoutView = Backbone.Marionette.LayoutView.extend({
+        _viewName: 'GlossaryTermsListLayoutView',
+
+        template: GlossaryTermsListLayoutViewTmpl,
+
+        regions: {
+            RGlossaryTermsTableLayoutView: '#r_glossaryTermsTableLayoutView'
+        },
+
+        ui: {
+            refreshButton: "[data-id='refreshGlossaryTermsList']",
+            downloadButton: "[data-id='downloadGlossaryTermsList']",
+            downloadCsv: "[data-id='downloadGlossaryCsv']",
+            downloadXlsx: "[data-id='downloadGlossaryXlsx']",
+            filterGlossary: "[data-id='filterGlossary']",
+            filterRecordType: "[data-id='filterRecordType']",
+            filterStatus: "[data-id='filterStatus']",
+            filterSearchText: "[data-id='filterSearchText']",
+            tagClick: '[data-id="tagClick"]',
+            addTag: '[data-id="addTag"]'
+        },
+
+        events: function() {
+            var events = {},
+                that = this;
+            events['click ' + this.ui.refreshButton] = 'onRefresh';
+            events['click ' + this.ui.downloadCsv] = 'onDownloadCsv';
+            events['click ' + this.ui.downloadXlsx] = 'onDownloadXlsx';
+            events['change ' + this.ui.filterGlossary] = 'onFilterChange';
+            events['change ' + this.ui.filterRecordType] = 'onFilterChange';
+            events['change ' + this.ui.filterStatus] = 'onFilterChange';
+            events['keyup ' + this.ui.filterSearchText] = 'onSearchTextChange';
+            events['click ' + this.ui.tagClick] = function(e) {
+                var scope = $(e.currentTarget);
+                if (e.target.nodeName.toLocaleLowerCase() === 'i') {
+                    that.onClickTagCross(e);
+                } else {
+                    Utils.setUrl({
+                        url: '#!/tag/tagAttribute/' + scope.text().split('@')[0],
+                        mergeBrowserUrl: false,
+                        trigger: true
+                    });
+                }
+            };
+            events['click ' + this.ui.addTag] = 'onClickAddTag';
+            return events;
+        },
+
+        initialize: function(options) {
+            _.extend(this, _.pick(options, 'glossaryCollection', 'classificationDefCollection', 'enumDefCollection', 'searchVent'));
+            this.filters = GlossaryExport.createDefaultFilters();
+            this.limit = GlossaryExport.SEARCH_DEFAULTS.limit;
+            this.offset = 0;
+            this.totalCount = 0;
+            this.isDownloading = false;
+            this.isFetching = false;
+            this.fetchSequence = 0;
+            this.sortBy = GlossaryExport.SEARCH_DEFAULTS.sortBy;
+            this.sortOrder = GlossaryExport.SEARCH_DEFAULTS.sortOrder;
+            this.debounceTimer = null;
+            this.tableCollection = new Backbone.Collection();
+            this.tableCollection.state = {
+                totalRecords: 0,
+                pageSize: this.limit,
+                currentPage: 0
+            };
+            this.tableCollection.queryParams = {
+                limit: this.limit,
+                offset: this.offset
+            };
+            this.commonTableOptions = {
+                collection: this.tableCollection,
+                clientAtlasPagination: true,
+                includePagination: false,
+                includeAtlasPagination: true,
+                includeFooterRecords: true,
+                includeColumnManager: false,
+                includeOrderAbleColumns: false,
+                includeSizeAbleColumns: false,
+                includeTableLoader: true,
+                includeAtlasPageSize: true,
+                includeAtlasTableSorting: false,
+                atlasShowLoaderBeforeFetch: this.showFetchLoader.bind(this),
+                atlasPaginationOpts: {
+                    limit: this.limit,
+                    offset: this.offset,
+                    fetchCollection: this.fetchCollection.bind(this),
+                    atlasApproximateDatasetTotal: this.getApproximateTotal.bind(this)
+                },
+                gridOpts: {
+                    emptyText: 'No rows match the current filters.',
+                    className: 'table table-hover backgrid table-quickMenu colSort'
+                },
+                filterOpts: {},
+                paginatorOpts: {}
+            };
+        },
+
+        onRender: function() {
+            var that = this;
+            if (this.glossaryCollection && !this.glossaryCollection.fullCollection.length) {
+                this.glossaryCollection.fetch({
+                    reset: true,
+                    success: function() {
+                        that.populateGlossaryFilter();
+                    }
+                });
+            } else {
+                this.populateGlossaryFilter();
+            }
+            this.renderTableLayoutView();
+        },
+
+        getApproximateTotal: function() {
+            return this.totalCount;
+        },
+
+        getGlossaryGuidByName: function() {
+            return GlossaryExport.buildGlossaryGuidByName(this.glossaryCollection);
+        },
+
+        populateGlossaryFilter: function() {
+            var $select = this.ui.filterGlossary;
+            $select.find('option:not(:first)').remove();
+            if (!this.glossaryCollection || !this.glossaryCollection.fullCollection) {
+                return;
+            }
+            var names = this.glossaryCollection.fullCollection.map(function(model) {
+                return model.get('name');
+            });
+            names = _.sortBy(_.compact(names), function(name) {
+                return name.toLowerCase();
+            });
+            _.each(names, function(name) {
+                $select.append($('<option></option>').attr('value', name).text(name));
+            });
+        },
+
+        readFiltersFromUi: function() {
+            this.filters.glossaryName = this.ui.filterGlossary.val() || '';
+            this.filters.recordType = this.ui.filterRecordType.val() || 'all';
+            this.filters.statusFilter = this.ui.filterStatus.val() || '';
+            this.filters.searchText = this.ui.filterSearchText.val() || '';
+        },
+
+        onFilterChange: function() {
+            this.readFiltersFromUi();
+            this.offset = 0;
+            this.fetchCollection({ fromUrl: true, filterChange: true });
+        },
+
+        onSearchTextChange: function() {
+            var that = this;
+            this.readFiltersFromUi();
+            if (this.debounceTimer) {
+                clearTimeout(this.debounceTimer);
+            }
+            this.debounceTimer = setTimeout(function() {
+                that.offset = 0;
+                that.fetchCollection({ fromUrl: true, filterChange: true });
+            }, FILTER_DEBOUNCE_MS);
+        },
+
+        onRefresh: function() {
+            this.fetchCollection({ fromUrl: true, refresh: true });
+        },
+
+        mapColumnToSortBy: function(columnName) {
+            var sortMap = {
+                glossaryName: 'glossaryName',
+                name: 'name',
+                recordType: 'recordType',
+                status: 'status'
+            };
+            return sortMap[columnName] || 'name';
+        },
+
+        createSortableHeaderCell: function() {
+            var that = this;
+            return Backgrid.HeaderCell.extend({
+                onClick: function(e) {
+                    e.preventDefault();
+                    var column = this.column;
+                    if (!column.get('sortable')) {
+                        return;
+                    }
+                    var columnName = column.get('name');
+                    var direction = 'ascending';
+                    if (that.sortBy === that.mapColumnToSortBy(columnName) && that.sortOrder === 'ASCENDING') {
+                        direction = 'descending';
+                    }
+                    that.sortBy = that.mapColumnToSortBy(columnName);
+                    that.sortOrder = direction === 'ascending' ? 'ASCENDING' : 'DESCENDING';
+                    that.offset = 0;
+                    if (that.tableLayout && that.tableLayout.columns) {
+                        that.tableLayout.columns.each(function(col) {
+                            col.set('direction', col.get('name') === columnName ? direction : null);
+                        });
+                    }
+                    that.fetchCollection({ fromUrl: true, sortChange: true });
+                }
+            });
+        },
+
+        showFetchLoader: function(options) {
+            options = options || {};
+            this.isFetching = true;
+            this.$('.glossary-terms-filters').addClass('is-loading');
+            if (this.tableLayout) {
+                if (this.tableLayout.setAtlasPaginationBusy) {
+                    var navHint = options.next ? 'next' : (options.previous ? 'prev' : 'both');
+                    this.tableLayout.setAtlasPaginationBusy(true, navHint);
+                }
+                this.tableLayout.$('div[data-id="r_tableSpinner"]').addClass('show');
+            }
+            this.ui.filterGlossary.prop('disabled', true);
+            this.ui.filterRecordType.prop('disabled', true);
+            this.ui.filterStatus.prop('disabled', true);
+            this.ui.filterSearchText.prop('disabled', true);
+            this.ui.refreshButton.attr('disabled', true);
+            this.ui.downloadButton.attr('disabled', true);
+        },
+
+        hideFetchLoader: function() {
+            this.isFetching = false;
+            this.$('.glossary-terms-filters').removeClass('is-loading');
+            if (this.tableLayout) {
+                this.tableLayout.$('div[data-id="r_tableSpinner"]').removeClass('show');
+                if (this.tableLayout.setAtlasPaginationBusy) {
+                    this.tableLayout.setAtlasPaginationBusy(false);
+                }
+            }
+            this.ui.filterGlossary.prop('disabled', false);
+            this.ui.filterRecordType.prop('disabled', false);
+            this.ui.filterStatus.prop('disabled', false);
+            this.ui.filterSearchText.prop('disabled', false);
+            this.ui.refreshButton.attr('disabled', false);
+            this.ui.downloadButton.attr('disabled', false);
+        },
+
+        completeFetch: function(result, options, fetchId) {
+            if (fetchId !== this.fetchSequence) {
+                return;
+            }
+            this.totalCount = result.totalCount;
+            this.tableCollection.state.totalRecords = result.totalCount;
+            this.tableCollection.state.pageSize = this.limit;
+            this.tableCollection.state.currentPage = Math.floor(this.offset / this.limit);
+            this.tableCollection.reset(result.rows);
+            this.tableCollection.trigger('sync');
+            this.ui.downloadButton.attr('disabled', this.totalCount === 0 || this.isDownloading);
+            this.hideFetchLoader();
+            if (this.tableLayout) {
+                this.tableLayout.trigger('grid:refresh');
+                if (this.tableLayout.renderAtlasPagination) {
+                    this.tableLayout.renderAtlasPagination(options || {});
+                }
+            }
+        },
+
+        failFetch: function(xhr, fetchId) {
+            if (fetchId !== this.fetchSequence) {
+                return;
+            }
+            this.totalCount = 0;
+            this.tableCollection.state.totalRecords = 0;
+            this.tableCollection.reset([]);
+            this.tableCollection.trigger('error');
+            this.ui.downloadButton.attr('disabled', true);
+            this.hideFetchLoader();
+            var message = 'Failed to load glossary terms';
+            if (xhr && xhr.responseJSON && xhr.responseJSON.errorMessage) {
+                message = xhr.responseJSON.errorMessage;
+            }
+            Utils.notifyError({ content: message });
+        },
+
+        onDownloadCsv: function(e) {
+            if (e) {
+                e.preventDefault();
+            }
+            this.onDownload('CSV');
+        },
+
+        onDownloadXlsx: function(e) {
+            if (e) {
+                e.preventDefault();
+            }
+            this.onDownload('XLSX');
+        },
+
+        onDownload: function(format) {
+            var that = this;
+            if (this.isDownloading || this.totalCount === 0) {
+                return;
+            }
+            this.isDownloading = true;
+            this.ui.downloadButton.attr('disabled', true);
+            GlossaryExport.requestExportDownload(this.filters, this.getGlossaryGuidByName(), format || 'CSV').done(function() {
+                Utils.notifySuccess({
+                    content: 'The current glossary export has been enqueued for download. You can access the file by clicking the download icon at the top of the page.'
+                });
+            }).fail(function(xhr) {
+                var message = 'Glossary export failed';
+                if (xhr && xhr.responseJSON && xhr.responseJSON.errorMessage) {
+                    message = xhr.responseJSON.errorMessage;
+                }
+                Utils.notifyError({ content: message });
+            }).always(function() {
+                that.isDownloading = false;
+                that.ui.downloadButton.attr('disabled', that.totalCount === 0);
+            });
+        },
+
+        getTagList: function(guid) {
+            var model = this.tableCollection.find(function(item) {
+                return item.get('guid') === guid;
+            });
+            if (!model) {
+                return [];
+            }
+            var obj = model.toJSON();
+            return _.compact(_.map(obj.classifications, function(val) {
+                if (val.entityGuid === guid) {
+                    return val.typeName;
+                }
+            }));
+        },
+
+        addTagModalView: function(guid) {
+            var that = this;
+            require(['views/tag/AddTagModalView'], function(AddTagModalView) {
+                var view = new AddTagModalView({
+                    guid: guid,
+                    callback: function() {
+                        that.fetchCollection({ fromUrl: true, refresh: true });
+                        if (that.searchVent) {
+                            that.searchVent.trigger('entityList:refresh');
+                        }
+                    },
+                    tagList: that.getTagList(guid),
+                    showLoader: that.showFetchLoader.bind(that),
+                    hideLoader: that.hideFetchLoader.bind(that),
+                    collection: that.classificationDefCollection,
+                    enumDefCollection: that.enumDefCollection
+                });
+            });
+        },
+
+        onClickAddTag: function(e) {
+            var guid = this.$(e.currentTarget).data('guid');
+            if (guid) {
+                this.addTagModalView(guid);
+            }
+        },
+
+        onClickTagCross: function(e) {
+            var that = this,
+                tagName = $(e.target).data('name'),
+                guid = $(e.target).data('guid'),
+                entityGuid = $(e.target).data('entityguid'),
+                assetName = $(e.target).data('assetname');
+            CommonViewFunction.deleteTag({
+                tagName: tagName,
+                guid: guid,
+                associatedGuid: guid !== entityGuid ? entityGuid : null,
+                msg: "<div class='ellipsis-with-margin'>Remove: " + "<b>" + _.escape(tagName) + "</b> assignment from <b>" + _.escape(assetName) + " ?</b></div>",
+                titleMessage: Messages.removeTag,
+                okText: 'Remove',
+                showLoader: that.showFetchLoader.bind(that),
+                hideLoader: that.hideFetchLoader.bind(that),
+                callback: function() {
+                    that.fetchCollection({ fromUrl: true, refresh: true });
+                    if (that.searchVent) {
+                        that.searchVent.trigger('entityList:refresh');
+                    }
+                }
+            });
+        },
+
+        formatClassificationsCell: function(model) {
+            var row = model.toJSON();
+            if (row.recordType !== 'Term' || !row.guid || !this.classificationDefCollection) {
+                return GlossaryExport.formatClassificationsHtml(row.classifications);
+            }
+            var obj = {
+                guid: row.guid,
+                status: row.status,
+                classifications: row.classifications || []
+            };
+            if (obj.status && Enums.entityStateReadOnly[obj.status]) {
+                return '<div class="readOnly">' + CommonViewFunction.tagForTable(obj, this.classificationDefCollection) + '</div>';
+            }
+            return CommonViewFunction.tagForTable(obj, this.classificationDefCollection);
+        },
+
+        fetchCollection: function(options) {
+            var that = this;
+            options = options || {};
+            this.fetchSequence += 1;
+            var fetchId = this.fetchSequence;
+            this.showFetchLoader(options);
+            this.readFiltersFromUi();
+            if (_.isFinite(options.offset)) {
+                this.offset = options.offset;
+            } else if (this.tableLayout) {
+                this.offset = this.tableLayout.offset || this.offset;
+                this.limit = this.tableLayout.limit || this.limit;
+            }
+            if (options.filterChange || options.sortChange || options.refresh) {
+                this.offset = options.offset || 0;
+                if (this.tableLayout) {
+                    this.tableLayout.offset = this.offset;
+                }
+            }
+            var pageIndex = Math.floor(this.offset / this.limit);
+            var request = GlossaryExport.buildSearchRequest(
+                this.filters,
+                pageIndex,
+                this.limit,
+                this.getGlossaryGuidByName(),
+                {
+                    sortBy: this.sortBy,
+                    sortOrder: this.sortOrder
+                }
+            );
+            this.tableCollection.trigger('request');
+            GlossaryExport.fetchSearchPage(request).done(function(result) {
+                that.completeFetch(result, options, fetchId);
+            }).fail(function(xhr) {
+                that.failFetch(xhr, fetchId);
+            });
+        },
+
+        renderTableLayoutView: function() {
+            var that = this;
+            if (this._tableLayoutLoading) {
+                return;
+            }
+            this._tableLayoutLoading = true;
+            require(['utils/TableLayout'], function(TableLayout) {
+                var columns = new Backgrid.Columns(that.getColumns());
+                that.tableLayout = new TableLayout(_.extend({}, that.commonTableOptions, {
+                    columns: columns
+                }));
+                that.RGlossaryTermsTableLayoutView.show(that.tableLayout);
+                _.extend(that.tableCollection.queryParams, {
+                    limit: that.limit,
+                    offset: that.offset
+                });
+                that._tableLayoutLoading = false;
+                that.fetchCollection({ fromUrl: true });
+            });
+        },
+
+        getColumns: function() {
+            var that = this;
+            var sortableHeaderCell = this.createSortableHeaderCell();
+            var colDefs = {
+                glossaryName: {
+                    label: 'Glossary Name',
+                    cell: 'string',
+                    editable: false,
+                    sortable: true,
+                    headerCell: sortableHeaderCell,
+                    className: 'searchTableName'
+                },
+                name: {
+                    label: 'Name',
+                    cell: 'html',
+                    editable: false,
+                    sortable: true,
+                    headerCell: sortableHeaderCell,
+                    className: 'searchTableName',
+                    formatter: _.extend({}, Backgrid.CellFormatter.prototype, {
+                        fromRaw: function(rawValue, model) {
+                            return GlossaryExport.formatNameHtml(model.toJSON());
+                        }
+                    })
+                },
+                recordType: {
+                    label: 'Record Type',
+                    cell: 'string',
+                    editable: false,
+                    sortable: true,
+                    headerCell: sortableHeaderCell
+                },
+                shortDescription: {
+                    label: 'Short Description',
+                    cell: 'string',
+                    editable: false,
+                    sortable: false,
+                    className: 'searchTableName'
+                },
+                longDescription: {
+                    label: 'Long Description',
+                    cell: 'string',
+                    editable: false,
+                    sortable: false,
+                    className: 'searchTableName'
+                },
+                classifications: {
+                    label: 'Classifications',
+                    cell: 'html',
+                    editable: false,
+                    sortable: false,
+                    formatter: _.extend({}, Backgrid.CellFormatter.prototype, {
+                        fromRaw: function(rawValue, model) {
+                            return that.formatClassificationsCell(model);
+                        }
+                    })
+                },
+                customAttributes: {
+                    label: 'Custom Attributes',
+                    cell: 'html',
+                    editable: false,
+                    sortable: false,
+                    className: 'searchTableName',
+                    formatter: _.extend({}, Backgrid.CellFormatter.prototype, {
+                        fromRaw: function(rawValue, model) {
+                            var attrs = model.get('customAttributes');
+                            var display = GlossaryExport.formatCustomAttributesForDisplay(attrs);
+                            if (!display) {
+                                return '';
+                            }
+                            var tooltip = _.escape(GlossaryExport.formatCustomAttributesForTooltip(attrs));
+                            return '<span class="entity-name" title="' + tooltip + '">' + _.escape(display) + '</span>';
+                        }
+                    })
+                },
+                status: {
+                    label: 'Status',
+                    cell: 'html',
+                    editable: false,
+                    sortable: true,
+                    headerCell: sortableHeaderCell,
+                    formatter: _.extend({}, Backgrid.CellFormatter.prototype, {
+                        fromRaw: function(rawValue) {
+                            return GlossaryExport.formatStatusHtml(rawValue);
+                        }
+                    })
+                }
+            };
+            return _.map(colDefs, function(def, key) {
+                return _.extend({ name: key }, def);
+            });
+        }
+    });
+
+    return GlossaryTermsListLayoutView;
+});

--- a/dashboardv2/public/js/views/site/DownloadSearchResultLayoutView.js
+++ b/dashboardv2/public/js/views/site/DownloadSearchResultLayoutView.js
@@ -53,13 +53,9 @@ define(['require',
                 events['click ' + this.ui.closeDownloadsButton] = "onHideDownloads";
                 events['click ' + this.ui.refreshDownloadsButton] = "onRefreshDownloads";
                 events['change ' + this.ui.toggleDownloads] = function(e) {
-                    this.showCompletedDownloads = !this.showCompletedDownloads;
-                    if(this.showCompletedDownloads){
-                        this.ui.toggleDownloads.attr("data-original-title", "Display All Files");
-                    } else {
-                        this.ui.toggleDownloads.attr("data-original-title", "Display Available Files");
-                    }
-                    this.genrateDownloadList();
+                    this.showAllDownloads = e.currentTarget.checked;
+                    this.updateDownloadToggleTooltip();
+                    this.generateDownloadList();
                 }
                 return events;
             },
@@ -70,8 +66,10 @@ define(['require',
             initialize: function(options) {
                 this.options = options;
                 this.showDownloads = new VDownloadList();
-                this.showCompletedDownloads = true;
+                this.showAllDownloads = true;
                 this.downloadsData = [];
+                this.isDownloadsPanelOpen = false;
+                this.onDocumentClickBound = _.bind(this.onDocumentClick, this);
                 this.bindEvents();
             },
             bindEvents: function() {
@@ -80,51 +78,92 @@ define(['require',
                 });
             },
             onRender: function() {
-                this.ui.toggleDownloads.attr("data-original-title", "Display All Files");
+                this.ui.toggleDownloads.prop('checked', this.showAllDownloads);
+                this.updateDownloadToggleTooltip();
+            },
+            updateDownloadToggleTooltip: function() {
+                var tooltip = this.showAllDownloads
+                    ? "Showing all files (including in progress)"
+                    : "Showing completed files only";
+                this.ui.toggleDownloads.attr("data-original-title", tooltip);
             },
             initializeValues: function() {},
             fetchDownloadsData: function() {
-                var that = this;
-                var apiObj = {
-                    success: function(data, response) {
-                        that.downloadsData = data.searchDownloadRecords;
-                        that.genrateDownloadList();
-                    },
-                    complete: function() {
+                var that = this,
+                    merged = [],
+                    pending = 2,
+                    hadFailure = false;
+
+                var finishIfDone = function() {
+                    pending -= 1;
+                    if (pending === 0) {
+                        that.downloadsData = merged;
+                        that.generateDownloadList();
                         that.hideLoader();
+                        if (hadFailure && merged.length === 0) {
+                            Utils.notifyError({ content: 'Failed to fetch download records' });
+                        }
+                    }
+                };
+
+                this.showDownloads.getDownloadsList({
+                    success: function(data) {
+                        var records = (data && data.searchDownloadRecords) || [];
+                        _.each(records, function(record) {
+                            merged.push(_.extend({}, record, { source: 'search' }));
+                        });
                     },
+                    error: function() {
+                        hadFailure = true;
+                    },
+                    complete: finishIfDone,
                     reset: true
-                }
-                this.showDownloads.getDownloadsList(apiObj);
+                });
+
+                this.showDownloads.getGlossaryDownloadsList({
+                    success: function(data) {
+                        // Backend reuses searchDownloadRecords for glossary export status.
+                        var records = (data && (data.glossaryDownloadRecords || data.searchDownloadRecords)) || [];
+                        _.each(records, function(record) {
+                            merged.push(_.extend({}, record, { source: 'glossary' }));
+                        });
+                    },
+                    error: function() {
+                        hadFailure = true;
+                    },
+                    complete: finishIfDone
+                });
             },
-            genrateDownloadList: function() {
+            // Keep timestamp parsing/sorting aligned with dashboard/src/utils/downloadRecords.ts
+            generateDownloadList: function() {
                 var that = this,
                     stateIconEl = "",
                     completedDownloads = "",
                     allDownloads = "",
                     downloadList = "",
-                    sortedData = _.sortBy(this.downloadsData, function(obj){
-                        return obj.createdTime;
-                    }).reverse();
+                    sortedData = that.sortDownloadRecordsByLatest(this.downloadsData);
                 if (sortedData.length) {
                     _.each(sortedData, function(obj) {
+                        var downloadUrl = obj.source === 'glossary'
+                            ? UrlLinks.glossaryDownloadFileUrl(obj.fileName)
+                            : UrlLinks.downloadSearchResultsFileUrl(obj.fileName);
                         if (obj.status === "PENDING") {
                             stateIconEl = "<span class='download-state'><i class='fa fa-refresh fa-spin-custom' aria-hidden='true'></i></span>";
                         } else {
-                            stateIconEl = "<span class='download-state'><a href=" + UrlLinks.downloadSearchResultsFileUrl(obj.fileName) + "><i class='fa fa-arrow-circle-o-down fa-lg' aria-hidden='true'></i></a></span>";
-                            completedDownloads += "<li><i class='fa fa-file-excel-o fa-lg' aria-hidden='true'></i><span class='file-name'>" + obj.fileName + "</span>" + stateIconEl + "</li>"
+                            stateIconEl = "<span class='download-state'><a href='" + downloadUrl + "'><i class='fa fa-arrow-circle-o-down fa-lg' aria-hidden='true'></i></a></span>";
+                            completedDownloads += "<li><i class='fa fa-file-excel-o fa-lg' aria-hidden='true'></i><span class='file-name'>" + obj.fileName + "</span>" + stateIconEl + "</li>";
                         }
                         allDownloads += "<li><i class='fa fa-file-excel-o fa-lg' aria-hidden='true'></i><span class='file-name'>" + obj.fileName + "</span>" + stateIconEl + "</li>";
                     });
                 } else {
-                    completedDownloads = allDownloads = "<li class='text-center' style='border-bottom:none'>No Data Found</li>"
+                    completedDownloads = allDownloads = "<li class='text-center download-list-empty'>No Data Found</li>";
                 }
 
                 if (this.downloadsData.length && completedDownloads === "") {
-                    completedDownloads = "<li class='text-center' style='border-bottom:none'>No Data Found</li>";
+                    completedDownloads = "<li class='text-center download-list-empty'>No Data Found</li>";
                 }
 
-                downloadList = this.showCompletedDownloads ? completedDownloads : allDownloads;
+                downloadList = this.showAllDownloads ? allDownloads : completedDownloads;
                 this.ui.downloadListContainer.empty();
                 this.ui.downloadListContainer.html(downloadList);
             },
@@ -138,15 +177,80 @@ define(['require',
                 this.fetchDownloadsData();
                 this.showLoader();
                 this.ui.downloadsPanel.css("right", "20px");
+                if (!this.isDownloadsPanelOpen) {
+                    this.isDownloadsPanelOpen = true;
+                    var that = this;
+                    setTimeout(function() {
+                        $(document).on('click.downloadsPanel', that.onDocumentClickBound);
+                    }, 0);
+                }
             },
             onHideDownloads: function() {
-                this.ui.downloadsPanel.css("right", "-700px")
+                this.ui.downloadsPanel.css("right", "-700px");
+                if (this.isDownloadsPanelOpen) {
+                    this.isDownloadsPanelOpen = false;
+                    $(document).off('click.downloadsPanel');
+                }
+            },
+            onDocumentClick: function(e) {
+                var $target = $(e.target);
+                if ($target.closest('.downloads-panel').length) {
+                    return;
+                }
+                if ($target.closest('[data-id="showDownloads"]').length) {
+                    return;
+                }
+                this.onHideDownloads();
+            },
+            onBeforeDestroy: function() {
+                $(document).off('click.downloadsPanel');
             },
             showLoader: function() {
                 this.$('.downloadListLoader').show();
             },
             hideLoader: function(options) {
                 this.$('.downloadListLoader').hide();
+            },
+            parseCreatedTime: function(createdTime) {
+                if (createdTime === undefined || createdTime === null || createdTime === '') {
+                    return null;
+                }
+
+                if (typeof createdTime === 'number' && isFinite(createdTime)) {
+                    return createdTime;
+                }
+
+                var parsed = Date.parse(String(createdTime));
+                return isNaN(parsed) ? null : parsed;
+            },
+            parseTimestampFromFileName: function(fileName) {
+                if (!fileName) {
+                    return null;
+                }
+
+                var match = fileName.match(/(\d{4}-\d{2}-\d{2})_(\d{2})-(\d{2})-(\d{2}(?:\.\d{3})?)/);
+                if (!match) {
+                    return null;
+                }
+
+                var normalized = match[1] + 'T' + match[2] + ':' + match[3] + ':' + match[4];
+                var parsed = Date.parse(normalized);
+                return isNaN(parsed) ? null : parsed;
+            },
+            resolveDownloadRecordTime: function(record) {
+                var fromApi = this.parseCreatedTime(record.createdTime);
+                if (fromApi !== null) {
+                    return fromApi;
+                }
+
+                var fromFileName = this.parseTimestampFromFileName(record.fileName);
+                return fromFileName !== null ? fromFileName : 0;
+            },
+            sortDownloadRecordsByLatest: function(records) {
+                var that = this;
+                return _.sortBy(records, function(record) {
+                    return -that.resolveDownloadRecordTime(record);
+                });
             }
         });
     return DownloadSearchResultLayoutView;


### PR DESCRIPTION

## What changes were proposed in this pull request?

This PR adds Glossary Terms & Categories list export (CSV/XLSX) on React (v3) and Classic (v2), integrates async exports into the header download panel, and fixes several glossary navigation and download UX issues on both UIs.

Automated tests: 399/399 pass

## Glossary terms list & export
New Glossary Terms & Categories page on React (GlossaryTermsListPage) and Classic (GlossaryTermsListLayoutView)
Download dropdown (CSV / XLSX) enqueues async export via POST /v2/glossary/create_file
Export uses the same filter body as the table search
Status column with GlossaryStatusBadge (Active / Draft / Deprecated)
Glossary export navigation moved to sidebar ⋮ menu (removed header glossary list icon)

## Header download panel (React + Classic)
Merges search + glossary download records, dedupes by filename, sorts newest first
Toggle: ON (default) = all files (pending + completed); OFF = completed only
State-based tooltips for toggle
Pending rows show spinner; completed rows show download action
Removed per-file source labels (Glossary export / Search export)
Classic: panel closes on outside click (search, page content)
Classic: filename ↔ icon spacing aligned with React (gap: 16px)
Classic: renamed showCompletedDownloads → showAllDownloads (matches React semantics)
Empty state moved from inline styles to .download-list-empty SCSS class

## Sidebar & import
Import Glossary Term and Download Import template always enabled (React + Classic)
React import success triggers glossary sidebar refresh via ImportDialog.onImportSuccess

## Classic glossary fixes
Term name links use correct gType/gId query params (fixes category API 400 on term click)
Classifications column editable (add/remove tags)
Terms-list URL stability on refresh/tree load
Terms-list refresh + Download actions aligned horizontally

## Code coverage (PR-changed React files)

- Statements - 98.61%
- Branches - 88.02% 
- Functions- 92.37%
- Lines - 98.61%

## Over all coverage on react ui:

- Statements - 85.75% (46,451 / 54,168)
- Branches - 82.00% (6,965 / 8,493)
- Functions- 80.02% (1,274 / 1,592)
- Lines-  85.75% (46,451 / 54,168)

Test run: 189 suites, 4,790 tests — all passed (≈175s)

## How was this patch tested?
Manual on Both UI
and Automated react 

```
cd dashboard
npm run lint          # 0 errors
npm run build         # pass
npm test -- --watchAll=false \
  --testPathPattern="GlossaryTermsListPage|downloadRecords|Header.test|ImportDialog|SideBarTree|glossaryExport|glossaryStatus|GlossaryStatusBadge|glossaryTermsListColumns|glossaryApiMethod|glossaryUrl"
# Result: 399/399 pass
```

Test plan

- Lint passes (0 errors)
- Build passes
- 399 automated tests pass
- Code coverage ≥ 98% statements on changed React files
- Classic manual (download panel, terms-list export, sidebar import)
- React manual (download panel, terms-list export, import refresh)

<img width="1840" height="1106" alt="Screenshot 2026-08-12 at 6 17 59 PM" src="https://github.com/user-attachments/assets/105fe0b0-72ee-415d-b5cc-ce5cb566f00f" />
<img width="1840" height="1106" alt="Screenshot 2026-08-12 at 6 18 16 PM" src="https://github.com/user-attachments/assets/76e59290-e8d7-4749-945c-321937ec51af" />
<img width="1840" height="1106" alt="Screenshot 2026-08-12 at 6 19 06 PM" src="https://github.com/user-attachments/assets/266c92cd-0dd1-4504-9bc8-00649d1de101" />
<img width="1840" height="1106" alt="Screenshot 2026-08-12 at 6 19 28 PM" src="https://github.com/user-attachments/assets/fe955359-eb67-4626-9e92-ffedc08b3468" />
<img width="574" height="826" alt="Screenshot 2026-08-12 at 6 21 04 PM" src="https://github.com/user-attachments/assets/d4c6f2dd-b5df-4d31-ba18-404d464c5f12" />
<img width="1721" height="817" alt="Screenshot 2026-08-12 at 7 21 50 PM" src="https://github.com/user-attachments/assets/b13add97-4218-4270-b245-82d97333c7bf" />
<img width="1702" height="798" alt="Screenshot 2026-08-12 at 7 22 22 PM" src="https://github.com/user-attachments/assets/f08fcfbc-8b4d-4fbd-8702-098685b393d4" />

