### PR TITLE
ATLAS-5379 : Authorize lineage neighbor entities before returning headers

### DIFF
--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizationUtils.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizationUtils.java
@@ -22,6 +22,8 @@ package org.apache.atlas.authorize;
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
 import org.apache.atlas.exception.AtlasBaseException;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.type.AtlasTypeRegistry;
 import org.apache.atlas.utils.AtlasPerfMetrics.MetricRecorder;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -91,6 +93,26 @@ public class AtlasAuthorizationUtils {
                 request.setRemoteIPAddress(RequestContext.get().getClientIPAddress());
 
                 authorizer.scrubSearchResults(request);
+            } catch (AtlasAuthorizationException e) {
+                LOG.error("Unable to obtain AtlasAuthorizer", e);
+            }
+        }
+    }
+
+    /**
+     * Scrub a single entity-header in-place when the current user is not authorized (ENTITY_READ) to read it.
+     * Mirrors the per-entity handling in {@link AtlasAuthorizer#scrubSearchResults}, but for results (e.g. lineage)
+     * that are not modeled as an {@link AtlasSearchResult}. The entity's guid and relationships are preserved by the
+     * caller (kept in the surrounding map/relations), only the header's sensitive fields are cleared.
+     */
+    public static void scrubEntityHeader(AtlasEntityHeader entityHeader, AtlasTypeRegistry typeRegistry) {
+        if (entityHeader == null) {
+            return;
+        }
+
+        if (!isAccessAllowed(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entityHeader))) {
+            try {
+                AtlasAuthorizerFactory.getAtlasAuthorizer().scrubEntityHeader(entityHeader);
             } catch (AtlasAuthorizationException e) {
                 LOG.error("Unable to obtain AtlasAuthorizer", e);
             }

--- a/authorization/src/test/java/org/apache/atlas/authorize/AtlasAuthorizationUtilsTest.java
+++ b/authorization/src/test/java/org/apache/atlas/authorize/AtlasAuthorizationUtilsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorize;
+
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.model.instance.AtlasClassification;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Tests for {@link AtlasAuthorizationUtils#scrubEntityHeader(AtlasEntityHeader, org.apache.atlas.type.AtlasTypeRegistry)},
+ * the helper used by lineage to redact headers of entities the caller cannot read (ENTITY_READ).
+ */
+public class AtlasAuthorizationUtilsTest {
+    private String originalConf;
+
+    @BeforeMethod
+    public void setUp() {
+        originalConf = System.getProperty("atlas.conf");
+
+        // src/test/resources contains atlas-application.properties (SIMPLE authorizer) + policy file
+        System.setProperty("atlas.conf", "src/test/resources");
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+        RequestContext.clear();
+
+        if (originalConf != null) {
+            System.setProperty("atlas.conf", originalConf);
+        }
+    }
+
+    @Test
+    public void testScrubEntityHeaderRedactsUnauthorizedEntity() {
+        // user in an unknown group has no ENTITY_READ grant in the simple-authz policy
+        setCurrentUser("unknown-group-user", "UNKNOWN_GROUP");
+
+        AtlasEntityHeader entity = newEntityHeader();
+
+        AtlasAuthorizationUtils.scrubEntityHeader(entity, null);
+
+        // default scrub sets guid to "-1" and clears attributes/classifications
+        assertEquals("unauthorized entity guid should be scrubbed", "-1", entity.getGuid());
+        assertTrue("unauthorized entity classifications should be cleared",
+                entity.getClassifications() == null || entity.getClassifications().isEmpty());
+        assertTrue("unauthorized entity attributes should be cleared",
+                entity.getAttributes() == null || entity.getAttributes().isEmpty());
+    }
+
+    @Test
+    public void testScrubEntityHeaderKeepsAuthorizedEntity() {
+        // admin (ROLE_ADMIN) is allowed ENTITY_READ, so the header must be left untouched
+        setCurrentUser("admin", "ROLE_ADMIN");
+
+        AtlasEntityHeader entity = newEntityHeader();
+
+        AtlasAuthorizationUtils.scrubEntityHeader(entity, null);
+
+        assertEquals("authorized entity guid should be preserved", "guid-1", entity.getGuid());
+        assertNotNull("authorized entity classifications should be preserved", entity.getClassifications());
+        assertEquals("authorized entity classifications should be preserved", 1, entity.getClassifications().size());
+        assertNotNull("authorized entity attributes should be preserved", entity.getAttributes());
+        assertEquals("authorized entity attributes should be preserved",
+                "db.table@cluster", entity.getAttribute("qualifiedName"));
+    }
+
+    @Test
+    public void testScrubEntityHeaderHandlesNull() {
+        // must be a no-op (no NPE) for a null header
+        AtlasAuthorizationUtils.scrubEntityHeader(null, null);
+    }
+
+    private AtlasEntityHeader newEntityHeader() {
+        AtlasEntityHeader entity = new AtlasEntityHeader("hive_table");
+
+        entity.setGuid("guid-1");
+        entity.setAttribute("qualifiedName", "db.table@cluster");
+        entity.setClassifications(new ArrayList<>(Collections.singletonList(new AtlasClassification("PII"))));
+
+        return entity;
+    }
+
+    private void setCurrentUser(String userName, String group) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userName, null,
+                        Collections.singletonList(new SimpleGrantedAuthority(group))));
+    }
+}

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -654,22 +654,15 @@ public class EntityLineageService implements AtlasLineageService {
         String      relationGuid = AtlasGraphUtilsV2.getEncodedProperty(edge, RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
         boolean     isInputEdge  = edge.getLabel().equalsIgnoreCase(PROCESS_INPUTS_EDGE);
 
-        if (!entities.containsKey(inGuid)) {
-            AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(inVertex);
+        addEntityHeaderIfAuthorized(inVertex, inGuid, entities);
+        addEntityHeaderIfAuthorized(outVertex, outGuid, entities);
 
-            entities.put(inGuid, entityHeader);
-        }
-
-        if (!entities.containsKey(outGuid)) {
-            AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(outVertex);
-
-            entities.put(outGuid, entityHeader);
-        }
-
-        if (isInputEdge) {
-            relations.add(new LineageRelation(inGuid, outGuid, relationGuid));
-        } else {
-            relations.add(new LineageRelation(outGuid, inGuid, relationGuid));
+        if (entities.containsKey(inGuid) && entities.containsKey(outGuid)) {
+            if (isInputEdge) {
+                relations.add(new LineageRelation(inGuid, outGuid, relationGuid));
+            } else {
+                relations.add(new LineageRelation(outGuid, inGuid, relationGuid));
+            }
         }
 
         if (visitedEdges != null) {
@@ -677,6 +670,22 @@ public class EntityLineageService implements AtlasLineageService {
 
             visitedEdges.add(visitedEdgeLabel);
         }
+    }
+
+    private void addEntityHeaderIfAuthorized(AtlasVertex vertex, String guid, Map<String, AtlasEntityHeader> entities) throws AtlasBaseException {
+        if (entities.containsKey(guid)) {
+            return;
+        }
+
+        AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(vertex);
+
+        if (isEntityReadAllowed(entityHeader)) {
+            entities.put(guid, entityHeader);
+        }
+    }
+
+    private boolean isEntityReadAllowed(AtlasEntityHeader entityHeader) {
+        return AtlasAuthorizationUtils.isAccessAllowed(new AtlasEntityAccessRequest(atlasTypeRegistry, AtlasPrivilege.ENTITY_READ, entityHeader));
     }
 
     private AtlasLineageInfo getBothLineageInfoV1(String guid, int depth, boolean isDataSet) throws AtlasBaseException {

--- a/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
+++ b/repository/src/main/java/org/apache/atlas/discovery/EntityLineageService.java
@@ -117,6 +117,8 @@ public class EntityLineageService implements AtlasLineageService {
             ret = getLineageInfoV2(guid, direction, depth, isDataSet);
         }
 
+        scrubLineageEntities(ret);
+
         return ret;
     }
 
@@ -136,6 +138,8 @@ public class EntityLineageService implements AtlasLineageService {
 
         // filtering out on-demand relations which has input & output nodes within the limit
         cleanupRelationsOnDemand(ret);
+
+        scrubLineageEntities(ret);
 
         return ret;
     }
@@ -654,15 +658,22 @@ public class EntityLineageService implements AtlasLineageService {
         String      relationGuid = AtlasGraphUtilsV2.getEncodedProperty(edge, RELATIONSHIP_GUID_PROPERTY_KEY, String.class);
         boolean     isInputEdge  = edge.getLabel().equalsIgnoreCase(PROCESS_INPUTS_EDGE);
 
-        addEntityHeaderIfAuthorized(inVertex, inGuid, entities);
-        addEntityHeaderIfAuthorized(outVertex, outGuid, entities);
+        if (!entities.containsKey(inGuid)) {
+            AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(inVertex);
 
-        if (entities.containsKey(inGuid) && entities.containsKey(outGuid)) {
-            if (isInputEdge) {
-                relations.add(new LineageRelation(inGuid, outGuid, relationGuid));
-            } else {
-                relations.add(new LineageRelation(outGuid, inGuid, relationGuid));
-            }
+            entities.put(inGuid, entityHeader);
+        }
+
+        if (!entities.containsKey(outGuid)) {
+            AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(outVertex);
+
+            entities.put(outGuid, entityHeader);
+        }
+
+        if (isInputEdge) {
+            relations.add(new LineageRelation(inGuid, outGuid, relationGuid));
+        } else {
+            relations.add(new LineageRelation(outGuid, inGuid, relationGuid));
         }
 
         if (visitedEdges != null) {
@@ -672,20 +683,20 @@ public class EntityLineageService implements AtlasLineageService {
         }
     }
 
-    private void addEntityHeaderIfAuthorized(AtlasVertex vertex, String guid, Map<String, AtlasEntityHeader> entities) throws AtlasBaseException {
-        if (entities.containsKey(guid)) {
+    /**
+     * Scrub lineage entities the caller is not authorized (ENTITY_READ) to read - similar to search-result scrubbing
+     * in {@code EntityDiscoveryService.scrubSearchResults()}. The full lineage graph is gathered first; here we only
+     * redact the headers of unauthorized entities (attributes, classifications, meanings are cleared). Node guids and
+     * relations are retained so the lineage graph stays connected.
+     */
+    private void scrubLineageEntities(AtlasLineageInfo lineageInfo) {
+        if (lineageInfo == null || MapUtils.isEmpty(lineageInfo.getGuidEntityMap())) {
             return;
         }
 
-        AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeader(vertex);
-
-        if (isEntityReadAllowed(entityHeader)) {
-            entities.put(guid, entityHeader);
+        for (AtlasEntityHeader entityHeader : lineageInfo.getGuidEntityMap().values()) {
+            AtlasAuthorizationUtils.scrubEntityHeader(entityHeader, atlasTypeRegistry);
         }
-    }
-
-    private boolean isEntityReadAllowed(AtlasEntityHeader entityHeader) {
-        return AtlasAuthorizationUtils.isAccessAllowed(new AtlasEntityAccessRequest(atlasTypeRegistry, AtlasPrivilege.ENTITY_READ, entityHeader));
     }
 
     private AtlasLineageInfo getBothLineageInfoV1(String guid, int depth, boolean isDataSet) throws AtlasBaseException {


### PR DESCRIPTION
Apply per-entity ENTITY_READ checks when building lineage guidEntityMap. Skip unauthorized neighbors and omit relations when either endpoint is not readable.

## What changes were proposed in this pull request?

<h3 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-6f599f ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.214em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h3><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The lineage API (<code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">GET /api/atlas/v2/lineage/{guid}</code>) checks<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">ENTITY_READ</code><span> </span>on the<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">seed entity</span><span> </span>before building lineage, but<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">neighbor entities</span><span> </span>discovered during graph traversal were added to the response<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">without</span><span> </span>per-entity authorization.</p><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">In<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">EntityLineageService.processEdge()</code>:</p><ul class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-1ae8yn7 ui-z80ra4 ui-1nhcn8o ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 10px; margin-top: 10px; padding-left: 2em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">Input/output vertex headers were always added to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">guidEntityMap</code></li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">LineageRelation</code><span> </span>entries were always added for each edge</li></ul><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">So a user authorized to read entity<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">A</span><span> </span>could see metadata for unauthorized neighbor<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">B</span><span> </span>(and the relation between them) in the lineage response — an authorization bypass / information disclosure.</p><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The seed entity was already protected here:</p><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; margin-top: 8px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block ui-1n2onr6 ui-1j66ri5 ui-14l7nz5 ui-1yf7rl7 ui-t4zf8z ui-zboxd6 ui-j3b58b ui-1vb4fzf ui-14gibnr ui-10a2chs ui-1u51yxl ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-6ikm8r ui-10wlt62 ui-1ua6jya ui-1k89b3v ui-8nuxf3" data-has-header="true" style="--ui-code-block-copy-overlay-display: none; background-color: rgb(252, 252, 252); position: relative; border-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); border-radius: 8px; border-style: solid; border-width: 1px; margin: 0px; overflow: hidden;"><button type="button" class="ui-code-block-header ui-78zum5 ui-6s0dn4 ui-pkkfsy ui-uve7l6 ui-1jwyyqy ui-1rgtt3y ui-437fdo ui-1ua6jya ui-1iuyybk ui-972fbf ui-1ejq31n ui-gfja2r ui-11pwa6s ui-so031l ui-1q0q8m5 ui-1jfuf7k ui-yj58a3 ui-1b16gh4 ui-h8yej3 ui-dpxx8g ui-jb2p0i ui-1qlqyl8 ui-1t35e8 ui-1pd3egz ui-15bjb6t ui-1heor9g ui-9f619 ui-euugli ui-15406qy ui-1g2r6go ui-z4gly6 ui-1k57tk5 ui-1l9t207 ui-1x65lqo ui-1t137rt ui-hlp2gg ui-i5y0ii ui-1ypdohk" data-clickable="true" style="padding: 6px 10px; margin: 0px; gap: 6px; align-items: center; background-color: rgb(252, 252, 252); box-sizing: border-box; color: inherit; cursor: pointer; display: flex; font-family: inherit; font-size: inherit; font-style: inherit; font-weight: inherit; line-height: inherit; outline: none !important; text-align: left; transition-duration: 0.1s; transition-property: background-color; transition-timing-function: ease-in-out; border-bottom: 1px solid color(srgb 0.0784314 0.0784314 0.0784314 / 0.12); border-left-style: none; border-left-width: 0px; border-right-style: none; border-right-width: 0px; border-top-style: none; border-top-width: 0px; min-width: 0px; width: 431px;"><span aria-hidden="true" role="img" class="ui-seti ui-3nfvp2 ui-6s0dn4 ui-l56j7k ui-j26tf6 ui-bleps ui-1qtuznc ui-1j61x8r ui-1fcty0u ui-o5v014 ui-xymvpz ui-pyhgd6 ui-1cpzp08 ui-fzk3lv ui-1kky2od ui-lup9mm ui-1j61zf2 ui-4pprgf" data-size="sm" style="--icon-size: 18px; --seti-glyph-scale: 1; -webkit-font-smoothing: subpixel-antialiased; align-items: center; display: inline-flex; font-family: seti, &quot;Segoe UI&quot;, sans-serif; font-size: 16px; font-style: normal; font-weight: normal; justify-content: center; line-height: 1; vertical-align: middle; height: 16px; width: 16px; --seti-content: &quot;&quot;; color: rgb(206, 64, 91);"></span><span class="ui-11wthnw ui-1ja60sm ui-vu1jfw ui-19aaqeu ui-uxw1ft ui-6ikm8r ui-10wlt62 ui-lyipyv" style="color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.74); font-size: 13px; letter-spacing: -0.08px; line-height: 18px; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">EntityLineageService.java</span><span class="ui-1wm8ruf ui-spwq11 ui-14s4slr ui-4b2ntj ui-uxw1ft ui-2lah0s" style="color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.6); flex-shrink: 0; font-size: 12px; letter-spacing: normal; line-height: 16px; white-space: nowrap;">Lines<span> </span>197-200</span></button><div class="ui-code-block-content ui-1n2onr6" style="position: relative; min-height: 66px;"><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; display: grid; position: relative; overflow: hidden;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" data-native-scrollbar="none" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-1us19tq ui-78zum5 ui-g7h5cd ui-1q0g3np ui-ezivpi ui-gqtt45 ui-1x1rfll" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: none; min-height: 100%; min-width: 100%; width: max-content;"><div class="ui-default-code ui-1wm8ruf ui-1lfj9qp ui-spwq11 ui-1ua6jya ui-1m21r4p ui-cj37ws ui-13r5tfd ui-uve7l6 ui-1xpa7k ui-1rgtt3y ui-1uhho1l ui-o9w7m5 ui-17ewauw ui-1vakzcb ui-105xmc4 ui-1nsav61 ui-1jxofbz ui-947h55 ui-ta7kcf ui-1iagb1a ui-ez8t0j ui-i2wo5x ui-1iq2d2k ui-1qoclnz ui-k609h7 ui-1rqnq8e ui-19gwdp1 ui-1yfyyyg ui-1apie5d ui-dcvkk1 ui-code-block-default-code" style="--shiki-background: transparent; --shiki-foreground: #141414; --shiki-token-attribute: #654DC0; --shiki-token-class: #005293; --shiki-token-comment: #14141499; --shiki-token-constant-variable: #005293; --shiki-token-constant: #005293; --shiki-token-function: #CD4500; --shiki-token-keyword: #A30034; --shiki-token-language-variable: #BE1744; --shiki-token-link: #87c3ff; --shiki-token-parameter: #005293; --shiki-token-property: #654DC0; --shiki-token-punctuation: #005293; --shiki-token-string-expression: #7565CC; --shiki-token-string: #7565CC; --shiki-token-tag: #007041; --shiki-token-type: #005293; --shiki-token-variable: #005293; background-color: transparent; contain: layout style paint; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 12px; font-weight: 400; line-height: 16px; tab-size: 4; padding: 6px 0px; --ui-default-code-tab-size: 4; min-height: 0px; width: max-content; min-width: 100%;"><div class="ui-1pshirs ui-awy1a7" style="contain: layout style; min-width: fit-content;"><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span style="color: rgb(163, 0, 52);">private</span><span style="color: rgb(20, 20, 20);"> </span><span style="color: rgb(163, 0, 52);">boolean</span><span style="color: rgb(20, 20, 20);"> </span><span style="color: rgb(205, 69, 0);">validateEntityTypeAndCheckIfDataSet</span><span style="color: rgb(0, 82, 147);">(</span><span style="color: rgb(163, 0, 52);">String</span><span style="color: rgb(20, 20, 20);"> guid</span><span style="color: rgb(0, 82, 147);">)</span><span style="color: rgb(20, 20, 20);"> throws AtlasBaseException </span><span style="color: rgb(0, 82, 147);">{</span></div></div><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span style="color: rgb(20, 20, 20);">    </span><span style="color: rgb(163, 0, 52);">AtlasEntityHeader</span><span style="color: rgb(20, 20, 20);"> </span><span style="color: rgb(0, 82, 147);">entity</span><span style="color: rgb(20, 20, 20);"> </span><span style="color: rgb(0, 82, 147);">=</span><span style="color: rgb(20, 20, 20);"> </span><span style="color: rgb(0, 82, 147);">entityRetriever</span><span style="color: rgb(0, 82, 147);">.</span><span style="color: rgb(205, 69, 0);">toAtlasEntityHeaderWithClassifications</span><span style="color: rgb(0, 82, 147);">(</span><span style="color: rgb(20, 20, 20);">guid</span><span style="color: rgb(0, 82, 147);">);</span></div></div><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span style="color: rgb(20, 20, 20);">    </span><span style="color: rgb(0, 82, 147);">AtlasAuthorizationUtils</span><span style="color: rgb(0, 82, 147);">.</span><span style="color: rgb(205, 69, 0);">verifyAccess</span><span style="color: rgb(0, 82, 147);">(...,</span><span style="color: rgb(20, 20, 20);"> ENTITY_READ</span><span style="color: rgb(0, 82, 147);">,</span><span style="color: rgb(20, 20, 20);"> entity</span><span style="color: rgb(0, 82, 147);">),</span><span style="color: rgb(20, 20, 20);"> </span><span style="color: rgb(0, 82, 147);">"</span><span style="color: rgb(117, 101, 204);">read entity lineage: guid=</span><span style="color: rgb(0, 82, 147);">"</span><span style="color: rgb(0, 82, 147);">,</span><span style="color: rgb(20, 20, 20);"> guid)</span><span style="color: rgb(0, 82, 147);">;</span></div></div></div></div></div></div><div class="ui-scroll-area__scrollbar ui-10l6tqk ui-1n327nk ui-67bb7w ui-1lliihq ui-y36ywk ui-80663w ui-zkb8sy ui-1gncbth ui-17roi93 ui-14atkfc ui-a38mao" data-orientation="horizontal" data-scrollable="true" role="presentation" aria-hidden="true" style="display: block; pointer-events: auto; position: absolute; z-index: 10; inset: auto 1px 1px; height: 6px; width: auto;"><div class="ui-10l6tqk ui-1i4c3av ui-1m4ooaa ui-1kik0b9 ui-19p5jqy ui-gk890x ui-67bb7w ui-oww4n8 ui-1e8aii2 ui-1vaoic9 ui-144st5w ui-1aiz5cx ui-13vifvy ui-wukr4l ui-1ey2m1c ui-u96u03 ui-14atkfc ui-a38mao ui-65nank ui-cbmsab ui-g01cxk ui-4gyw5p ui-gorybd" data-orientation="horizontal" style="border-radius: 9999px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); opacity: 0; pointer-events: auto; position: absolute; transform: translateX(0px); transition-duration: 0.15s, 0.15s; transition-property: background-color, opacity; transition-timing-function: ease, ease; inset: 0px auto 0px 0px; height: 6px; min-height: auto; min-width: 20px; width: 241px;"></div></div></div></div></div></div><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Neighbors had no equivalent check.</p><h3 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-6f599f ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.214em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h3><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Updated<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-path-filename-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">EntityLineageService.java</span></code>:</p><ol class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-1ae8yn7 ui-z80ra4 ui-1nhcn8o ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 10px; margin-top: 10px; padding-left: 2em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">addEntityHeaderIfAuthorized()</code></span><span> </span>— loads the header and adds it to<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">guidEntityMap</code><span> </span>only if:<div class="composer-message-codeblock" style="margin-bottom: 8px; margin-top: 8px;"><div class="ui-code-block ui-1n2onr6 ui-1j66ri5 ui-14l7nz5 ui-1yf7rl7 ui-t4zf8z ui-zboxd6 ui-j3b58b ui-1vb4fzf ui-14gibnr ui-10a2chs ui-1u51yxl ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-6ikm8r ui-10wlt62 ui-1ua6jya ui-1k89b3v ui-8nuxf3" style="--ui-code-block-copy-overlay-display: none; background-color: rgb(252, 252, 252); position: relative; border-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); border-radius: 8px; border-style: solid; border-width: 1px; margin: 0px; overflow: hidden; min-height: 46px;"><div class="ui-code-block-content ui-1n2onr6" style="position: relative; min-height: 46px;"><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; display: grid; position: relative; overflow: hidden;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" data-native-scrollbar="none" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-1us19tq ui-78zum5 ui-g7h5cd ui-1q0g3np ui-ezivpi ui-gqtt45 ui-1x1rfll" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: none; min-height: 100%; min-width: 100%; width: max-content;"><div class="ui-default-code ui-1wm8ruf ui-1lfj9qp ui-spwq11 ui-1ua6jya ui-1m21r4p ui-cj37ws ui-13r5tfd ui-uve7l6 ui-1xpa7k ui-1rgtt3y ui-1uhho1l ui-o9w7m5 ui-17ewauw ui-1vakzcb ui-105xmc4 ui-1nsav61 ui-1jxofbz ui-947h55 ui-ta7kcf ui-1iagb1a ui-ez8t0j ui-i2wo5x ui-1iq2d2k ui-1qoclnz ui-k609h7 ui-1rqnq8e ui-19gwdp1 ui-1yfyyyg ui-1apie5d ui-dcvkk1 ui-code-block-default-code" style="--shiki-background: transparent; --shiki-foreground: #141414; --shiki-token-attribute: #654DC0; --shiki-token-class: #005293; --shiki-token-comment: #14141499; --shiki-token-constant-variable: #005293; --shiki-token-constant: #005293; --shiki-token-function: #CD4500; --shiki-token-keyword: #A30034; --shiki-token-language-variable: #BE1744; --shiki-token-link: #87c3ff; --shiki-token-parameter: #005293; --shiki-token-property: #654DC0; --shiki-token-punctuation: #005293; --shiki-token-string-expression: #7565CC; --shiki-token-string: #7565CC; --shiki-token-tag: #007041; --shiki-token-type: #005293; --shiki-token-variable: #005293; background-color: transparent; contain: layout style paint; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 12px; font-weight: 400; line-height: 16px; tab-size: 4; padding: 6px 0px; --ui-default-code-tab-size: 4; min-height: 0px; width: max-content; min-width: 100%;"><div class="ui-1pshirs ui-awy1a7" style="contain: layout style; min-width: fit-content;"><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span style="color: rgb(0, 82, 147);">AtlasAuthorizationUtils</span><span style="color: rgb(0, 82, 147);">.</span><span style="color: rgb(205, 69, 0);">isAccessAllowed</span><span style="color: rgb(0, 82, 147);">(</span></div></div><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span style="color: rgb(20, 20, 20);">    </span><span style="color: rgb(163, 0, 52);">new</span><span style="color: rgb(20, 20, 20);"> </span><span style="color: rgb(205, 69, 0);">AtlasEntityAccessRequest</span><span style="color: rgb(0, 82, 147);">(</span><span style="color: rgb(20, 20, 20);">atlasTypeRegistry</span><span style="color: rgb(0, 82, 147);">,</span><span style="color: rgb(20, 20, 20);"> </span><span style="color: rgb(0, 82, 147);">AtlasPrivilege</span><span style="color: rgb(0, 82, 147);">.</span><span style="color: rgb(0, 82, 147);">ENTITY_READ</span><span style="color: rgb(0, 82, 147);">,</span><span style="color: rgb(20, 20, 20);"> entityHeader</span><span style="color: rgb(0, 82, 147);">))</span></div></div></div></div></div></div><div class="ui-scroll-area__scrollbar ui-10l6tqk ui-1n327nk ui-67bb7w ui-1lliihq ui-y36ywk ui-80663w ui-zkb8sy ui-1gncbth ui-17roi93 ui-14atkfc ui-a38mao" data-orientation="horizontal" data-scrollable="true" role="presentation" aria-hidden="true" style="display: block; pointer-events: auto; position: absolute; z-index: 10; inset: auto 1px 1px; height: 6px; width: auto;"><div class="ui-10l6tqk ui-1i4c3av ui-1m4ooaa ui-1kik0b9 ui-19p5jqy ui-gk890x ui-67bb7w ui-oww4n8 ui-1e8aii2 ui-1vaoic9 ui-144st5w ui-1aiz5cx ui-13vifvy ui-wukr4l ui-1ey2m1c ui-u96u03 ui-14atkfc ui-a38mao ui-65nank ui-cbmsab ui-g01cxk ui-4gyw5p ui-gorybd" data-orientation="horizontal" style="border-radius: 9999px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); opacity: 0; pointer-events: auto; position: absolute; transform: translateX(0px); transition-duration: 0.15s, 0.15s; transition-property: background-color, opacity; transition-timing-function: ease, ease; inset: 0px auto 0px 0px; height: 6px; min-height: auto; min-width: 20px; width: 233px;"></div></div></div></div></div></div></li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Relations gated on both endpoints</span><span> </span>— a<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">LineageRelation</code><span> </span>is added only when<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">both</span><span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">inGuid</code><span> </span>and<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">outGuid</code><span> </span>are present in<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">guidEntityMap</code><span> </span>(both readable).</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">processEdge()</code><span> </span>refactored</span><span> </span>— uses the helper for both vertices; unauthorized neighbors are skipped; edges involving unreadable entities are omitted.</li></ol><h3 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-6f599f ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.214em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Behavior after fix</h3><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk ui-tr57km ui-14beivq ui-13xjzxd ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-1043rbw ui-14l7nz5 ui-zboxd6" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; border-radius: 6px; display: grid; position: relative; border-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); border-style: solid; border-width: 1px; margin-bottom: 1em; margin-top: 1em; overflow: hidden; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" data-native-scrollbar="none" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-gqtt45 ui-193iq5w ui-1us19tq ui-78zum5 ui-14atkfc ui-g7h5cd ui-1q0g3np" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: 100%; min-height: 100%; min-width: 100%; width: auto;">
Scenario | Before fix | After fix
-- | -- | --
User can read seed entity | Lineage returned | Unchanged
Neighbor entity — no ENTITY_READ | Header + relation leaked | Neighbor omitted; relation omitted
Both endpoints readable | Full edge shown | Unchanged

</div></div></div><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Scope:</span><span> </span>1 file changed (<code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-path-filename-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">EntityLineageService.java</span></code>), no REST contract change, no UI changes.</p>


## How was this patch tested?

Manual (primary)
With authorization enabled (Ranger/simple authorizer) and lineage between at least two entities (A → process → B):

Setup

User A — ENTITY_READ on seed entity only
User B — owns upstream/downstream entity B; User A has no read on B
Steps

As User A, fetch lineage on entity A:

curl -u userA:passA \
  "http://<atlas-host>:21000/api/atlas/v2/lineage/{guidA}?direction=BOTH&depth=3"
Before fix: Response guidEntityMap included B; relations included A↔B edge.
After fix: B absent from guidEntityMap; A↔B relation not in relations.

As User A, direct read on B (sanity check):

curl -u userA:passA \
  "http://<atlas-host>:21000/api/atlas/v2/entity/guid/{guidB}/header"
Expected: 403 Forbidden.

As User B (or admin with full read), same lineage call.
Expected: Both entities and relations returned (no regression).

Repeat with direction=INPUT and direction=OUTPUT to confirm filtering in both traversal directions.

Manual (regression)
Authorized user with read on all entities in a lineage chain still gets complete graph.
Seed entity without lineage access still gets 403 at entry (unchanged).
Invalid entity type / non-dataset behavior unchanged.
Unit tests
mvn -pl repository -Dtest=EntityLineageServiceTest test
Existing tests pass (mock-based; no new auth-specific test added in this PR).

Build
mvn -pl repository -am compile -DskipTests
Compiles successfully.