### PR TITLE
ATLAS-5382: Atlas React UI: Upgrade react-router and react-router-dom from v6 to v7

### DIFF
--- a/dashboard/jest.config.js
+++ b/dashboard/jest.config.js
@@ -32,6 +32,7 @@ const config = {
   ],
   
   // Setup files
+  setupFiles: ['<rootDir>/src/setupTests.polyfills.ts'],
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.simple.ts'],
   
   // Module name mapping for path aliases

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -73,6 +73,9 @@
         "typescript-eslint": "8.62.0",
         "vite": "6.4.3"
       },
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@esbuild/darwin-arm64": "0.25.4",
         "@rollup/rollup-darwin-arm64": "4.59.0",

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -73,9 +73,6 @@
         "typescript-eslint": "8.62.0",
         "vite": "6.4.3"
       },
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@esbuild/darwin-arm64": "0.25.4",
         "@rollup/rollup-darwin-arm64": "4.59.0",

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -35,7 +35,8 @@
         "react-querybuilder": "8.0.0",
         "react-quill-new": "3.4.1",
         "react-redux": "9.1.0",
-        "react-router-dom": "6.30.4",
+        "react-router": "7.18.2",
+        "react-router-dom": "7.18.2",
         "react-toastify": "10.0.5",
         "recharts": "2.15.1",
         "sanitize-html": "2.17.4"
@@ -3442,15 +3443,6 @@
         }
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
@@ -5502,6 +5494,19 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -9893,35 +9898,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-smooth": {
@@ -10352,6 +10363,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -53,7 +53,8 @@
     "react-querybuilder": "8.0.0",
     "react-quill-new": "3.4.1",
     "react-redux": "9.1.0",
-    "react-router-dom": "6.30.4",
+    "react-router": "7.18.2",
+    "react-router-dom": "7.18.2",
     "react-toastify": "10.0.5",
     "recharts": "2.15.1",
     "sanitize-html": "2.17.4"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -3,9 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "engines": {
-    "node": ">=20"
-  },
   "scripts": {
     "postinstall": "node scripts/ensure-native-deps.mjs",
     "dev": "vite",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "postinstall": "node scripts/ensure-native-deps.mjs",
     "dev": "vite",

--- a/dashboard/src/setupTests.polyfills.ts
+++ b/dashboard/src/setupTests.polyfills.ts
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TextEncoder, TextDecoder } from 'util';
+
+// Polyfills for Jest jsdom compatibility
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/dashboard/src/setupTests.simple.ts
+++ b/dashboard/src/setupTests.simple.ts
@@ -19,6 +19,11 @@
 
 import '@testing-library/jest-dom';
 
+// Polyfills for Node 12 / Jest jsdom compatibility
+import { TextEncoder, TextDecoder } from 'util';
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;
+
 export {};
 
 

--- a/dashboard/src/setupTests.simple.ts
+++ b/dashboard/src/setupTests.simple.ts
@@ -19,11 +19,6 @@
 
 import '@testing-library/jest-dom';
 
-// Polyfills for Node 12 / Jest jsdom compatibility
-import { TextEncoder, TextDecoder } from 'util';
-(global as any).TextEncoder = TextEncoder;
-(global as any).TextDecoder = TextDecoder;
-
 export {};
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR resolves **ATLAS-5382** by upgrading the `react-router` and `react-router-dom` dependencies in the Atlas React UI (`/dashboard`) from `v6` to the latest `v7`. 

Upgrading to version 7 introduced a known issue with the Jest test environment (`jsdom`), which does not natively expose the `TextEncoder` and `TextDecoder` globals that the modern router relies on, causing the test suite to crash immediately upon importing routing components.

To safely migrate to v7 while keeping the test suite green, this PR includes the following changes:

1. **`package.json` / `package-lock.json`**: Bumped `react-router` and `react-router-dom` to `^7.18.2`.
2. **`jest.config.js` & `src/setupTests.polyfills.ts`**: Created a dedicated pre-test setup file for the `TextEncoder` and `TextDecoder` polyfills (imported from the Node.js native `util` module) and configured it in Jest's `setupFiles` array. This ensures the polyfills run *before* test modules are loaded, properly intercepting `react-router-dom` imports and resolving the crash.
3. **`src/setupTests.simple.ts`**: Kept clean and solely dedicated to post-environment setup (`setupFilesAfterEnv`).

*(Note: There were no code-level deprecations or breaking API changes that affected our React components. All `useNavigate`, `useLocation`, `<Routes>`, and `<Route>` implementations remain fully compatible with v7).*

## How was this patch tested?

**Build & Type Tests:**
* Ran `npm install` and `npm run build` to ensure the TypeScript compiler successfully builds the app without any type errors or API deprecation warnings from the new router version.

**Unit Tests (Resolving the Jest crash):**
* Ran `npm run test` across the entire `/dashboard` directory. 
* Verified that the dedicated `TextEncoder` polyfill runs successfully ahead of component imports, and that all test suites pass, proving identical backwards compatibility with our v6 component usage.

**Manual UI Verification:**
* Started the local Vite dev server and verified that the client-side router functions correctly in the browser. Navigated between main tabs (Administrator, Search, Entities, Lineage) to ensure the URL updates and views render as expected.