### PR TITLE
ATLAS-5380 : Authorize bulk entity headers before returning classifica…

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociator.java
@@ -86,7 +86,13 @@ public class ClassificationAssociator {
 
         private AtlasEntityHeader getEntityHeaderByGuid(String guid) {
             try {
-                return entityRetriever.toAtlasEntityHeaderWithClassifications(guid);
+                AtlasEntityHeader entityHeader = entityRetriever.toAtlasEntityHeaderWithClassifications(guid);
+
+                if (entityHeader == null || !entityRetriever.isEntityReadAllowed(entityHeader)) {
+                    return null;
+                }
+
+                return entityHeader;
             } catch (AtlasBaseException e) {
                 LOG.error("Error fetching entity: {}", guid, e);
             }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/EntityGraphRetriever.java
@@ -20,6 +20,9 @@ package org.apache.atlas.repository.store.graph.v2;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.atlas.AtlasErrorCode;
 import org.apache.atlas.RequestContext;
+import org.apache.atlas.authorize.AtlasAuthorizationUtils;
+import org.apache.atlas.authorize.AtlasEntityAccessRequest;
+import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.model.TimeBoundary;
 import org.apache.atlas.model.glossary.AtlasGlossaryCategory;
@@ -317,6 +320,10 @@ public class EntityGraphRetriever {
         ret.setClassifications(getAllClassifications(entityVertex));
 
         return ret;
+    }
+
+    public boolean isEntityReadAllowed(AtlasEntityHeader entityHeader) {
+        return AtlasAuthorizationUtils.isAccessAllowed(new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entityHeader));
     }
 
     public Map<String, Map<String, Object>> getBusinessMetadata(AtlasVertex entityVertex) throws AtlasBaseException {

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociatorTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/ClassificationAssociatorTest.java
@@ -44,6 +44,7 @@ import static org.apache.atlas.repository.store.graph.v2.ClassificationAssociato
 import static org.apache.atlas.repository.store.graph.v2.ClassificationAssociator.Updater.PROCESS_UPDATE;
 import static org.apache.atlas.repository.store.graph.v2.ClassificationAssociator.Updater.STATUS_DONE;
 import static org.apache.atlas.repository.store.graph.v2.ClassificationAssociator.Updater.STATUS_SKIPPED;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -174,6 +175,7 @@ public class ClassificationAssociatorTest {
             EntityGraphRetriever entityGraphRetriever = mock(EntityGraphRetriever.class);
 
             when(entityGraphRetriever.toAtlasEntityHeaderWithClassifications(TABLE_GUID)).thenReturn(entityHeaderWithClassification);
+            when(entityGraphRetriever.isEntityReadAllowed(any())).thenReturn(true);
 
             ClassificationAssociator.Retriever retriever = new ClassificationAssociator.Retriever(entityGraphRetriever, auditRepository);
 


### PR DESCRIPTION
tions

<p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The bulk entity headers API (<code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">GET /api/atlas/v2/entity/bulk/headers?tagUpdateStartTime=...</code>) returned entity headers including classifications without checking<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">ENTITY_READ</code><span> </span>per entity.</p><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The single-header API (<code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">GET /api/atlas/v2/entity/guid/{guid}/header</code>) already enforces<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">ENTITY_READ</code><span> </span>and returns 403 when access is denied.</p><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">So a user blocked from reading an entity via the single API could still see that entity's metadata (and classifications) through the bulk API — an authorization bypass / information disclosure.</p><h3 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-6f599f ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.214em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h3><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Per review feedback (@mneethiraj), the per-entity read check is centralized in<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">EntityGraphRetriever</code><span> </span>instead of holding<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">AtlasTypeRegistry</code><span> </span>in the retriever:</p><ol class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-1ae8yn7 ui-z80ra4 ui-1nhcn8o ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 10px; margin-top: 10px; padding-left: 2em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">Added<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">EntityGraphRetriever.isEntityReadAllowed(AtlasEntityHeader)</code>, which performs:<div class="composer-message-codeblock" style="margin-bottom: 8px; margin-top: 8px;"><div class="ui-code-block ui-1n2onr6 ui-1j66ri5 ui-14l7nz5 ui-1yf7rl7 ui-t4zf8z ui-zboxd6 ui-j3b58b ui-1vb4fzf ui-14gibnr ui-10a2chs ui-1u51yxl ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-6ikm8r ui-10wlt62 ui-1ua6jya ui-1k89b3v ui-8nuxf3" style="--ui-code-block-copy-overlay-display: none; background-color: rgb(252, 252, 252); position: relative; border-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); border-radius: 8px; border-style: solid; border-width: 1px; margin: 0px; overflow: hidden; min-height: 46px;"><div class="ui-code-block-content ui-1n2onr6" style="position: relative; min-height: 46px;"><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; display: grid; position: relative; overflow: hidden;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" data-native-scrollbar="none" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-1us19tq ui-78zum5 ui-g7h5cd ui-1q0g3np ui-ezivpi ui-gqtt45 ui-1x1rfll" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: none; min-height: 100%; min-width: 100%; width: max-content;"><div class="ui-default-code ui-1wm8ruf ui-1lfj9qp ui-spwq11 ui-1ua6jya ui-1m21r4p ui-cj37ws ui-13r5tfd ui-uve7l6 ui-1xpa7k ui-1rgtt3y ui-1uhho1l ui-o9w7m5 ui-17ewauw ui-1vakzcb ui-105xmc4 ui-1nsav61 ui-1jxofbz ui-947h55 ui-ta7kcf ui-1iagb1a ui-ez8t0j ui-i2wo5x ui-1iq2d2k ui-1qoclnz ui-k609h7 ui-1rqnq8e ui-19gwdp1 ui-1yfyyyg ui-1apie5d ui-dcvkk1 ui-code-block-default-code" style="--shiki-background: transparent; --shiki-foreground: #141414; --shiki-token-attribute: #654DC0; --shiki-token-class: #005293; --shiki-token-comment: #14141499; --shiki-token-constant-variable: #005293; --shiki-token-constant: #005293; --shiki-token-function: #CD4500; --shiki-token-keyword: #A30034; --shiki-token-language-variable: #BE1744; --shiki-token-link: #87c3ff; --shiki-token-parameter: #005293; --shiki-token-property: #654DC0; --shiki-token-punctuation: #005293; --shiki-token-string-expression: #7565CC; --shiki-token-string: #7565CC; --shiki-token-tag: #007041; --shiki-token-type: #005293; --shiki-token-variable: #005293; background-color: transparent; contain: layout style paint; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 12px; font-weight: 400; line-height: 16px; tab-size: 4; padding: 6px 0px; --ui-default-code-tab-size: 4; min-height: 0px; width: max-content; min-width: 100%;"><div class="ui-1pshirs ui-awy1a7" style="contain: layout style; min-width: fit-content;"><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span>AtlasAuthorizationUtils.isAccessAllowed(</span></div></div><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span>    new AtlasEntityAccessRequest(typeRegistry, AtlasPrivilege.ENTITY_READ, entityHeader))</span></div></div></div></div></div></div><div class="ui-scroll-area__scrollbar ui-10l6tqk ui-1n327nk ui-67bb7w ui-1lliihq ui-y36ywk ui-80663w ui-zkb8sy ui-1gncbth ui-17roi93 ui-14atkfc ui-a38mao" data-orientation="horizontal" data-scrollable="true" role="presentation" aria-hidden="true" style="display: block; pointer-events: auto; position: absolute; z-index: 10; inset: auto 1px 1px; height: 6px; width: auto;"><div class="ui-10l6tqk ui-1i4c3av ui-1m4ooaa ui-1kik0b9 ui-19p5jqy ui-gk890x ui-67bb7w ui-oww4n8 ui-1e8aii2 ui-1vaoic9 ui-144st5w ui-1aiz5cx ui-13vifvy ui-wukr4l ui-1ey2m1c ui-u96u03 ui-14atkfc ui-a38mao ui-65nank ui-cbmsab ui-g01cxk ui-4gyw5p ui-gorybd" data-orientation="horizontal" style="border-radius: 9999px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); opacity: 0; pointer-events: auto; position: absolute; transform: translateX(0px); transition-duration: 0.15s, 0.15s; transition-property: background-color, opacity; transition-timing-function: ease, ease; inset: 0px auto 0px 0px; height: 6px; min-height: auto; min-width: 20px; width: 245px;"></div></div></div></div></div></div></li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">Updated<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-path-filename-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">ClassificationAssociator.Retriever</span></code><span> </span>to call<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">entityRetriever.isEntityReadAllowed(entityHeader)</code><span> </span>after loading each header, and<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">skip unauthorized entities</span><span> </span>(omit from the result map).</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">Removed the<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">AtlasTypeRegistry</code><span> </span>member and the local<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">isEntityReadAllowed(...)</code><span> </span>helper (with its<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">typeRegistry == null</code><span> </span>bypass) from<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">Retriever</code>; cleaned up the now-unused constructor and imports.</li></ol><h3 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-6f599f ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.214em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Behavior after fix</h3><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk ui-tr57km ui-14beivq ui-13xjzxd ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-1043rbw ui-14l7nz5 ui-zboxd6" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; border-radius: 6px; display: grid; position: relative; border-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); border-style: solid; border-width: 1px; margin-bottom: 1em; margin-top: 1em; overflow: hidden; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" data-native-scrollbar="none" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-gqtt45 ui-193iq5w ui-1us19tq ui-78zum5 ui-14atkfc ui-g7h5cd ui-1q0g3np" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: 100%; min-height: 100%; min-width: 100%; width: auto;">
API | Unauthorized user
-- | --
GET .../guid/{guid}/header | 403 (unchanged)
GET .../bulk/headers?... | Entity omitted from response (no leak)

</div></div></div><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Authorized users are unaffected — they still get full bulk results.</p><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Scope: 2 main files changed (<code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk ui-s2xxs2 ui-7pq1vu ui-6tor67 ui-1ypdohk ui-l1v4ol ui-1sur9pj md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(0, 100, 176); cursor: pointer; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; transition-duration: 0.1s; transition-property: background-color, color; transition-timing-function: ease-out; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">ClassificationAssociator.java</span></code>,<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk ui-s2xxs2 ui-7pq1vu ui-6tor67 ui-1ypdohk ui-l1v4ol ui-1sur9pj md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(0, 100, 176); cursor: pointer; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; transition-duration: 0.1s; transition-property: background-color, color; transition-timing-function: ease-out; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">EntityGraphRetriever.java</span></code>) + test; no REST contract change, no UI changes.</p><h2 class="ui-markdown__heading ui-13ebx5f ui-x6cpbe ui-14l7nz5 ui-zboxd6 ui-1pz8kdr ui-1x419k1 ui-1qaq26d" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; font-size: 1.318em; font-weight: 590; line-height: 1.42; margin-bottom: 0.35em; margin-top: 0.9em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">How was this patch tested?</h2><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Unit tests</span><span> </span>—<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">ClassificationAssociatorTest</code><span> </span>(7/7 pass), including a new case asserting the fix:</p><ul class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-1ae8yn7 ui-z80ra4 ui-1nhcn8o ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 10px; margin-top: 10px; padding-left: 2em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">auditScanYieldsOneEntity_ButNotAuthorized_EntityFilteredOut</code><span> </span>→ entity is<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">omitted</span><span> </span>when<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">isEntityReadAllowed</code><span> </span>returns false.</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;"><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-variable-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">auditScanYieldsOneEntity_EntityHeadersHasOneElementWithClassification</code><span> </span>→ entity still returned when authorized (no regression).</li></ul><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; margin-top: 8px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block ui-1n2onr6 ui-1j66ri5 ui-14l7nz5 ui-1yf7rl7 ui-t4zf8z ui-zboxd6 ui-j3b58b ui-1vb4fzf ui-14gibnr ui-10a2chs ui-1u51yxl ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-6ikm8r ui-10wlt62 ui-1ua6jya ui-1k89b3v ui-8nuxf3" style="--ui-code-block-copy-overlay-display: none; background-color: rgb(252, 252, 252); position: relative; border-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); border-radius: 8px; border-style: solid; border-width: 1px; margin: 0px; overflow: hidden; min-height: 26px;"><div class="ui-code-block-content ui-1n2onr6" style="position: relative; min-height: 26px;"><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; display: grid; position: relative; overflow: hidden;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" data-native-scrollbar="none" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-1us19tq ui-78zum5 ui-g7h5cd ui-1q0g3np ui-ezivpi ui-gqtt45 ui-1x1rfll" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: none; min-height: 100%; min-width: 100%; width: max-content;"><div class="ui-default-code ui-1wm8ruf ui-1lfj9qp ui-spwq11 ui-1ua6jya ui-1m21r4p ui-cj37ws ui-13r5tfd ui-uve7l6 ui-1xpa7k ui-1rgtt3y ui-1uhho1l ui-o9w7m5 ui-17ewauw ui-1vakzcb ui-105xmc4 ui-1nsav61 ui-1jxofbz ui-947h55 ui-ta7kcf ui-1iagb1a ui-ez8t0j ui-i2wo5x ui-1iq2d2k ui-1qoclnz ui-k609h7 ui-1rqnq8e ui-19gwdp1 ui-1yfyyyg ui-1apie5d ui-dcvkk1 ui-code-block-default-code" style="--shiki-background: transparent; --shiki-foreground: #141414; --shiki-token-attribute: #654DC0; --shiki-token-class: #005293; --shiki-token-comment: #14141499; --shiki-token-constant-variable: #005293; --shiki-token-constant: #005293; --shiki-token-function: #CD4500; --shiki-token-keyword: #A30034; --shiki-token-language-variable: #BE1744; --shiki-token-link: #87c3ff; --shiki-token-parameter: #005293; --shiki-token-property: #654DC0; --shiki-token-punctuation: #005293; --shiki-token-string-expression: #7565CC; --shiki-token-string: #7565CC; --shiki-token-tag: #007041; --shiki-token-type: #005293; --shiki-token-variable: #005293; background-color: transparent; contain: layout style paint; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 12px; font-weight: 400; line-height: 16px; tab-size: 4; padding: 6px 0px; --ui-default-code-tab-size: 4; min-height: 0px; width: max-content; min-width: 100%;"><div class="ui-1pshirs ui-awy1a7" style="contain: layout style; min-width: fit-content;"><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span>mvn -pl repository -Dtest=ClassificationAssociatorTest test</span></div></div></div></div></div></div><div class="ui-scroll-area__scrollbar ui-10l6tqk ui-1n327nk ui-67bb7w ui-1lliihq ui-y36ywk ui-80663w ui-zkb8sy ui-1gncbth ui-17roi93 ui-14atkfc ui-a38mao" data-orientation="horizontal" data-scrollable="true" role="presentation" aria-hidden="true" style="display: block; pointer-events: auto; position: absolute; z-index: 10; inset: auto 1px 1px; height: 6px; width: auto;"><div class="ui-10l6tqk ui-1i4c3av ui-1m4ooaa ui-1kik0b9 ui-19p5jqy ui-gk890x ui-67bb7w ui-oww4n8 ui-1e8aii2 ui-1vaoic9 ui-144st5w ui-1aiz5cx ui-13vifvy ui-wukr4l ui-1ey2m1c ui-u96u03 ui-14atkfc ui-a38mao ui-65nank ui-cbmsab ui-g01cxk ui-4gyw5p ui-gorybd" data-orientation="horizontal" style="border-radius: 9999px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); opacity: 0; pointer-events: auto; position: absolute; transform: translateX(0px); transition-duration: 0.15s, 0.15s; transition-property: background-color, opacity; transition-timing-function: ease, ease; inset: 0px auto 0px 0px; height: 6px; min-height: auto; min-width: 20px; width: 420px;"></div></div></div></div></div></div><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Reporter's PoC re-run against the patched build</span><span> </span>(<code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk md-inline-path-filename-like" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;"><span class="ui-markdown__inline-path-filename ui-1heor9g md-inline-path-filename" style="color: inherit;">atlas-repository-3.0.0-SNAPSHOT</span></code>):</p><ul class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-1ae8yn7 ui-z80ra4 ui-1nhcn8o ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 10px; margin-top: 10px; padding-left: 2em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">The behavioral test that previously returned both tag-changed entities with their classifications to an unauthorized principal now returns an<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">empty</span><span> </span>header set — the disclosure is no longer reproducible.</li></ul><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Manual, with authorization enabled</span><span> </span>(User A with access, User B without<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">ENTITY_READ</code><span> </span>on a target entity):</p><ul class="ui-markdown__list ui-78zum5 ui-dt5ytf ui-1ae8yn7 ui-z80ra4 ui-1nhcn8o ui-j7cesy ui-1bae07f" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; gap: 6px; display: flex; flex-direction: column; margin-bottom: 10px; margin-top: 10px; padding-left: 2em; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">User A creates an entity and adds a classification.</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">User B calls<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">GET .../guid/{guid}/header</code><span> </span>→ 403 ✓</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">User B calls<span> </span><code class="ui-markdown__inline-code ui-rtu7ee ui-1i9v5mb ui-1hhlpkd ui-6lrnw6 ui-115g5cq ui-odjx36 ui-1wd3ewq ui-hayvgc ui-eb7xqv ui-37zpob ui-1lldw8n ui-1mzt3pk" style="border-radius: 5px; background-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); color: rgb(20, 20, 20); font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; line-height: 1.4; overflow-wrap: break-word; word-break: normal; padding: 1.5px 2px;">GET .../bulk/headers?tagUpdateStartTime={beforeChange}</code><span> </span>→ GUID not in response ✓</li><li class="ui-markdown__list-item ui--default-marker ui-exx8yu ui-1xpa7k ui-18d9i69 ui-1uhho1l ui-13faqbe ui-ez2fb" data-md-list-item="" style="word-break: break-word; padding: 0px;">User A calls same bulk API → entity returned with classifications ✓ (no regression)</li></ul><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Build</span></p><div class="composer-message-codeblock" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 8px; margin-top: 8px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-code-block ui-1n2onr6 ui-1j66ri5 ui-14l7nz5 ui-1yf7rl7 ui-t4zf8z ui-zboxd6 ui-j3b58b ui-1vb4fzf ui-14gibnr ui-10a2chs ui-1u51yxl ui-178xt8z ui-13fuv20 ui-1aeic0j ui-s1s249 ui-32b0ac ui-141kqco ui-so031l ui-1q0q8m5 ui-17fyfba ui-e0pwq ui-19ypqd9 ui-1arpupx ui-6ikm8r ui-10wlt62 ui-1ua6jya ui-1k89b3v ui-8nuxf3" style="--ui-code-block-copy-overlay-display: none; background-color: rgb(252, 252, 252); position: relative; border-color: color(srgb 0.0784314 0.0784314 0.0784314 / 0.08); border-radius: 8px; border-style: solid; border-width: 1px; margin: 0px; overflow: hidden; min-height: 26px;"><div class="ui-code-block-content ui-1n2onr6" style="position: relative; min-height: 26px;"><div class="ui-scroll-area ui-1ekbvf6 ui-1logqu4 ui-1fx8caa ui-8ddqcf ui-1n2onr6 ui-6ikm8r ui-10wlt62 ui-rvj5dj ui-ypqxfk" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--scroll-area-scroll-padding: 4px; --scrollbar-inset: 1px; --scrollbar-size: 6px; --scrollbar-thumb-top-offset: 6px; grid-template: 1fr / 1fr; display: grid; position: relative; overflow: hidden;"><div class="ui-scroll-area__viewport ui-175mniq ui-2lwn1j ui-mz0i5r ui-1pjcqnp ui-1rohswg ui-6ehuon ui-fk6m8 ui-w2csxc ui-10wlt62 ui-k8sdt9 ui-1duton ui-101ixbw ui-exgr1p ui-7p5m3t ui-y5w88m" data-native-scrollbar="none" style="grid-area: 1 / 1; border-radius: inherit; scrollbar-width: none; max-height: 100%; min-height: 0px; overflow: auto hidden; overscroll-behavior: contain auto; scroll-padding: 0px 4px;"><div class="ui-scroll-area__content ui-9f619 ui-1us19tq ui-78zum5 ui-g7h5cd ui-1q0g3np ui-ezivpi ui-gqtt45 ui-1x1rfll" style="box-sizing: border-box; display: flex; flex-direction: row; height: fit-content; max-width: none; min-height: 100%; min-width: 100%; width: max-content;"><div class="ui-default-code ui-1wm8ruf ui-1lfj9qp ui-spwq11 ui-1ua6jya ui-1m21r4p ui-cj37ws ui-13r5tfd ui-uve7l6 ui-1xpa7k ui-1rgtt3y ui-1uhho1l ui-o9w7m5 ui-17ewauw ui-1vakzcb ui-105xmc4 ui-1nsav61 ui-1jxofbz ui-947h55 ui-ta7kcf ui-1iagb1a ui-ez8t0j ui-i2wo5x ui-1iq2d2k ui-1qoclnz ui-k609h7 ui-1rqnq8e ui-19gwdp1 ui-1yfyyyg ui-1apie5d ui-dcvkk1 ui-code-block-default-code" style="--shiki-background: transparent; --shiki-foreground: #141414; --shiki-token-attribute: #654DC0; --shiki-token-class: #005293; --shiki-token-comment: #14141499; --shiki-token-constant-variable: #005293; --shiki-token-constant: #005293; --shiki-token-function: #CD4500; --shiki-token-keyword: #A30034; --shiki-token-language-variable: #BE1744; --shiki-token-link: #87c3ff; --shiki-token-parameter: #005293; --shiki-token-property: #654DC0; --shiki-token-punctuation: #005293; --shiki-token-string-expression: #7565CC; --shiki-token-string: #7565CC; --shiki-token-tag: #007041; --shiki-token-type: #005293; --shiki-token-variable: #005293; background-color: transparent; contain: layout style paint; font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 12px; font-weight: 400; line-height: 16px; tab-size: 4; padding: 6px 0px; --ui-default-code-tab-size: 4; min-height: 0px; width: max-content; min-width: 100%;"><div class="ui-1pshirs ui-awy1a7" style="contain: layout style; min-width: fit-content;"><div class="ui-78zum5 ui-1f4zecs" style="display: flex; min-height: 20px;"><div class="ui-default-code__line-content ui-98rzlu ui-1sdyfia ui-b3r6kr ui-lyipyv ui-1k9ch0o ui-lgbajd ui-1yxiud8 ui-1n2onr6" style="flex: 1 1 0%; overflow: hidden; color: rgb(20, 20, 20); position: relative; text-overflow: ellipsis; white-space: pre; padding-left: 6px; padding-right: 8px;"><span>mvn -pl repository -am compile -DskipTests</span></div></div></div></div></div></div></div></div></div></div><p class="ui-markdown__paragraph ui-z80ra4 ui-uu7i3w ui-1nhcn8o ui-j7cesy ui-13faqbe ui-14l7nz5 ui-zboxd6" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; word-break: break-word; margin-bottom: 10px; margin-top: 10px; color: rgb(20, 20, 20); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(252, 252, 252); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Compiles successfully.</p><br class="Apple-interchange-newline">