### PR TITLE
ATLAS-5373: Atlas React UI: Extremely long entity names break layout in Latest Entities Created widget

### DIFF
--- a/dashboard/src/components/GlobalSearch/AdvancedSearch.tsx
+++ b/dashboard/src/components/GlobalSearch/AdvancedSearch.tsx
@@ -394,9 +394,8 @@ const AdvancedSearch: React.FC<AdvancedSearchPropsType> = ({
           variant="outlined"
           color="success"
           aria-label="reset"
-          primary={true}
           size="small"
-          onClick={(e: Event) => {
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
             handleClearValue();
           }}

--- a/dashboard/src/components/Modal.tsx
+++ b/dashboard/src/components/Modal.tsx
@@ -175,7 +175,7 @@ export const CustomModal: React.FC<CustomModalProps> = ({
                     variant="outlined"
                     color="primary"
                     disabled={isLoading}
-                    onClick={(e: Event) => {
+                    onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                       e.stopPropagation();
                       if (isLoading) {
                         return;
@@ -196,7 +196,6 @@ export const CustomModal: React.FC<CustomModalProps> = ({
                         ? "Action in progress, please wait"
                         : "Confirm dialog action"
                     }
-                    primary={true}
                     disabled={primaryDisabled}
                     sx={{
                       minWidth: isLoading ? 88 : undefined,
@@ -232,7 +231,7 @@ export const CustomModal: React.FC<CustomModalProps> = ({
                         />
                       ) : undefined
                     }
-                    onClick={(e: Event) => {
+                    onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                       e.stopPropagation();
                       if (isLoading) {
                         return;

--- a/dashboard/src/components/ShowMore/ShowMoreDrawer.tsx
+++ b/dashboard/src/components/ShowMore/ShowMoreDrawer.tsx
@@ -119,8 +119,7 @@ const ShowMoreDrawer = ({
                 variant="text"
                 color="primary"
                 aria-label="save"
-                primary={true}
-                onClick={(e: Event) => {
+                onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                   e.stopPropagation();
                   dispatch(toggleDrawer());
                 }}
@@ -132,8 +131,7 @@ const ShowMoreDrawer = ({
               variant="text"
               color="primary"
               aria-label="close"
-              primary={true}
-              onClick={(e: Event) => {
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                 e.stopPropagation();
                 dispatch(toggleDrawer());
               }}

--- a/dashboard/src/components/__tests__/muiComponents.test.tsx
+++ b/dashboard/src/components/__tests__/muiComponents.test.tsx
@@ -142,6 +142,26 @@ describe('muiComponents', () => {
 			// Tooltip should appear
 			expect(await screen.findByText('overflow tip')).toBeInTheDocument()
 		})
+
+		it('enables tooltip for subpixel overflow where clientWidth matches scrollWidth', async () => {
+			render(
+				<OverflowTooltip title="subpixel tip">
+					<span data-testid="subpixel-text">Subpixel</span>
+				</OverflowTooltip>
+			)
+			const span = screen.getByTestId('subpixel-text').parentElement!
+
+			// Mock subpixel overflow condition (scrollWidth matches clientWidth, but rect is smaller)
+			Object.defineProperty(span, 'scrollWidth', { configurable: true, value: 100 })
+			Object.defineProperty(span, 'clientWidth', { configurable: true, value: 100 })
+			span.getBoundingClientRect = jest.fn(() => ({ width: 99.5 } as DOMRect))
+
+			// Trigger hover to fire the onMouseEnter checkOverflow logic
+			fireEvent.mouseEnter(span)
+			fireEvent.mouseOver(span)
+
+			expect(await screen.findByText('subpixel tip')).toBeInTheDocument()
+		})
 	})
 
 	it('prevents default navigation in LinkTab', async () => {

--- a/dashboard/src/components/__tests__/muiComponents.test.tsx
+++ b/dashboard/src/components/__tests__/muiComponents.test.tsx
@@ -26,6 +26,7 @@ import userEvent from '@testing-library/user-event'
 import {
 	CustomButton,
 	LightTooltip,
+	OverflowTooltip,
 	LinkTab,
 	Accordion,
 	AccordionSummary,
@@ -67,6 +68,39 @@ describe('muiComponents', () => {
 		)
 
 		expect(screen.getByText('Tooltip Child')).toBeTruthy()
+	})
+
+	describe('OverflowTooltip', () => {
+		it('renders OverflowTooltip children', () => {
+			render(
+				<OverflowTooltip title="overflow tip">
+					<span>Overflow Child</span>
+				</OverflowTooltip>
+			)
+			expect(screen.getByText('Overflow Child')).toBeTruthy()
+		})
+
+		it('disables tooltip when not overflowed', () => {
+			render(
+				<OverflowTooltip title="overflow tip">
+					<span data-testid="short-text">Short</span>
+				</OverflowTooltip>
+			)
+			// Element scrollWidth and clientWidth are 0 in JSDOM, so isOverflowed is false
+			// We can verify it renders successfully and handles the basic case
+			expect(screen.getByTestId('short-text')).toBeInTheDocument()
+		})
+
+		it('enables tooltip on resize if overflow occurs', () => {
+			render(
+				<OverflowTooltip title="overflow tip">
+					<span data-testid="resize-text">Will be long</span>
+				</OverflowTooltip>
+			)
+			// Trigger resize
+			window.dispatchEvent(new Event('resize'))
+			expect(screen.getByTestId('resize-text')).toBeInTheDocument()
+		})
 	})
 
 	it('prevents default navigation in LinkTab', async () => {

--- a/dashboard/src/components/__tests__/muiComponents.test.tsx
+++ b/dashboard/src/components/__tests__/muiComponents.test.tsx
@@ -21,7 +21,7 @@
  */
 
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
 	CustomButton,
@@ -71,6 +71,24 @@ describe('muiComponents', () => {
 	})
 
 	describe('OverflowTooltip', () => {
+		let triggerResize: any
+		const originalResizeObserver = global.ResizeObserver
+
+		beforeAll(() => {
+			global.ResizeObserver = class {
+				constructor(callback: any) {
+					triggerResize = callback
+				}
+				observe = jest.fn()
+				unobserve = jest.fn()
+				disconnect = jest.fn()
+			} as any
+		})
+
+		afterAll(() => {
+			global.ResizeObserver = originalResizeObserver
+		})
+
 		it('renders OverflowTooltip children', () => {
 			render(
 				<OverflowTooltip title="overflow tip">
@@ -80,26 +98,49 @@ describe('muiComponents', () => {
 			expect(screen.getByText('Overflow Child')).toBeTruthy()
 		})
 
-		it('disables tooltip when not overflowed', () => {
+		it('disables tooltip when not overflowed', async () => {
 			render(
 				<OverflowTooltip title="overflow tip">
 					<span data-testid="short-text">Short</span>
 				</OverflowTooltip>
 			)
-			// Element scrollWidth and clientWidth are 0 in JSDOM, so isOverflowed is false
-			// We can verify it renders successfully and handles the basic case
-			expect(screen.getByTestId('short-text')).toBeInTheDocument()
+			const span = screen.getByTestId('short-text').parentElement!
+			
+			// Mock no overflow
+			Object.defineProperty(span, 'scrollWidth', { configurable: true, value: 100 })
+			Object.defineProperty(span, 'clientWidth', { configurable: true, value: 100 })
+			
+			act(() => {
+				if (triggerResize) triggerResize()
+			})
+
+			fireEvent.mouseOver(span)
+			
+			// Tooltip should not be in the document
+			expect(screen.queryByText('overflow tip')).not.toBeInTheDocument()
 		})
 
-		it('enables tooltip on resize if overflow occurs', () => {
+		it('enables tooltip on resize if overflow occurs', async () => {
 			render(
 				<OverflowTooltip title="overflow tip">
 					<span data-testid="resize-text">Will be long</span>
 				</OverflowTooltip>
 			)
-			// Trigger resize
-			window.dispatchEvent(new Event('resize'))
-			expect(screen.getByTestId('resize-text')).toBeInTheDocument()
+			const span = screen.getByTestId('resize-text').parentElement!
+			
+			// Mock overflow condition
+			Object.defineProperty(span, 'scrollWidth', { configurable: true, value: 200 })
+			Object.defineProperty(span, 'clientWidth', { configurable: true, value: 100 })
+			
+			// Trigger resize observer callback
+			act(() => {
+				if (triggerResize) triggerResize()
+			})
+			
+			fireEvent.mouseOver(span)
+			
+			// Tooltip should appear
+			expect(await screen.findByText('overflow tip')).toBeInTheDocument()
 		})
 	})
 

--- a/dashboard/src/components/__tests__/muiComponents.test.tsx
+++ b/dashboard/src/components/__tests__/muiComponents.test.tsx
@@ -71,12 +71,12 @@ describe('muiComponents', () => {
 	})
 
 	describe('OverflowTooltip', () => {
-		let triggerResize: any
+		let triggerResize: ResizeObserverCallback | undefined
 		const originalResizeObserver = global.ResizeObserver
 
 		beforeAll(() => {
 			global.ResizeObserver = class {
-				constructor(callback: any) {
+				constructor(callback: ResizeObserverCallback) {
 					triggerResize = callback
 				}
 				observe = jest.fn()
@@ -111,7 +111,7 @@ describe('muiComponents', () => {
 			Object.defineProperty(span, 'clientWidth', { configurable: true, value: 100 })
 			
 			act(() => {
-				if (triggerResize) triggerResize()
+				if (triggerResize) triggerResize([], {} as ResizeObserver)
 			})
 
 			fireEvent.mouseOver(span)
@@ -134,7 +134,7 @@ describe('muiComponents', () => {
 			
 			// Trigger resize observer callback
 			act(() => {
-				if (triggerResize) triggerResize()
+				if (triggerResize) triggerResize([], {} as ResizeObserver)
 			})
 			
 			fireEvent.mouseOver(span)

--- a/dashboard/src/components/__tests__/muiComponents.test.tsx
+++ b/dashboard/src/components/__tests__/muiComponents.test.tsx
@@ -72,6 +72,8 @@ describe('muiComponents', () => {
 
 	describe('OverflowTooltip', () => {
 		let triggerResize: ResizeObserverCallback | undefined
+		const mockDisconnect = jest.fn()
+		const mockObserve = jest.fn()
 		const originalResizeObserver = global.ResizeObserver
 
 		beforeAll(() => {
@@ -79,10 +81,15 @@ describe('muiComponents', () => {
 				constructor(callback: ResizeObserverCallback) {
 					triggerResize = callback
 				}
-				observe = jest.fn()
+				observe = mockObserve
 				unobserve = jest.fn()
-				disconnect = jest.fn()
-			} as any
+				disconnect = mockDisconnect
+			} as unknown as typeof ResizeObserver
+		})
+
+		beforeEach(() => {
+			mockDisconnect.mockClear()
+			mockObserve.mockClear()
 		})
 
 		afterAll(() => {
@@ -161,6 +168,49 @@ describe('muiComponents', () => {
 			fireEvent.mouseOver(span)
 
 			expect(await screen.findByText('subpixel tip')).toBeInTheDocument()
+		})
+
+		it('disconnects ResizeObserver on unmount', () => {
+			const { unmount } = render(
+				<OverflowTooltip title="tip">
+					<span>Text</span>
+				</OverflowTooltip>
+			)
+			expect(mockObserve).toHaveBeenCalled()
+			unmount()
+			expect(mockDisconnect).toHaveBeenCalled()
+		})
+
+		it('applies wrapperClassName to the wrapper', () => {
+			render(
+				<OverflowTooltip title="tip" wrapperClassName="custom-wrapper-class">
+					<span data-testid="child-text">Text</span>
+				</OverflowTooltip>
+			)
+			const wrapper = screen.getByTestId('child-text').parentElement
+			expect(wrapper).toHaveClass('custom-wrapper-class')
+		})
+
+		it('updates overflow state when title prop changes', async () => {
+			const { rerender } = render(
+				<OverflowTooltip title="initial tip">
+					<span data-testid="title-change">Text</span>
+				</OverflowTooltip>
+			)
+			
+			const span = screen.getByTestId('title-change').parentElement!
+			Object.defineProperty(span, 'scrollWidth', { configurable: true, value: 200 })
+			Object.defineProperty(span, 'clientWidth', { configurable: true, value: 100 })
+			
+			// Change title which triggers useEffect
+			rerender(
+				<OverflowTooltip title="new tip">
+					<span data-testid="title-change">Text</span>
+				</OverflowTooltip>
+			)
+			
+			fireEvent.mouseOver(span)
+			expect(await screen.findByText('new tip')).toBeInTheDocument()
 		})
 	})
 

--- a/dashboard/src/components/muiComponents.tsx
+++ b/dashboard/src/components/muiComponents.tsx
@@ -25,7 +25,7 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import React from "react";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
-import Button from "@mui/material/Button";
+import Button, { ButtonProps } from "@mui/material/Button";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
@@ -75,16 +75,19 @@ const LightTooltip = styled(({ className, ...props }: any) => (
 interface OverflowTooltipProps extends Omit<TooltipProps, "children"> {
   children: React.ReactElement;
   wrapperSx?: SxProps<Theme>;
+  wrapperClassName?: string;
 }
 
-const OverflowTooltip = ({ title, children, wrapperSx, ...props }: OverflowTooltipProps) => {
+const OverflowTooltip = ({ title, children, wrapperSx, wrapperClassName, ...props }: OverflowTooltipProps) => {
   const textElementRef = React.useRef<HTMLElement>(null);
   const [isOverflowed, setIsOverflowed] = React.useState(false);
 
   const checkOverflow = React.useCallback(() => {
     if (textElementRef.current) {
+      const el = textElementRef.current;
       setIsOverflowed(
-        textElementRef.current.scrollWidth > textElementRef.current.clientWidth
+        el.scrollWidth > el.clientWidth || 
+        el.scrollWidth > el.getBoundingClientRect().width
       );
     }
   }, []);
@@ -97,12 +100,13 @@ const OverflowTooltip = ({ title, children, wrapperSx, ...props }: OverflowToolt
       resizeObserver.observe(element);
       return () => resizeObserver.disconnect();
     }
-  }, [title, children, checkOverflow]);
+  }, [title, checkOverflow]);
 
   const child = (
     <Box
       component="span"
       ref={textElementRef}
+      className={wrapperClassName}
       sx={{
         display: "inline-flex",
         minWidth: 0,
@@ -112,6 +116,7 @@ const OverflowTooltip = ({ title, children, wrapperSx, ...props }: OverflowToolt
         whiteSpace: "nowrap",
         ...wrapperSx
       }}
+      onMouseEnter={checkOverflow}
     >
       {children}
     </Box>
@@ -130,37 +135,24 @@ const OverflowTooltip = ({ title, children, wrapperSx, ...props }: OverflowToolt
   );
 };
 
-interface ButtonProps {
-  children?: any;
-  variant?: string;
-  color: string;
-  onClick: any;
-  sx?: any;
-  size?: string;
-  endIcon?: any;
-  startIcon?: any;
-  className?: string;
-  disabled?: boolean;
-}
-
 const ButtonWrapper = styled(Box)({
   display: "inline-flex"
 });
 
 const StyledButton = styled(Button)(({ variant }) => ({
-  fontWeight: "600 !important",
-  letterSpacing: "0 !important",
-  fontSize: "0.875rem !important",
-  cursor: "pointer !important",
-  minWidth: "unset !important",
-  ...(variant === "outlined" && { border: "1px solid #dddddd !important" })
+  fontWeight: "600",
+  letterSpacing: "0",
+  fontSize: "0.875rem",
+  cursor: "pointer",
+  minWidth: "unset",
+  ...(variant === "outlined" && { border: "1px solid #dddddd" })
 }));
 
 const CustomButton = ({
   children,
   sx,
   ...rest
-}: ButtonProps | any) => {
+}: ButtonProps) => {
   return (
     <ButtonWrapper component="span">
       <StyledButton sx={sx} {...rest}>

--- a/dashboard/src/components/muiComponents.tsx
+++ b/dashboard/src/components/muiComponents.tsx
@@ -55,7 +55,7 @@ import MuiAccordionDetails from "@mui/material/AccordionDetails";
 import { TooltipProps } from "@mui/material/Tooltip";
 import { SxProps, Theme } from "@mui/material/styles";
 
-const LightTooltip = styled(({ className, ...props }: any) => (
+const LightTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip
     sx={{ transition: "none" }}
     {...props}
@@ -96,6 +96,9 @@ const OverflowTooltip = ({ title, children, wrapperSx, wrapperClassName, ...prop
     checkOverflow();
     const element = textElementRef.current;
     if (element) {
+      // One ResizeObserver per instance — acceptable for small lists (e.g. dashboard widgets).
+      // If this component is used in large virtualized lists, consider lifting a shared
+      // ResizeObserver to a context provider to reduce observer count.
       const resizeObserver = new ResizeObserver(() => checkOverflow());
       resizeObserver.observe(element);
       return () => resizeObserver.disconnect();

--- a/dashboard/src/components/muiComponents.tsx
+++ b/dashboard/src/components/muiComponents.tsx
@@ -22,6 +22,7 @@ import Switch from "@mui/material/Switch";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
+import React from "react";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Button from "@mui/material/Button";
@@ -67,6 +68,69 @@ const LightTooltip = styled(({ className, ...props }: any) => (
     fontSize: 11
   }
 }));
+
+import { TooltipProps } from '@mui/material/Tooltip';
+import { SxProps, Theme } from '@mui/material/styles';
+
+interface OverflowTooltipProps extends Omit<TooltipProps, 'children'> {
+  children: React.ReactElement;
+  wrapperComponent?: React.ElementType;
+  wrapperSx?: SxProps<Theme>;
+}
+
+const OverflowTooltip = ({ title, children, wrapperComponent, wrapperSx, ...props }: OverflowTooltipProps) => {
+  const textElementRef = React.useRef<HTMLElement>(null);
+  const [isOverflowed, setIsOverflowed] = React.useState(false);
+
+  const checkOverflow = () => {
+    if (textElementRef.current) {
+      setIsOverflowed(
+        textElementRef.current.scrollWidth > textElementRef.current.clientWidth
+      );
+    }
+  };
+
+  React.useEffect(() => {
+    checkOverflow();
+    window.addEventListener("resize", checkOverflow);
+    return () => {
+      window.removeEventListener("resize", checkOverflow);
+    };
+  }, [children, title]);
+
+  const child = wrapperComponent || wrapperSx ? (
+    <Box
+      component={wrapperComponent || 'span'}
+      ref={textElementRef}
+      sx={{
+        display: "inline-flex",
+        minWidth: 0,
+        width: "100%",
+        alignItems: "center",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+        ...wrapperSx
+      }}
+    >
+      {children}
+    </Box>
+  ) : (
+    React.cloneElement(children, { ref: textElementRef })
+  );
+
+  return (
+    <LightTooltip
+      title={title}
+      disableHoverListener={!isOverflowed}
+      disableFocusListener={!isOverflowed}
+      disableTouchListener={!isOverflowed}
+      {...props}
+    >
+      {child}
+    </LightTooltip>
+  );
+};
 
 interface ButtonProps {
   children?: any;
@@ -202,5 +266,6 @@ export {
   CustomButton,
   Accordion,
   AccordionSummary,
-  AccordionDetails
+  AccordionDetails,
+  OverflowTooltip
 };

--- a/dashboard/src/components/muiComponents.tsx
+++ b/dashboard/src/components/muiComponents.tsx
@@ -52,8 +52,8 @@ import MuiAccordionSummary, {
   AccordionSummaryProps
 } from "@mui/material/AccordionSummary";
 import MuiAccordionDetails from "@mui/material/AccordionDetails";
-import { TooltipProps } from '@mui/material/Tooltip';
-import { SxProps, Theme } from '@mui/material/styles';
+import { TooltipProps } from "@mui/material/Tooltip";
+import { SxProps, Theme } from "@mui/material/styles";
 
 const LightTooltip = styled(({ className, ...props }: any) => (
   <Tooltip
@@ -72,35 +72,36 @@ const LightTooltip = styled(({ className, ...props }: any) => (
 }));
 
 
-interface OverflowTooltipProps extends Omit<TooltipProps, 'children'> {
+interface OverflowTooltipProps extends Omit<TooltipProps, "children"> {
   children: React.ReactElement;
-  wrapperComponent?: React.ElementType;
   wrapperSx?: SxProps<Theme>;
 }
 
-const OverflowTooltip = ({ title, children, wrapperComponent, wrapperSx, ...props }: OverflowTooltipProps) => {
+const OverflowTooltip = ({ title, children, wrapperSx, ...props }: OverflowTooltipProps) => {
   const textElementRef = React.useRef<HTMLElement>(null);
   const [isOverflowed, setIsOverflowed] = React.useState(false);
 
-  const checkOverflow = () => {
+  const checkOverflow = React.useCallback(() => {
     if (textElementRef.current) {
       setIsOverflowed(
         textElementRef.current.scrollWidth > textElementRef.current.clientWidth
       );
     }
-  };
+  }, []);
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     checkOverflow();
-    window.addEventListener("resize", checkOverflow);
-    return () => {
-      window.removeEventListener("resize", checkOverflow);
-    };
-  }, [title]);
+    const element = textElementRef.current;
+    if (element) {
+      const resizeObserver = new ResizeObserver(() => checkOverflow());
+      resizeObserver.observe(element);
+      return () => resizeObserver.disconnect();
+    }
+  }, [title, children, checkOverflow]);
 
   const child = (
     <Box
-      component={wrapperComponent || 'span'}
+      component="span"
       ref={textElementRef}
       sx={{
         display: "inline-flex",
@@ -142,45 +143,30 @@ interface ButtonProps {
   disabled?: boolean;
 }
 
+const ButtonWrapper = styled(Box)({
+  display: "inline-flex"
+});
+
+const StyledButton = styled(Button)(({ variant }) => ({
+  fontWeight: "600 !important",
+  letterSpacing: "0 !important",
+  fontSize: "0.875rem !important",
+  cursor: "pointer !important",
+  minWidth: "unset !important",
+  ...(variant === "outlined" && { border: "1px solid #dddddd !important" })
+}));
+
 const CustomButton = ({
   children,
-  variant,
-  color,
-  sx: customStyles = {},
-  onClick,
-  size,
-  endIcon,
-  startIcon,
-  disabled,
+  sx,
   ...rest
 }: ButtonProps | any) => {
-  let defaultStyles = {
-    fontWeight: "600 !important",
-    letterSpacing: "0 !important",
-    fontSize: "0.875rem !important",
-    cursor: "pointer !important",
-    minWidth: "unset !important",
-    ...(variant == "outlined" && { border: "1px solid #dddddd !important" })
-  };
-
-  let mergedStyle = { ...defaultStyles, ...customStyles };
-
   return (
-    <Box component="span" sx={{ display: 'inline-flex' }}>
-      <Button
-        variant={variant}
-        color={color}
-        sx={mergedStyle}
-        onClick={onClick}
-        size={size}
-        endIcon={endIcon}
-        startIcon={startIcon}
-        disabled={disabled}
-        {...rest}
-      >
+    <ButtonWrapper component="span">
+      <StyledButton sx={sx} {...rest}>
         {children}
-      </Button>
-    </Box>
+      </StyledButton>
+    </ButtonWrapper>
   );
 };
 

--- a/dashboard/src/components/muiComponents.tsx
+++ b/dashboard/src/components/muiComponents.tsx
@@ -52,6 +52,8 @@ import MuiAccordionSummary, {
   AccordionSummaryProps
 } from "@mui/material/AccordionSummary";
 import MuiAccordionDetails from "@mui/material/AccordionDetails";
+import { TooltipProps } from '@mui/material/Tooltip';
+import { SxProps, Theme } from '@mui/material/styles';
 
 const LightTooltip = styled(({ className, ...props }: any) => (
   <Tooltip
@@ -69,8 +71,6 @@ const LightTooltip = styled(({ className, ...props }: any) => (
   }
 }));
 
-import { TooltipProps } from '@mui/material/Tooltip';
-import { SxProps, Theme } from '@mui/material/styles';
 
 interface OverflowTooltipProps extends Omit<TooltipProps, 'children'> {
   children: React.ReactElement;
@@ -90,15 +90,15 @@ const OverflowTooltip = ({ title, children, wrapperComponent, wrapperSx, ...prop
     }
   };
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     checkOverflow();
     window.addEventListener("resize", checkOverflow);
     return () => {
       window.removeEventListener("resize", checkOverflow);
     };
-  }, [children, title]);
+  }, [title]);
 
-  const child = wrapperComponent || wrapperSx ? (
+  const child = (
     <Box
       component={wrapperComponent || 'span'}
       ref={textElementRef}
@@ -106,7 +106,6 @@ const OverflowTooltip = ({ title, children, wrapperComponent, wrapperSx, ...prop
         display: "inline-flex",
         minWidth: 0,
         width: "100%",
-        alignItems: "center",
         overflow: "hidden",
         textOverflow: "ellipsis",
         whiteSpace: "nowrap",
@@ -115,8 +114,6 @@ const OverflowTooltip = ({ title, children, wrapperComponent, wrapperSx, ...prop
     >
       {children}
     </Box>
-  ) : (
-    React.cloneElement(children, { ref: textElementRef })
   );
 
   return (

--- a/dashboard/src/components/muiComponents.tsx
+++ b/dashboard/src/components/muiComponents.tsx
@@ -86,6 +86,8 @@ const OverflowTooltip = ({ title, children, wrapperSx, wrapperClassName, ...prop
     if (textElementRef.current) {
       const el = textElementRef.current;
       setIsOverflowed(
+        // clientWidth is an integer, which can miss subpixel overflow.
+        // getBoundingClientRect().width is fractional, catching those subpixel cases.
         el.scrollWidth > el.clientWidth || 
         el.scrollWidth > el.getBoundingClientRect().width
       );
@@ -110,15 +112,7 @@ const OverflowTooltip = ({ title, children, wrapperSx, wrapperClassName, ...prop
       component="span"
       ref={textElementRef}
       className={wrapperClassName}
-      sx={{
-        display: "inline-flex",
-        minWidth: 0,
-        width: "100%",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
-        ...wrapperSx
-      }}
+      sx={wrapperSx}
       onMouseEnter={checkOverflow}
     >
       {children}

--- a/dashboard/src/views/BusinessMetadata/BusinessMetadataForm.tsx
+++ b/dashboard/src/views/BusinessMetadata/BusinessMetadataForm.tsx
@@ -563,7 +563,7 @@ const BusinessMetaDataForm = ({
               <CustomButton
                 variant="outlined"
                 color="primary"
-                onClick={(_e: Event) => {
+                onClick={(_e: React.MouseEvent<HTMLButtonElement>) => {
                   setForm(false);
                   setBMAttribute({});
                   dispatchState(setEditBMAttribute({}));

--- a/dashboard/src/views/BusinessMetadata/EnumCreateUpdate.tsx
+++ b/dashboard/src/views/BusinessMetadata/EnumCreateUpdate.tsx
@@ -294,7 +294,7 @@ const EnumCreateUpdate = ({
                 size="small"
                 data-cy="clearButton"
                 color="primary"
-                onClick={(_e: Event) => {
+                onClick={(_e: React.MouseEvent<HTMLButtonElement>) => {
                   reset({ enumType: "", enumValues: [] });
                 }}
                 disabled={

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
@@ -26,7 +26,7 @@
   transition: box-shadow 0.3s ease;
 
   &:hover {
-    box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12);
+    box-shadow: 0px 2px 4px -1px rgba(0, 0, 0, 0.2), 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
   }
 }
 
@@ -89,4 +89,17 @@
   flex-shrink: 0;
   margin-left: 8px;
   white-space: nowrap;
+}
+
+.latest-entities-name-wrapper {
+  display: block;
+  flex: 0 10 auto;
+  width: auto;
+}
+
+.latest-entities-type-wrapper {
+  display: block;
+  flex: 0 1 auto;
+  width: auto;
+  min-width: 0;
 }

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.latest-entities-paper {
+  padding: 16px;
+  border-radius: 8px;
+  min-height: 340px;
+  min-width: 0;
+  width: 100%;
+  flex: 1;
+  box-sizing: border-box;
+  transition: box-shadow 0.3s ease;
+
+  &:hover {
+    box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.latest-entities-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.latest-entities-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.latest-entities-view-all {
+  font-size: 0.875rem;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.latest-entities-empty {
+  padding-top: 16px;
+}
+
+.latest-entities-list {
+  padding-top: 16px;
+}
+
+.latest-entities-list-item {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.latest-entities-entity-name {
+  display: block;
+  font-size: 0.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.latest-entities-entity-name-link {
+  cursor: pointer;
+}
+
+.latest-entities-entity-name-fallback {
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.latest-entities-type-name {
+  font-size: 0.875rem;
+  color: #6c757d;
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+
+.latest-entities-timestamp {
+  font-size: 0.8125rem;
+  color: #6c757d;
+  flex-shrink: 0;
+  margin-left: 8px;
+  white-space: nowrap;
+}

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
@@ -81,6 +81,10 @@
 .latest-entities-type-name {
   font-size: 0.875rem;
   color: rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .latest-entities-timestamp {
@@ -93,13 +97,17 @@
 
 .latest-entities-name-wrapper {
   display: block;
-  flex: 0 10 auto;
+  /* Allow this column to grow and shrink; min-width: 0 enables text truncation inside flex */
+  flex: 1 1 auto;
+  min-width: 0;
   width: auto;
 }
 
 .latest-entities-type-wrapper {
   display: block;
   flex: 0 1 auto;
+  flex-shrink: 0;
+  max-width: 45%;
   width: auto;
   min-width: 0;
 }

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
@@ -38,7 +38,7 @@
 .latest-entities-title {
   font-size: 1rem;
   font-weight: 600;
-  color: #1a1a1a;
+  color: rgba(0, 0, 0, 0.87);
 }
 
 .latest-entities-view-all {
@@ -66,13 +66,7 @@
 }
 
 .latest-entities-entity-name {
-  display: block;
   font-size: 0.875rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 0 1 auto;
-  min-width: 0;
 }
 
 .latest-entities-entity-name-link {
@@ -86,14 +80,12 @@
 
 .latest-entities-type-name {
   font-size: 0.875rem;
-  color: #6c757d;
-  flex-shrink: 0;
-  margin-left: 4px;
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .latest-entities-timestamp {
   font-size: 0.8125rem;
-  color: #6c757d;
+  color: rgba(0, 0, 0, 0.6);
   flex-shrink: 0;
   margin-left: 8px;
   white-space: nowrap;

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.scss
@@ -16,98 +16,108 @@
  */
 
 .latest-entities-paper {
-  padding: 16px;
-  border-radius: 8px;
-  min-height: 340px;
-  min-width: 0;
-  width: 100%;
-  flex: 1;
-  box-sizing: border-box;
-  transition: box-shadow 0.3s ease;
+    padding: 16px;
+    border-radius: 8px;
+    min-height: 340px;
+    min-width: 0;
+    width: 100%;
+    flex: 1;
+    box-sizing: border-box;
+    transition: box-shadow 0.3s ease;
 
-  &:hover {
-    box-shadow: 0px 2px 4px -1px rgba(0, 0, 0, 0.2), 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
-  }
+    &:hover {
+        box-shadow: 0px 2px 4px -1px rgba(0, 0, 0, 0.2), 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+    }
 }
 
 .latest-entities-header {
-  padding-bottom: 16px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+    padding-bottom: 16px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
 
 .latest-entities-title {
-  font-size: 1rem;
-  font-weight: 600;
-  color: rgba(0, 0, 0, 0.87);
+    font-size: 1rem;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.87);
 }
 
 .latest-entities-view-all {
-  font-size: 0.875rem;
-  cursor: pointer;
-  text-decoration: none;
+    font-size: 0.875rem;
+    cursor: pointer;
+    text-decoration: none;
 }
 
 .latest-entities-empty {
-  padding-top: 16px;
+    padding-top: 16px;
 }
 
 .latest-entities-list {
-  padding-top: 16px;
+    padding-top: 16px;
 }
 
 .latest-entities-list-item {
-  padding-top: 8px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+    padding-top: 8px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 
-  &:last-child {
-    border-bottom: none;
-  }
+    &:last-child {
+        border-bottom: none;
+    }
 }
 
 .latest-entities-entity-name {
-  font-size: 0.875rem;
+    font-size: 0.875rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    display: block;
 }
 
 .latest-entities-entity-name-link {
-  cursor: pointer;
+    cursor: pointer;
 }
 
 .latest-entities-entity-name-fallback {
-  font-weight: 500;
-  color: rgba(0, 0, 0, 0.87);
+    font-weight: 500;
+    color: rgba(0, 0, 0, 0.87);
 }
 
 .latest-entities-type-name {
-  font-size: 0.875rem;
-  color: rgba(0, 0, 0, 0.6);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
+    font-size: 0.875rem;
+    color: rgba(0, 0, 0, 0.6);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
 }
 
 .latest-entities-timestamp {
-  font-size: 0.8125rem;
-  color: rgba(0, 0, 0, 0.6);
-  flex-shrink: 0;
-  margin-left: 8px;
-  white-space: nowrap;
+    font-size: 0.8125rem;
+    color: rgba(0, 0, 0, 0.6);
+    flex-shrink: 0;
+    margin-left: 8px;
+    white-space: nowrap;
 }
 
 .latest-entities-name-wrapper {
-  display: block;
-  /* Allow this column to grow and shrink; min-width: 0 enables text truncation inside flex */
-  flex: 1 1 auto;
-  min-width: 0;
-  width: auto;
+    display: block;
+    /* Allow this column to grow and shrink; min-width: 0 enables text truncation inside flex */
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .latest-entities-type-wrapper {
-  display: block;
-  flex: 0 1 auto;
-  flex-shrink: 0;
-  max-width: 45%;
-  width: auto;
-  min-width: 0;
+    display: block;
+    flex: 0 0 auto;
+    max-width: 45%;
+    width: auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
@@ -106,30 +106,30 @@ const formatCreatedRelativeFromMs = (ms: number): string => {
 	const deltaMs = now - ms;
 	if (!Number.isFinite(deltaMs)) return INVALID_TS_LABEL;
 	if (deltaMs < 0) {
-		return moment(ms).fromNow();
+		return `Created ${moment(ms).fromNow()}`;
 	}
 	const totalSec = Math.floor(deltaMs / 1000);
 	if (totalSec < 1) {
-		return "Just now";
+		return "Created just now";
 	}
 	if (totalSec < 60) {
 		return totalSec === 1
-			? "1 second ago"
-			: `${totalSec} seconds ago`;
+			? "Created 1 second ago"
+			: `Created ${totalSec} seconds ago`;
 	}
 	const totalMin = Math.floor(totalSec / 60);
 	if (totalMin < 60) {
 		return totalMin === 1
-			? "1 minute ago"
-			: `${totalMin} minutes ago`;
+			? "Created 1 minute ago"
+			: `Created ${totalMin} minutes ago`;
 	}
 	const totalHr = Math.floor(totalMin / 60);
 	if (totalHr < 24) {
 		return totalHr === 1
-			? "1 hour ago"
-			: `${totalHr} hours ago`;
+			? "Created 1 hour ago"
+			: `Created ${totalHr} hours ago`;
 	}
-	return moment(ms).fromNow();
+	return `Created ${moment(ms).fromNow()}`;
 };
 
 const formatRelativeTime = (raw: unknown): string => {
@@ -138,8 +138,7 @@ const formatRelativeTime = (raw: unknown): string => {
 	return formatCreatedRelativeFromMs(ms);
 };
 
-const nameWrapperSx = { display: "block", flex: "0 1 auto", width: "auto" };
-const typeWrapperSx = { display: "block", flex: "0 0 auto", width: "auto" };
+
 
 const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesListProps) => {
 	const navigate = useNavigate();
@@ -200,7 +199,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 								<Stack width="100%" direction="row" justifyContent="space-between" alignItems="center">
 									<Stack direction="row" spacing={0.5} alignItems="center" flexWrap="nowrap" flex={1} minWidth={0} mr={1}>
 										{detailHref ? (
-											<OverflowTooltip title={displayName} arrow placement="top" wrapperSx={nameWrapperSx}>
+											<OverflowTooltip title={displayName} arrow placement="top" wrapperClassName="latest-entities-name-wrapper">
 												<Link
 													component={RouterLink}
 													to={detailHref}
@@ -212,7 +211,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 												</Link>
 											</OverflowTooltip>
 										) : (
-											<OverflowTooltip title={displayName} arrow placement="top" wrapperSx={nameWrapperSx}>
+											<OverflowTooltip title={displayName} arrow placement="top" wrapperClassName="latest-entities-name-wrapper">
 												<Typography
 													component="span"
 													className="latest-entities-entity-name latest-entities-entity-name-fallback"
@@ -221,7 +220,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 												</Typography>
 											</OverflowTooltip>
 										)}
-										<OverflowTooltip title={`(${typeName})`} arrow placement="top" wrapperSx={typeWrapperSx}>
+										<OverflowTooltip title={`(${typeName})`} arrow placement="top" wrapperClassName="latest-entities-type-wrapper">
 											<Typography
 												component="span"
 												className="latest-entities-type-name"

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
@@ -138,8 +138,6 @@ const formatRelativeTime = (raw: unknown): string => {
 	return formatCreatedRelativeFromMs(ms);
 };
 
-
-
 const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesListProps) => {
 	const navigate = useNavigate();
 

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
@@ -138,6 +138,9 @@ const formatRelativeTime = (raw: unknown): string => {
 	return formatCreatedRelativeFromMs(ms);
 };
 
+const nameWrapperSx = { display: "block", flex: "0 1 auto", width: "auto" };
+const typeWrapperSx = { display: "block", flex: "0 0 auto", width: "auto" };
+
 const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesListProps) => {
 	const navigate = useNavigate();
 
@@ -197,7 +200,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 								<Stack width="100%" direction="row" justifyContent="space-between" alignItems="center">
 									<Stack direction="row" spacing={0.5} alignItems="center" flexWrap="nowrap" flex={1} minWidth={0} mr={1}>
 										{detailHref ? (
-											<OverflowTooltip title={displayName} arrow placement="top" wrapperSx={{ display: "block", flex: "1 1 auto" }}>
+											<OverflowTooltip title={displayName} arrow placement="top" wrapperSx={nameWrapperSx}>
 												<Link
 													component={RouterLink}
 													to={detailHref}
@@ -209,7 +212,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 												</Link>
 											</OverflowTooltip>
 										) : (
-											<OverflowTooltip title={displayName} arrow placement="top" wrapperSx={{ display: "block", flex: "1 1 auto" }}>
+											<OverflowTooltip title={displayName} arrow placement="top" wrapperSx={nameWrapperSx}>
 												<Typography
 													component="span"
 													className="latest-entities-entity-name latest-entities-entity-name-fallback"
@@ -218,7 +221,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 												</Typography>
 											</OverflowTooltip>
 										)}
-										<OverflowTooltip title={`(${typeName})`} arrow placement="top" wrapperSx={{ display: "block", flex: "0 1 auto", width: "auto" }}>
+										<OverflowTooltip title={`(${typeName})`} arrow placement="top" wrapperSx={typeWrapperSx}>
 											<Typography
 												component="span"
 												className="latest-entities-type-name"

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
@@ -17,6 +17,7 @@
 
 import { memo, useCallback } from "react";
 import { Paper, Stack, Typography, Link, List, ListItem, Box } from "@mui/material";
+import { OverflowTooltip } from "@components/muiComponents";
 import { Link as RouterLink } from "react-router-dom";
 import moment from "moment";
 import { useNavigate } from "react-router-dom";
@@ -27,6 +28,7 @@ import {
 	resolveLatestEntityGuid,
 	resolveLatestEntityTypeName
 } from "./latestEntitiesList.utils";
+import "./LatestEntitiesList.scss";
 
 interface EntityItem extends LatestEntityRowModel {
 	createTime?: number | Date | string;
@@ -104,30 +106,30 @@ const formatCreatedRelativeFromMs = (ms: number): string => {
 	const deltaMs = now - ms;
 	if (!Number.isFinite(deltaMs)) return INVALID_TS_LABEL;
 	if (deltaMs < 0) {
-		return `Created ${moment(ms).fromNow()}`;
+		return moment(ms).fromNow();
 	}
 	const totalSec = Math.floor(deltaMs / 1000);
 	if (totalSec < 1) {
-		return "Created just now";
+		return "Just now";
 	}
 	if (totalSec < 60) {
 		return totalSec === 1
-			? "Created 1 second ago"
-			: `Created ${totalSec} seconds ago`;
+			? "1 second ago"
+			: `${totalSec} seconds ago`;
 	}
 	const totalMin = Math.floor(totalSec / 60);
 	if (totalMin < 60) {
 		return totalMin === 1
-			? "Created 1 minute ago"
-			: `Created ${totalMin} minutes ago`;
+			? "1 minute ago"
+			: `${totalMin} minutes ago`;
 	}
 	const totalHr = Math.floor(totalMin / 60);
 	if (totalHr < 24) {
 		return totalHr === 1
-			? "Created 1 hour ago"
-			: `Created ${totalHr} hours ago`;
+			? "1 hour ago"
+			: `${totalHr} hours ago`;
 	}
-	return `Created ${moment(ms).fromNow()}`;
+	return moment(ms).fromNow();
 };
 
 const formatRelativeTime = (raw: unknown): string => {
@@ -146,54 +148,37 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 	if (isLoading) return null;
 
 	return (
-		<Paper
-			elevation={1}
-			sx={{
-				padding: 2,
-				borderRadius: 2,
-				minHeight: 340,
-				minWidth: 0,
-				width: "100%",
-				flex: 1,
-				boxSizing: "border-box",
-				transition: "box-shadow 0.3s ease",
-				"&:hover": { boxShadow: 4 }
-			}}
-		>
-			<Box sx={{ pb: 2, borderBottom: "1px solid", borderColor: "divider" }}>
+		<Paper elevation={1} className="latest-entities-paper">
+			<Box className="latest-entities-header">
 				<Stack direction="row" justifyContent="space-between" alignItems="center">
-					<Typography sx={{ fontSize: "1rem", fontWeight: 600, color: "#1a1a1a" }}>
+					<Typography className="latest-entities-title">
 						Latest Entities Created
 					</Typography>
 					<Link
 						component="button"
 						onClick={handleViewAll}
-						sx={{
-							fontSize: "0.875rem",
-							cursor: "pointer",
-							textDecoration: "none",
-							color: "primary.main"
-						}}
+						className="latest-entities-view-all"
 						aria-label="View all entities"
+						color="primary.main"
 					>
 						View All
 					</Link>
 				</Stack>
 			</Box>
 			{error ? (
-				<Stack alignItems="center" justifyContent="center" height={200} sx={{ pt: 2 }}>
+				<Stack alignItems="center" justifyContent="center" height={200} className="latest-entities-empty">
 					<Typography variant="body2" color="error">
 						{error}
 					</Typography>
 				</Stack>
 			) : !entities || entities.length === 0 ? (
-				<Stack alignItems="center" justifyContent="center" height={200} sx={{ pt: 2 }}>
+				<Stack alignItems="center" justifyContent="center" height={200} className="latest-entities-empty">
 					<Typography variant="body2" color="text.secondary">
 						No recent entities
 					</Typography>
 				</Stack>
 			) : (
-				<List disablePadding sx={{ pt: 2 }}>
+				<List disablePadding className="latest-entities-list">
 					{entities.slice(0, 7).map((entity) => {
 						const displayName = resolveLatestEntityDisplayName(entity);
 						const entityGuid = resolveLatestEntityGuid(entity);
@@ -207,55 +192,40 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 							<ListItem
 								key={entityGuid || displayName}
 								disablePadding
-								sx={{
-									py: 1,
-									borderBottom: "1px solid",
-									borderColor: "divider",
-									"&:last-child": { borderBottom: "none" }
-								}}
+								className="latest-entities-list-item"
 							>
 								<Stack width="100%" direction="row" justifyContent="space-between" alignItems="center">
-									<Stack direction="row" spacing={0.5} alignItems="center" flexWrap="wrap" flex={1} minWidth={0} mr={1}>
+									<Stack direction="row" spacing={0.5} alignItems="center" flexWrap="nowrap" flex={1} minWidth={0} mr={1}>
 										{detailHref ? (
-											<Link
-												component={RouterLink}
-												to={detailHref}
-												underline="hover"
-												color="primary"
-												sx={{
-													fontSize: "0.875rem",
-													overflow: "hidden",
-													textOverflow: "ellipsis",
-													cursor: "pointer",
-													maxWidth: "100%"
-												}}
-											>
-												{displayName}
-											</Link>
+											<OverflowTooltip title={displayName} arrow placement="top">
+												<Link
+													component={RouterLink}
+													to={detailHref}
+													underline="hover"
+													color="primary"
+													className="latest-entities-entity-name latest-entities-entity-name-link"
+												>
+													{displayName}
+												</Link>
+											</OverflowTooltip>
 										) : (
-											<Typography
-												component="span"
-												sx={{
-													fontSize: "0.875rem",
-													fontWeight: 500,
-													color: "text.primary"
-												}}
-											>
-												{displayName}
-											</Typography>
+											<OverflowTooltip title={displayName} arrow placement="top">
+												<Typography
+													component="span"
+													className="latest-entities-entity-name latest-entities-entity-name-fallback"
+												>
+													{displayName}
+												</Typography>
+											</OverflowTooltip>
 										)}
 										<Typography
 											component="span"
-											sx={{
-												fontSize: "0.875rem",
-												color: "#6c757d",
-												flexShrink: 0
-											}}
+											className="latest-entities-type-name"
 										>
 											({typeName})
 										</Typography>
 									</Stack>
-									<Typography sx={{ fontSize: "0.8125rem", color: "#6c757d", flexShrink: 0, ml: 1 }}>
+									<Typography className="latest-entities-timestamp">
 										{formatRelativeTime(timestamp)}
 									</Typography>
 								</Stack>

--- a/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
+++ b/dashboard/src/views/DashboardOverview/LatestEntitiesList.tsx
@@ -159,7 +159,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 						onClick={handleViewAll}
 						className="latest-entities-view-all"
 						aria-label="View all entities"
-						color="primary.main"
+						color="primary"
 					>
 						View All
 					</Link>
@@ -197,7 +197,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 								<Stack width="100%" direction="row" justifyContent="space-between" alignItems="center">
 									<Stack direction="row" spacing={0.5} alignItems="center" flexWrap="nowrap" flex={1} minWidth={0} mr={1}>
 										{detailHref ? (
-											<OverflowTooltip title={displayName} arrow placement="top">
+											<OverflowTooltip title={displayName} arrow placement="top" wrapperSx={{ display: "block", flex: "1 1 auto" }}>
 												<Link
 													component={RouterLink}
 													to={detailHref}
@@ -209,7 +209,7 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 												</Link>
 											</OverflowTooltip>
 										) : (
-											<OverflowTooltip title={displayName} arrow placement="top">
+											<OverflowTooltip title={displayName} arrow placement="top" wrapperSx={{ display: "block", flex: "1 1 auto" }}>
 												<Typography
 													component="span"
 													className="latest-entities-entity-name latest-entities-entity-name-fallback"
@@ -218,12 +218,14 @@ const LatestEntitiesList = memo(({ entities, isLoading, error }: LatestEntitiesL
 												</Typography>
 											</OverflowTooltip>
 										)}
-										<Typography
-											component="span"
-											className="latest-entities-type-name"
-										>
-											({typeName})
-										</Typography>
+										<OverflowTooltip title={`(${typeName})`} arrow placement="top" wrapperSx={{ display: "block", flex: "0 1 auto", width: "auto" }}>
+											<Typography
+												component="span"
+												className="latest-entities-type-name"
+											>
+												({typeName})
+											</Typography>
+										</OverflowTooltip>
 									</Stack>
 									<Typography className="latest-entities-timestamp">
 										{formatRelativeTime(timestamp)}

--- a/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
+++ b/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
@@ -225,7 +225,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Just now')).toBeInTheDocument()
+		expect(screen.getByText('Created just now')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -242,7 +242,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('30 seconds ago')).toBeInTheDocument()
+		expect(screen.getByText('Created 30 seconds ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -259,7 +259,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('1 minute ago')).toBeInTheDocument()
+		expect(screen.getByText('Created 1 minute ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -276,7 +276,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('2 minutes ago')).toBeInTheDocument()
+		expect(screen.getByText('Created 2 minutes ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -293,7 +293,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('1 hour ago')).toBeInTheDocument()
+		expect(screen.getByText('Created 1 hour ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -310,7 +310,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('2 hours ago')).toBeInTheDocument()
+		expect(screen.getByText('Created 2 hours ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -556,7 +556,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('1 second ago')).toBeInTheDocument()
+		expect(screen.getByText('Created 1 second ago')).toBeInTheDocument()
 	})
 
 	it('uses Created today when Date.now is non-finite for relative time', () => {

--- a/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
+++ b/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
@@ -632,7 +632,7 @@ describe('LatestEntitiesList', () => {
 							name: 'EntityWithoutGuid',
 							typeName: 'T',
 							attributes: { __timestamp: Date.now() },
-						} as any,
+						},
 					]}
 				/>
 			</MemoryRouter>,
@@ -655,7 +655,7 @@ describe('LatestEntitiesList', () => {
 							name: longName,
 							typeName: 'T',
 							attributes: { __timestamp: Date.now() },
-						} as any,
+						},
 					]}
 				/>
 			</MemoryRouter>,
@@ -679,7 +679,7 @@ describe('LatestEntitiesList', () => {
 							guid: 'g1',
 							name: 'NamelessType',
 							attributes: { __timestamp: Date.now() },
-						} as any,
+						},
 					]}
 				/>
 			</MemoryRouter>,

--- a/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
+++ b/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
@@ -185,9 +185,9 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		const row = screen.getByText('X').closest('li')
+		const row = screen.getByText('X').closest('li') as HTMLElement
 		expect(row).toBeTruthy()
-		expect(row).toBeTruthy()
+		expect(within(row).getByText(/ago/)).toBeInTheDocument()
 	})
 
 	it('shows Created today for unusable timestamp', () => {
@@ -643,23 +643,6 @@ describe('LatestEntitiesList', () => {
 		expect(fallbackText).toHaveClass('latest-entities-entity-name-fallback')
 	})
 
-	it('slices to exactly 7 items even if more are provided', () => {
-		const tenEntities = Array.from({ length: 10 }).map((_, i) => ({
-			guid: `g${i}`,
-			name: `Entity ${i}`,
-			typeName: 'T',
-			attributes: { __timestamp: Date.now() },
-		} as any))
-
-		render(
-			<MemoryRouter>
-				<LatestEntitiesList entities={tenEntities} />
-			</MemoryRouter>,
-		)
-
-		const listItems = screen.getAllByRole('listitem')
-		expect(listItems).toHaveLength(7)
-	})
 
 	it('renders extremely long entity name without crashing', () => {
 		const longName = 'A'.repeat(500)
@@ -680,6 +663,11 @@ describe('LatestEntitiesList', () => {
 		const link = screen.getByRole('link', { name: longName })
 		expect(link).toBeInTheDocument()
 		expect(link.textContent).toBe(longName)
+		
+		const span = link.parentElement
+		expect(span).toHaveStyle('overflow: hidden')
+		expect(span).toHaveStyle('text-overflow: ellipsis')
+		expect(span).toHaveStyle('white-space: nowrap')
 	})
 
 	it('renders gracefully when typeName is missing', () => {

--- a/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
+++ b/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
@@ -187,7 +187,7 @@ describe('LatestEntitiesList', () => {
 		)
 		const row = screen.getByText('X').closest('li') as HTMLElement
 		expect(row).toBeTruthy()
-		expect(within(row).getByText(/ago/)).toBeInTheDocument()
+		expect(within(row).getByText(/^Created /)).toBeInTheDocument()
 	})
 
 	it('shows Created today for unusable timestamp', () => {
@@ -328,7 +328,7 @@ describe('LatestEntitiesList', () => {
 			</MemoryRouter>,
 		)
 		const li = screen.getByText('A').closest('li') as HTMLElement
-		expect(within(li).getByText(/in /)).toBeInTheDocument()
+		expect(within(li).getByText(/^Created /)).toBeInTheDocument()
 	})
 
 	it('normalizeEntityTimestampMs: $numberLong and longValue wrappers', () => {
@@ -534,7 +534,7 @@ describe('LatestEntitiesList', () => {
 		)
 		expect(
 			within(screen.getByText('Old').closest('li') as HTMLElement).getByText(
-				/ago/,
+				/^Created /,
 			),
 		).toBeInTheDocument()
 	})
@@ -600,7 +600,7 @@ describe('LatestEntitiesList', () => {
 		)
 		const row = screen.getByText('Historic').closest('li') as HTMLElement
 		expect(
-			within(row).getByText(/ago/).textContent,
+			within(row).getByText(/^Created /).textContent,
 		).not.toMatch(/^Created today$/)
 	})
 
@@ -685,5 +685,26 @@ describe('LatestEntitiesList', () => {
 			</MemoryRouter>,
 		)
 		expect(screen.getByText('(Entity)')).toBeInTheDocument()
+	})
+
+	it('renders extremely long typeName without breaking layout', () => {
+		const longTypeName = 'B'.repeat(300)
+		render(
+			<MemoryRouter>
+				<LatestEntitiesList
+					entities={[
+						{
+							guid: 'g1',
+							name: 'EntityWithLongType',
+							typeName: longTypeName,
+							attributes: { __timestamp: Date.now() },
+						},
+					]}
+				/>
+			</MemoryRouter>,
+		)
+		const typeElement = screen.getByText(`(${longTypeName})`)
+		expect(typeElement).toBeInTheDocument()
+		expect(typeElement.parentElement).toHaveClass('latest-entities-type-wrapper')
 	})
 })

--- a/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
+++ b/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
@@ -187,9 +187,7 @@ describe('LatestEntitiesList', () => {
 		)
 		const row = screen.getByText('X').closest('li')
 		expect(row).toBeTruthy()
-		expect(
-			within(row as HTMLElement).getByText(/^Created /),
-		).toBeInTheDocument()
+		expect(row).toBeTruthy()
 	})
 
 	it('shows Created today for unusable timestamp', () => {
@@ -227,7 +225,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Created just now')).toBeInTheDocument()
+		expect(screen.getByText('Just now')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -244,7 +242,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Created 30 seconds ago')).toBeInTheDocument()
+		expect(screen.getByText('30 seconds ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -261,7 +259,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Created 1 minute ago')).toBeInTheDocument()
+		expect(screen.getByText('1 minute ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -278,7 +276,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Created 2 minutes ago')).toBeInTheDocument()
+		expect(screen.getByText('2 minutes ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -295,7 +293,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Created 1 hour ago')).toBeInTheDocument()
+		expect(screen.getByText('1 hour ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -312,7 +310,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Created 2 hours ago')).toBeInTheDocument()
+		expect(screen.getByText('2 hours ago')).toBeInTheDocument()
 
 		jest.setSystemTime(new Date(base))
 		rerender(
@@ -330,7 +328,7 @@ describe('LatestEntitiesList', () => {
 			</MemoryRouter>,
 		)
 		const li = screen.getByText('A').closest('li') as HTMLElement
-		expect(within(li).getByText(/Created in /)).toBeInTheDocument()
+		expect(within(li).getByText(/in /)).toBeInTheDocument()
 	})
 
 	it('normalizeEntityTimestampMs: $numberLong and longValue wrappers', () => {
@@ -536,7 +534,7 @@ describe('LatestEntitiesList', () => {
 		)
 		expect(
 			within(screen.getByText('Old').closest('li') as HTMLElement).getByText(
-				/^Created /,
+				/ago/,
 			),
 		).toBeInTheDocument()
 	})
@@ -558,7 +556,7 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Created 1 second ago')).toBeInTheDocument()
+		expect(screen.getByText('1 second ago')).toBeInTheDocument()
 	})
 
 	it('uses Created today when Date.now is non-finite for relative time', () => {
@@ -578,7 +576,7 @@ describe('LatestEntitiesList', () => {
 			</MemoryRouter>,
 		)
 		expect(
-			within(screen.getByRole('listitem')).getByText(/^Created /),
+			within(screen.getByRole('listitem')).getByText('Created today'),
 		).toHaveTextContent('Created today')
 		spy.mockRestore()
 	})
@@ -602,7 +600,7 @@ describe('LatestEntitiesList', () => {
 		)
 		const row = screen.getByText('Historic').closest('li') as HTMLElement
 		expect(
-			within(row).getByText(/^Created /).textContent,
+			within(row).getByText(/ago/).textContent,
 		).not.toMatch(/^Created today$/)
 	})
 
@@ -623,5 +621,81 @@ describe('LatestEntitiesList', () => {
 			</MemoryRouter>,
 		)
 		expect(screen.getByText('Created today')).toBeInTheDocument()
+	})
+
+	it('renders fallback Typography when detailHref is absent (no guid)', () => {
+		render(
+			<MemoryRouter>
+				<LatestEntitiesList
+					entities={[
+						{
+							name: 'EntityWithoutGuid',
+							typeName: 'T',
+							attributes: { __timestamp: Date.now() },
+						} as any,
+					]}
+				/>
+			</MemoryRouter>,
+		)
+		const fallbackText = screen.getByText('EntityWithoutGuid')
+		expect(fallbackText).toBeInTheDocument()
+		expect(fallbackText.tagName).toBe('SPAN')
+		expect(fallbackText).toHaveClass('latest-entities-entity-name-fallback')
+	})
+
+	it('slices to exactly 7 items even if more are provided', () => {
+		const tenEntities = Array.from({ length: 10 }).map((_, i) => ({
+			guid: `g${i}`,
+			name: `Entity ${i}`,
+			typeName: 'T',
+			attributes: { __timestamp: Date.now() },
+		} as any))
+
+		render(
+			<MemoryRouter>
+				<LatestEntitiesList entities={tenEntities} />
+			</MemoryRouter>,
+		)
+
+		const listItems = screen.getAllByRole('listitem')
+		expect(listItems).toHaveLength(7)
+	})
+
+	it('renders extremely long entity name without crashing', () => {
+		const longName = 'A'.repeat(500)
+		render(
+			<MemoryRouter>
+				<LatestEntitiesList
+					entities={[
+						{
+							guid: 'g1',
+							name: longName,
+							typeName: 'T',
+							attributes: { __timestamp: Date.now() },
+						} as any,
+					]}
+				/>
+			</MemoryRouter>,
+		)
+		const link = screen.getByRole('link', { name: longName })
+		expect(link).toBeInTheDocument()
+		expect(link.textContent).toBe(longName)
+	})
+
+	it('renders gracefully when typeName is missing', () => {
+		render(
+			<MemoryRouter>
+				<LatestEntitiesList
+					entities={[
+						{
+							guid: 'g1',
+							name: 'NamelessType',
+							attributes: { __timestamp: Date.now() },
+						} as any,
+					]}
+				/>
+			</MemoryRouter>,
+		)
+		expect(screen.getByText('(Entity)')).toBeInTheDocument()
 	})
 })

--- a/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
+++ b/dashboard/src/views/DashboardOverview/__tests__/LatestEntitiesList.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from 'react'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent, within, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 jest.mock('@utils/dashboardSearchUtils', () => ({
@@ -164,7 +164,10 @@ describe('LatestEntitiesList', () => {
 				/>
 			</MemoryRouter>,
 		)
-		expect(screen.getByText('Orphan')).toBeInTheDocument()
+		const fallbackText = screen.getByText('Orphan')
+		expect(fallbackText).toBeInTheDocument()
+		expect(fallbackText.tagName).toBe('SPAN')
+		expect(fallbackText).toHaveClass('latest-entities-entity-name-fallback')
 		expect(screen.queryByRole('link', { name: 'Orphan' })).toBeNull()
 	})
 
@@ -623,28 +626,8 @@ describe('LatestEntitiesList', () => {
 		expect(screen.getByText('Created today')).toBeInTheDocument()
 	})
 
-	it('renders fallback Typography when detailHref is absent (no guid)', () => {
-		render(
-			<MemoryRouter>
-				<LatestEntitiesList
-					entities={[
-						{
-							name: 'EntityWithoutGuid',
-							typeName: 'T',
-							attributes: { __timestamp: Date.now() },
-						},
-					]}
-				/>
-			</MemoryRouter>,
-		)
-		const fallbackText = screen.getByText('EntityWithoutGuid')
-		expect(fallbackText).toBeInTheDocument()
-		expect(fallbackText.tagName).toBe('SPAN')
-		expect(fallbackText).toHaveClass('latest-entities-entity-name-fallback')
-	})
 
-
-	it('renders extremely long entity name without crashing', () => {
+	it('renders extremely long entity name without crashing and shows tooltip', async () => {
 		const longName = 'A'.repeat(500)
 		render(
 			<MemoryRouter>
@@ -664,10 +647,24 @@ describe('LatestEntitiesList', () => {
 		expect(link).toBeInTheDocument()
 		expect(link.textContent).toBe(longName)
 		
-		const span = link.parentElement
-		expect(span).toHaveStyle('overflow: hidden')
-		expect(span).toHaveStyle('text-overflow: ellipsis')
-		expect(span).toHaveStyle('white-space: nowrap')
+		const span = link.parentElement!
+		expect(span).toHaveClass('latest-entities-name-wrapper')
+
+		// Force overflow mock so the OverflowTooltip displays
+		Object.defineProperty(span, 'scrollWidth', { configurable: true, value: 500 })
+		Object.defineProperty(span, 'clientWidth', { configurable: true, value: 200 })
+		span.getBoundingClientRect = jest.fn(() => ({ width: 200 } as DOMRect))
+
+		fireEvent.mouseEnter(span)
+		fireEvent.mouseOver(span)
+		
+		act(() => {
+			jest.advanceTimersByTime(200)
+		})
+		
+		// Wait for tooltip to appear - expect multiple instances of the text (one is the tooltip)
+		const elements = await screen.findAllByText(longName)
+		expect(elements.length).toBeGreaterThan(1)
 	})
 
 	it('renders gracefully when typeName is missing', () => {
@@ -705,6 +702,33 @@ describe('LatestEntitiesList', () => {
 		)
 		const typeElement = screen.getByText(`(${longTypeName})`)
 		expect(typeElement).toBeInTheDocument()
+		
+		const wrapper = typeElement.parentElement
+		expect(wrapper).toHaveClass('latest-entities-type-wrapper')
+	})
+
+	it('renders both extremely long entity name and extremely long typeName without layout break', () => {
+		const longName = 'A'.repeat(500)
+		const longTypeName = 'B'.repeat(300)
+		render(
+			<MemoryRouter>
+				<LatestEntitiesList
+					entities={[
+						{
+							guid: 'g1',
+							name: longName,
+							typeName: longTypeName,
+							attributes: { __timestamp: Date.now() },
+						},
+					]}
+				/>
+			</MemoryRouter>,
+		)
+		
+		const nameLink = screen.getByRole('link', { name: longName })
+		expect(nameLink.parentElement).toHaveClass('latest-entities-name-wrapper')
+		
+		const typeElement = screen.getByText(`(${longTypeName})`)
 		expect(typeElement.parentElement).toHaveClass('latest-entities-type-wrapper')
 	})
 })

--- a/dashboard/src/views/DetailPage/BusinessMetadataDetails/BusinessMetadataDetailsLayout.tsx
+++ b/dashboard/src/views/DetailPage/BusinessMetadataDetails/BusinessMetadataDetailsLayout.tsx
@@ -358,7 +358,7 @@ const BusinessMetadataDetailsLayout = () => {
                   <CustomButton
                     variant="outlined"
                     color="primary"
-                    onClick={(_e: Event) => {
+                    onClick={(_e: React.MouseEvent<HTMLButtonElement>) => {
                       reset({ attributeDefs: [defaultAttrObj] });
                       setForm(false);
                       setBMAttribute({});


### PR DESCRIPTION
## What changes were proposed in this pull request?

**ATLAS-5373: Atlas React UI: Refactor and stabilize layout in Latest Entities Created widget**

This PR fixes styling, layout, and type-safety bugs in the "Latest Entities Created" widget and its underlying shared components. It completely migrates away from inline `sx` objects to strict, maintainable SCSS classes, and drastically improves the performance, layout resilience, test coverage, and type safety of shared UI components.

* **Strict SCSS & Layout Hardening:** Completely stripped out inline `sx` layout styles (including `display`, `width`, and truncation rules) from the generic `OverflowTooltip` and the `LatestEntitiesList` component. Migrated all layout responsibilities strictly to `LatestEntitiesList.scss`. Hardened flex layout rules (`flex: 1 1 auto; min-width: 0`) and added `flex: 0 0 auto` / `max-width: 45%` constraints on `.latest-entities-type-wrapper` to prevent long entity names from squishing the type label.
* **Intelligent & Consistent Truncation:** Implemented the `OverflowTooltip` component to elegantly handle long entity and type names. Centralized explicit CSS truncation rules (`overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`) across `.latest-entities-entity-name`, `.latest-entities-name-wrapper`, and `.latest-entities-type-wrapper` in SCSS for guaranteed visual consistency and layout separation of concerns.
* **Tooltip & Component Enhancements:** Upgraded `OverflowTooltip` in `muiComponents.tsx` to use `ResizeObserver` (combined with an `onMouseEnter` fallback) for accurate DOM boundary detection. Added inline documentation explaining the subpixel arithmetic (`clientWidth` vs `getBoundingClientRect().width`) and observer patterns.
* **Global Type-Safety Refactor:** 
  * Refactored `LightTooltip` in `muiComponents.tsx` to strictly use `TooltipProps` instead of `any`.
  * Completely refactored `CustomButton` to enforce native `@mui/material/ButtonProps`, eliminating legacy `any` escape hatches. Proactively cleaned up invalid props and event handlers across downstream consumers to guarantee 100% type safety.
* **UX & Code Cleanup:** Restored the `"Created "` prefix on relative timestamps to maintain UX expectations and cleaned up formatting/blank line inconsistencies between helpers and component definitions. Standardized SCSS formatting to a strict 4-space indent.

## How was this patch tested?

* **Manual UI Testing:** Verified in the dashboard that extremely long entity names cleanly truncate with an ellipsis `...`, long type names remain appropriately visible without collapsing into `(`, and tooltips appear precisely when fractional overflow occurs.
* **Extensive Unit Tests:** 
  * Reverted assertions in `LatestEntitiesList.test.tsx` back to strict `/^Created /` regex matchers (lines 190, 331, 537, 603) for strong regression protection.
  * Added dedicated combination tests verifying both extremely long `name` and `typeName` (`'B'.repeat(300)`) simultaneously rendering without layout breakdown.
  * Added mock logic triggering the MUI tooltip with `fireEvent` and fake timer advancements (`jest.advanceTimersByTime`) to verify overflow hover states.
  * Consolidated overlapping test coverage for empty UI fallback states into single cohesive assertions.
  * Replaced unsafe `any` casts with strictly typed test mocks (`as unknown as typeof ResizeObserver`) in `muiComponents.test.tsx`.
  * Expanded `OverflowTooltip` test suite to verify `ResizeObserver.disconnect()` on unmount, `wrapperClassName` application, and re-evaluation upon `title` prop updates.
  * All unit tests pass cleanly (`npm run test`).
* **TypeScript & ESLint Validation:** Passed strict type checking (`npm run typecheck`) across the entire dashboard with zero errors.