### PR TITLE
ATLAS-5376: Atlas UI: Relationship cards layout breaking, overlapping, and tooltip placement issues with long entity names (React & Classic UI)

### DIFF
--- a/dashboard/src/styles/detailPage.scss
+++ b/dashboard/src/styles/detailPage.scss
@@ -592,3 +592,11 @@ pre.code-block .json-string {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.text-active {
+  color: #1976d2 !important;
+}
+
+.text-deleted {
+  color: #BB5838 !important;
+}

--- a/dashboard/src/styles/detailPage.scss
+++ b/dashboard/src/styles/detailPage.scss
@@ -189,7 +189,7 @@ pre.code-block .json-string {
   flex-direction: column;
   gap: 12px;
   min-width: 280px;
-  flex: 0 0 auto;
+  flex: 1 1 0;
 }
 
 @media (max-width: 599px) {
@@ -216,6 +216,9 @@ pre.code-block .json-string {
   background-color: #ffffff;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
   min-height: 80px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .relationship-card__header {
@@ -296,6 +299,7 @@ pre.code-block .json-string {
 .relationship-card__content {
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 .relationship-card__search {
@@ -330,15 +334,18 @@ pre.code-block .json-string {
 
 .relationship-card__item {
   font-size: 0.875rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   line-height: 1.5;
 }
 
 .relationship-card__link {
   color: #2563eb;
   text-decoration: none;
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
 }
 
 .relationship-card__link:hover {
@@ -356,6 +363,12 @@ pre.code-block .json-string {
 
 .relationship-card__text {
   color: #334155;
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
 }
 
 .relationship-card__empty {
@@ -571,4 +584,11 @@ pre.code-block .json-string {
   display: inline-block !important;
   cursor: pointer !important;
   margin-left: 6px !important;
+}
+
+.relationship-node-link {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/RelationshipLineage.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/RelationshipLineage.tsx
@@ -51,7 +51,6 @@ import { Link as MUILink } from "@mui/material";
 interface CustomLinkProps {
   href: string;
   status: string;
-  entityColor: string;
   guid: string;
   name: string;
   typeName: string;
@@ -61,13 +60,12 @@ interface CustomLinkProps {
 const CustomLink = ({
   href,
   status,
-  entityColor,
   guid,
   name,
   typeName,
   params
 }: CustomLinkProps): JSX.Element => {
-  const displayLabel = `${name} (${typeName})`;
+  const displayLabel = typeName ? `${name} (${typeName})` : name;
   return (
     <li className={status}>
       <LightTooltip title={displayLabel}>
@@ -77,7 +75,7 @@ const CustomLink = ({
             pathname: href,
             search: params.toString() ? params.toString() : ""
           }}
-          className={`relationship-node-link ${entityColor === "#1976d2" ? "text-blue" : "text-red"}`}
+          className={`relationship-node-link ${status.includes("deleted-relation") ? "text-deleted" : "text-active"}`}
           replace={true}
           underline="hover"
         >
@@ -93,8 +91,8 @@ const RelationshipLineage = ({
   relationshipAttributes,
   isLoading
 }: {
-  entity: Record<string, any>;
-  relationshipAttributes?: Record<string, any[]>;
+  entity: Record<string, unknown>;
+  relationshipAttributes?: Record<string, unknown[]>;
   isLoading?: boolean;
 }) => {
   const entityData = cloneDeep(entity);
@@ -109,13 +107,13 @@ const RelationshipLineage = ({
   const zoomOutButtonRef = useRef(null);
   const relationshipSVG = useRef(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [nodeDetails, setNodeDetails] = useState<any>({});
+  const [nodeDetails, setNodeDetails] = useState<Record<string, unknown>>({});
   const [searchTerm, setSearchTerm] = useState("");
   const [zoomId, setZoomId] = useState("");
 
-  const createData = (entityData: Record<string, any>) => {
+  const createData = (entityData: Record<string, unknown>) => {
     let links = [];
-    let nodes: Record<string, any> = {};
+    let nodes: Record<string, unknown> = {};
     if (entityData && entityData.relationshipAttributes) {
       for (const obj in entityData.relationshipAttributes) {
         if (!isEmpty(entityData.relationshipAttributes[obj])) {
@@ -201,7 +199,7 @@ const RelationshipLineage = ({
 
     var forceLink = d3
       .forceLink()
-      .id(function (d: any) {
+      .id(function (d: Record<string, unknown>) {
         return d.id;
       })
       .distance(function (d) {
@@ -266,7 +264,7 @@ const RelationshipLineage = ({
           d.radius = 25;
           return d.radius;
         })
-        .attr("fill", function (d: any) {
+        .attr("fill", function (d: Record<string, unknown>) {
           if (d && d.value && d.value.guid == guid) {
             if (isAllEntityRelationDeleted({ data: d, type: "node" })) {
               return deletedEntityColor;
@@ -486,7 +484,6 @@ const RelationshipLineage = ({
           ? " deleted-relation"
           : "";
         let nodeGuid = options.guid;
-        let entityColor = obj.color;
         let name = obj.name;
         let typeName = options.typeName;
         let keys = Array.from(searchParams.keys());
@@ -505,7 +502,6 @@ const RelationshipLineage = ({
             <CustomLink
               href={tempLink}
               status={status}
-              entityColor={entityColor}
               guid={nodeGuid}
               name={name}
               typeName={typeName}
@@ -518,7 +514,6 @@ const RelationshipLineage = ({
             <CustomLink
               href={`/detailPage/${nodeGuid}`}
               status={status}
-              entityColor={entityColor}
               guid={nodeGuid}
               name={name}
               typeName={typeName}
@@ -533,7 +528,6 @@ const RelationshipLineage = ({
         let status = entityStateReadOnly[entityStatus]
           ? " deleted-relation"
           : "";
-        let entityColor = obj.color;
         let name = obj.name;
 
         if (obj.relationship) {
@@ -541,14 +535,14 @@ const RelationshipLineage = ({
             ? "deleted-relation"
             : "";
         }
-        const displayLabel = `${name} (${options.typeName})`;
+        const displayLabel = options.typeName ? `${name} (${options.typeName})` : name;
         return (
           <li className={status}>
             <LightTooltip title={displayLabel}>
               <MUILink
                 component={RouterLink}
                 to={`/detailPage/${options.guid}?tabActive=relationship`}
-                className={`relationship-node-link ${entityColor === "#1976d2" ? "text-blue" : "text-red"}`}
+                className={`relationship-node-link ${status.includes("deleted-relation") ? "text-deleted" : "text-active"}`}
               >
                 {displayLabel}
               </MUILink>

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/RelationshipLineage.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/RelationshipLineage.tsx
@@ -15,11 +15,8 @@
  * limitations under the License.
  */
 
-// @ts-nocheck
-
 import {
   Button,
-  Chip,
   CircularProgress,
   IconButton,
   InputBase,
@@ -45,7 +42,6 @@ import {
 } from "@mui/icons-material";
 import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
 import { CloseIcon, LightTooltip } from "@components/muiComponents";
-import { useAppSelector } from "@hooks/reducerHook";
 import { Link as MUILink } from "@mui/material";
 
 interface CustomLinkProps {
@@ -67,24 +63,44 @@ const CustomLink = ({
 }: CustomLinkProps): JSX.Element => {
   const displayLabel = typeName ? `${name} (${typeName})` : name;
   return (
-    <li className={status}>
+    <li className={status} data-guid={guid}>
       <LightTooltip title={displayLabel}>
-        <MUILink
-          component={RouterLink}
-          to={{
-            pathname: href,
-            search: params.toString() ? params.toString() : ""
-          }}
-          className={`relationship-node-link ${status.includes("deleted-relation") ? "text-deleted" : "text-active"}`}
-          replace={true}
-          underline="hover"
-        >
-          {displayLabel}
-        </MUILink>
+        <span>
+          <MUILink
+            component={RouterLink}
+            to={{
+              pathname: href,
+              search: params.toString() ? params.toString() : ""
+            }}
+            className={`relationship-node-link ${status.includes("deleted-relation") ? "text-deleted" : "text-active"}`}
+            replace={true}
+            underline="hover"
+            data-testid={`relationship-link-${guid}`}
+          >
+            {displayLabel}
+          </MUILink>
+        </span>
       </LightTooltip>
     </li>
   );
 };
+
+interface GraphNode {
+  name: string;
+  value: unknown;
+  radius?: number;
+  id?: string;
+  x?: number;
+  y?: number;
+  fx?: number | null;
+  fy?: number | null;
+}
+
+interface GraphLink {
+  source: GraphNode | string;
+  target: GraphNode | string;
+  value: unknown;
+}
 
 const RelationshipLineage = ({
   entity,
@@ -109,11 +125,10 @@ const RelationshipLineage = ({
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [nodeDetails, setNodeDetails] = useState<Record<string, unknown>>({});
   const [searchTerm, setSearchTerm] = useState("");
-  const [zoomId, setZoomId] = useState("");
 
   const createData = (entityData: Record<string, unknown>) => {
-    let links = [];
-    let nodes: Record<string, unknown> = {};
+    let links: GraphLink[] = [];
+    let nodes: Record<string, GraphNode> = {};
     if (entityData && entityData.relationshipAttributes) {
       for (const obj in entityData.relationshipAttributes) {
         if (!isEmpty(entityData.relationshipAttributes[obj])) {
@@ -141,10 +156,10 @@ const RelationshipLineage = ({
   };
 
   const graphData = useMemo(() => createData(entityData), [entityData]);
-  const createGraph = (data) => {
+  const createGraph = (data: { nodes: Record<string, GraphNode>; links: GraphLink[] }) => {
     // Use getBoundingClientRect to get the actual width and height
     const svgElement = svgRef?.current;
-    const rect = svgElement ? svgElement.getBoundingClientRect() : null;
+    const rect = svgElement ? (svgElement as Element).getBoundingClientRect() : null;
     const width = rect ? rect.width : 0;
     const height = rect ? rect.height : 0;
     const padding = 60;
@@ -154,15 +169,14 @@ const RelationshipLineage = ({
 
     var activeEntityColor = "#00b98b",
       deletedEntityColor = "#BB5838",
-      defaultEntityColor = "#e0e0e0",
       selectedNodeColor = "#4a90e2";
 
     var svg = d3
-      .select(svgElement)
+      .select(svgElement as Element)
       .attr("viewBox", `${-padding} ${-padding} ${width + padding * 2} ${height + padding * 2}`)
       .attr("enable-background", `new ${-padding} ${-padding} ${width + padding * 2} ${height + padding * 2}`),
-      node,
-      path;
+      node: d3.Selection<d3.BaseType, unknown, SVGElement, unknown>,
+      path: d3.Selection<d3.BaseType, unknown, SVGElement, unknown>;
 
     var container = svg
       .append("g")
@@ -173,7 +187,7 @@ const RelationshipLineage = ({
       .zoom()
       .scaleExtent([0.1, 4])
       .on("zoom", function () {
-        container.attr("transform", d3.event.transform);
+        container.attr("transform", (d3.event as { transform: string }).transform);
       });
     svg.call(zoom).on("dblclick.zoom", null);
 
@@ -192,7 +206,7 @@ const RelationshipLineage = ({
       .attr("markerHeight", 6)
       .append("svg:path")
       .attr("d", "M 0,-5 L 10 ,0 L 0,5")
-      .attr("fill", function (d) {
+      .attr("fill", function (d: string) {
         return d == "deletedLink" ? deletedEntityColor : activeEntityColor;
       })
       .style("stroke", "none");
@@ -200,9 +214,9 @@ const RelationshipLineage = ({
     var forceLink = d3
       .forceLink()
       .id(function (d: Record<string, unknown>) {
-        return d.id;
+        return (d as { id?: string }).id || "";
       })
-      .distance(function (d) {
+      .distance(function () {
         return 100;
       })
       .strength(1);
@@ -222,10 +236,10 @@ const RelationshipLineage = ({
         .enter()
         .append("svg:path")
         .attr("class", "relationship-link")
-        .attr("stroke", function (d) {
+        .attr("stroke", function (d: GraphLink) {
           return getPathColor({ data: d, type: "path" });
         })
-        .attr("marker-end", function (d) {
+        .attr("marker-end", function (d: GraphLink) {
           return (
             "url(#" +
             (isAllEntityRelationDeleted({ data: d })
@@ -242,15 +256,15 @@ const RelationshipLineage = ({
         .append("g")
         .attr("class", "node")
         .on("mousedown", function () {
-          d3.event.preventDefault();
+          (d3.event as { preventDefault: () => void }).preventDefault();
         })
-        .on("click", function (d) {
-          if (d3.event.defaultPrevented) return; // ignore drag
-          if (d && d.value && d.value.guid == guid) {
+        .on("click", function (d: GraphNode) {
+          if ((d3.event as { defaultPrevented?: boolean }).defaultPrevented) return; // ignore drag
+          if (d && (d.value as { guid?: string })?.guid == guid) {
             return;
           }
           setDrawerOpen(true);
-          setNodeDetails(d);
+          setNodeDetails(d as unknown as Record<string, unknown>);
         })
         .call(d3.drag().on("start", dragstarted).on("drag", dragged));
 
@@ -260,12 +274,12 @@ const RelationshipLineage = ({
         .append("circle")
         .attr("cx", 0)
         .attr("cy", 0)
-        .attr("r", function (d) {
+        .attr("r", function (d: GraphNode) {
           d.radius = 25;
           return d.radius;
         })
-        .attr("fill", function (d: Record<string, unknown>) {
-          if (d && d.value && d.value.guid == guid) {
+        .attr("fill", function (d: GraphNode) {
+          if (d && (d.value as { guid?: string })?.guid == guid) {
             if (isAllEntityRelationDeleted({ data: d, type: "node" })) {
               return deletedEntityColor;
             } else {
@@ -277,7 +291,7 @@ const RelationshipLineage = ({
             return activeEntityColor;
           }
         })
-        .attr("typename", function (d) {
+        .attr("typename", function (d: GraphNode) {
           return d.name;
         });
 
@@ -288,22 +302,22 @@ const RelationshipLineage = ({
         .attr("dy", 25 - 17)
         .attr("text-anchor", "middle")
         .style("font-family", "FontAwesome")
-        .style("font-size", function (d) {
+        .style("font-size", function () {
           return "25px";
         })
-        .text(function (d) {
-          var iconObj = graphIcon[d.name];
+        .text(function (d: GraphNode) {
+          var iconObj = graphIcon[d.name as keyof typeof graphIcon];
           if (iconObj && iconObj.textContent) {
             return iconObj.textContent;
           } else {
-            if (d && isArray(d.value) && d.value.length > 1) {
+            if (d && isArray(d.value) && (d.value as unknown[]).length > 1) {
               return "\uf0c5";
             } else {
               return "\uf016";
             }
           }
         })
-        .attr("fill", function (d) {
+        .attr("fill", function () {
           return "#fff";
         });
 
@@ -313,8 +327,8 @@ const RelationshipLineage = ({
         .append("circle")
         .attr("cx", 22)
         .attr("cy", 32)
-        .attr("r", function (d) {
-          if (isArray(d.value) && d.value.length > 1) {
+        .attr("r", function (d: GraphNode) {
+          if (isArray(d.value) && (d.value as unknown[]).length > 1) {
             return 12;
           }
         })
@@ -331,9 +345,9 @@ const RelationshipLineage = ({
         .attr("fill", "#fff")
         .style("font-size", "11px")
         .style("font-weight", "600")
-        .text(function (d) {
-          if (isArray(d.value) && d.value.length > 1) {
-            return d.value.length;
+        .text(function (d: GraphNode) {
+          if (isArray(d.value) && (d.value as unknown[]).length > 1) {
+            return (d.value as unknown[]).length;
           }
         });
 
@@ -341,17 +355,17 @@ const RelationshipLineage = ({
         .append("text")
         .attr("x", -15)
         .attr("y", "35")
-        .text(function (d) {
+        .text(function (d: GraphNode) {
           return d.name;
         });
 
-      simulation.nodes(nodes).on("tick", ticked);
+      simulation.nodes(nodes as unknown as d3.SimulationNodeDatum[]).on("tick", ticked);
 
-      simulation.force("link").links(links);
+      (simulation.force("link") as d3.ForceLink<d3.SimulationNodeDatum, d3.SimulationLinkDatum<d3.SimulationNodeDatum>>)?.links(links as unknown as d3.SimulationLinkDatum<d3.SimulationNodeDatum>[]);
     }
 
     function ticked() {
-      path.attr("d", function (d) {
+      path.attr("d", function (d: { source: { x: number; y: number }; target: { x: number; y: number; radius: number } }) {
         var diffX = d.target.x - d.source.x,
           diffY = d.target.y - d.source.y,
           // Length of path from center of source node to center of target node
@@ -376,43 +390,43 @@ const RelationshipLineage = ({
         );
       });
 
-      node.attr("transform", function (d) {
+      node.attr("transform", function (d: { x: number; y: number }) {
         return "translate(" + d.x + "," + d.y + ")";
       });
     }
 
-    function dragstarted(d) {
-      d3.event.sourceEvent.stopPropagation();
-      if (d && d.value && d.value.guid != guid) {
-        if (!d3.event.active) simulation.alphaTarget(0.3).restart();
+    function dragstarted(d: GraphNode) {
+      ((d3.event as { sourceEvent?: { stopPropagation: () => void } }).sourceEvent)?.stopPropagation();
+      if (d && (d.value as { guid?: string })?.guid != guid) {
+        if (!(d3.event as { active?: boolean }).active) simulation.alphaTarget(0.3).restart();
         d.fx = d.x;
         d.fy = d.y;
       }
     }
 
-    function dragged(d) {
-      if (d && d.value && d.value.guid != guid) {
-        d.fx = d3.event.x;
-        d.fy = d3.event.y;
+    function dragged(d: GraphNode) {
+      if (d && (d.value as { guid?: string })?.guid != guid) {
+        d.fx = (d3.event as { x: number }).x;
+        d.fy = (d3.event as { y: number }).y;
       }
     }
 
-    function getPathColor(options) {
+    function getPathColor(options: { data: GraphLink; type?: string }) {
       return isAllEntityRelationDeleted(options)
         ? deletedEntityColor
         : activeEntityColor;
     }
 
-    function isAllEntityRelationDeleted(options) {
+    function isAllEntityRelationDeleted(options: { data: GraphLink | GraphNode; type?: string }) {
       let data = options.data;
       let type = options.type;
-      let d = extend(true, {}, data);
+      let d = extend(true, {}, data) as { value?: unknown };
       if (d && !isArray(d.value)) {
         d.value = [d.value];
       }
 
       return (
-        d.value.findIndex(function (val) {
+        (d.value as Record<string, unknown>[]).findIndex(function (val: Record<string, unknown>) {
           if (type == "node") {
             return (val.entityStatus || val.status) == "ACTIVE";
           } else {
@@ -446,7 +460,7 @@ const RelationshipLineage = ({
     if (!isEmpty(graphData.links)) {
       try {
         createGraph(graphData);
-      } catch (err) {
+      } catch (err: unknown) {
         // Swallow D3 errors to avoid breaking render
       }
     }
@@ -468,24 +482,24 @@ const RelationshipLineage = ({
     return <Typography>No relationship data found</Typography>;
   }
 
-  const updateRelationshipDetails = (options) => {
-    let data = options.obj.value;
-    let typeName = data.typeName || options.obj.name;
+  const updateRelationshipDetails = (options: { obj: Record<string, unknown>; searchString?: string }) => {
+    let data = (options.obj.value as Record<string, unknown>) || options.obj;
+    let typeName = (data.typeName as string) || (options.obj.name as string);
     let searchString = options.searchString;
     let listString = [];
-    const getEntityTypelist = (options) => {
+    const getEntityTypelist = (options: Record<string, unknown>) => {
       let activeEntityColor = "#1976d2";
       let deletedEntityColor = "#BB5838";
-      const entityStatus = options.entityStatus || options.status;
-      const relationshipStatus = options.relationshipStatus || options.status;
-      const getdefault = (obj) => {
+      const entityStatus = (options.entityStatus || options.status) as string;
+      const relationshipStatus = (options.relationshipStatus || options.status) as string;
+      const getdefault = (obj: { options: Record<string, unknown>; name?: string }) => {
         let options = obj.options;
-        let status = entityStateReadOnly[entityStatus]
+        let status = entityStateReadOnly[entityStatus as keyof typeof entityStateReadOnly]
           ? " deleted-relation"
           : "";
-        let nodeGuid = options.guid;
+        let nodeGuid = options.guid as string;
         let name = obj.name;
-        let typeName = options.typeName;
+        let typeName = options.typeName as string;
         let keys = Array.from(searchParams.keys());
         for (let i = 0; i < keys.length; i++) {
           if (keys[i] != "searchType") {
@@ -503,7 +517,7 @@ const RelationshipLineage = ({
               href={tempLink}
               status={status}
               guid={nodeGuid}
-              name={name}
+              name={name || ""}
               typeName={typeName}
               params={searchParams}
             />
@@ -515,7 +529,7 @@ const RelationshipLineage = ({
               href={`/detailPage/${nodeGuid}`}
               status={status}
               guid={nodeGuid}
-              name={name}
+              name={name || ""}
               typeName={typeName}
               // params={"searchParams"}
               params={""}
@@ -523,36 +537,38 @@ const RelationshipLineage = ({
           );
         }
       };
-      const getWithButton = (obj) => {
+      const getWithButton = (obj: { options: Record<string, unknown>; name?: string; relationship?: boolean; entity?: boolean }) => {
         let options = obj.options;
-        let status = entityStateReadOnly[entityStatus]
+        let status = entityStateReadOnly[entityStatus as keyof typeof entityStateReadOnly]
           ? " deleted-relation"
           : "";
         let name = obj.name;
 
         if (obj.relationship) {
-          status = entityStateReadOnly[relationshipStatus]
+          status = entityStateReadOnly[relationshipStatus as keyof typeof entityStateReadOnly]
             ? "deleted-relation"
             : "";
         }
         const displayLabel = options.typeName ? `${name} (${options.typeName})` : name;
         return (
           <li className={status}>
-            <LightTooltip title={displayLabel}>
-              <MUILink
-                component={RouterLink}
-                to={`/detailPage/${options.guid}?tabActive=relationship`}
-                className={`relationship-node-link ${status.includes("deleted-relation") ? "text-deleted" : "text-active"}`}
-              >
-                {displayLabel}
-              </MUILink>
+            <LightTooltip title={displayLabel || ""}>
+              <span>
+                <MUILink
+                  component={RouterLink}
+                  to={`/detailPage/${options.guid}?tabActive=relationship`}
+                  className={`relationship-node-link ${status.includes("deleted-relation") ? "text-deleted" : "text-active"}`}
+                >
+                  {displayLabel}
+                </MUILink>
+              </span>
             </LightTooltip>
           </li>
         );
       };
 
       const name = options.entityName
-        ? options.entityName
+        ? (options.entityName as string)
         : extractKeyValueFromEntity(options, "displayText").name;
       if (entityStatus === "ACTIVE") {
         if (relationshipStatus === "ACTIVE") {
@@ -585,10 +601,7 @@ const RelationshipLineage = ({
       }
     };
 
-    var getElement = function (options) {
-      const name = options.entityName
-        ? options.entityName
-        : extractKeyValueFromEntity(options, "displayText").name;
+    var getElement = function (options: Record<string, unknown>) {
       return getEntityTypelist(options);
     };
     if (isArray(data)) {
@@ -765,7 +778,7 @@ const RelationshipLineage = ({
                     flex={1}
                     fontWeight="600"
                   >
-                    {nodeDetails?.name}
+                    {String(nodeDetails?.name || "")}
                   </Typography>
                   <Button
                     onClick={() => setDrawerOpen(false)}

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/RelationshipLineage.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/RelationshipLineage.tsx
@@ -48,6 +48,16 @@ import { CloseIcon, LightTooltip } from "@components/muiComponents";
 import { useAppSelector } from "@hooks/reducerHook";
 import { Link as MUILink } from "@mui/material";
 
+interface CustomLinkProps {
+  href: string;
+  status: string;
+  entityColor: string;
+  guid: string;
+  name: string;
+  typeName: string;
+  params: URLSearchParams | string;
+}
+
 const CustomLink = ({
   href,
   status,
@@ -56,20 +66,24 @@ const CustomLink = ({
   name,
   typeName,
   params
-}: any): any => {
+}: CustomLinkProps): JSX.Element => {
+  const displayLabel = `${name} (${typeName})`;
   return (
     <li className={status}>
-      <MUILink
-        component={RouterLink}
-        to={{
-          pathname: href,
-          search: params.toString() ? params.toString() : ""
-        }}
-        style={{ color: entityColor }}
-        replace={true}
-      >
-        {name} ({typeName})
-      </MUILink>
+      <LightTooltip title={displayLabel}>
+        <MUILink
+          component={RouterLink}
+          to={{
+            pathname: href,
+            search: params.toString() ? params.toString() : ""
+          }}
+          className={`relationship-node-link ${entityColor === "#1976d2" ? "text-blue" : "text-red"}`}
+          replace={true}
+          underline="hover"
+        >
+          {displayLabel}
+        </MUILink>
+      </LightTooltip>
     </li>
   );
 };
@@ -146,9 +160,9 @@ const RelationshipLineage = ({
       selectedNodeColor = "#4a90e2";
 
     var svg = d3
-        .select(svgElement)
-        .attr("viewBox", `${-padding} ${-padding} ${width + padding * 2} ${height + padding * 2}`)
-        .attr("enable-background", `new ${-padding} ${-padding} ${width + padding * 2} ${height + padding * 2}`),
+      .select(svgElement)
+      .attr("viewBox", `${-padding} ${-padding} ${width + padding * 2} ${height + padding * 2}`)
+      .attr("enable-background", `new ${-padding} ${-padding} ${width + padding * 2} ${height + padding * 2}`),
       node,
       path;
 
@@ -527,15 +541,18 @@ const RelationshipLineage = ({
             ? "deleted-relation"
             : "";
         }
+        const displayLabel = `${name} (${options.typeName})`;
         return (
           <li className={status}>
-            <MUILink
-              component={RouterLink}
-              to={`/detailPage/${options.guid}?tabActive=relationship`}
-              style={{ color: entityColor }}
-            >
-              {name} ({options.typeName})
-            </MUILink>
+            <LightTooltip title={displayLabel}>
+              <MUILink
+                component={RouterLink}
+                to={`/detailPage/${options.guid}?tabActive=relationship`}
+                className={`relationship-node-link ${entityColor === "#1976d2" ? "text-blue" : "text-red"}`}
+              >
+                {displayLabel}
+              </MUILink>
+            </LightTooltip>
           </li>
         );
       };
@@ -617,7 +634,7 @@ const RelationshipLineage = ({
       listString.push(<Fragment key={itemKey}>{getElement(data)}</Fragment>);
     }
     return (
-      <Stack sx={{ background: "white" }} minHeight={"150px"} maxWidth="520px">
+      <Stack sx={{ background: "white" }} minHeight={"150px"} maxWidth="350px">
         {/* {listString?.length > 1 && ( */}
         <Paper
           variant="outlined"

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/__tests__/RelationshipLineage.test.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/__tests__/RelationshipLineage.test.tsx
@@ -25,13 +25,13 @@ var mockCloneDeep: jest.Mock;
 var mockExtractKeyValueFromEntity: jest.Mock;
 var mockCustomSortBy: jest.Mock;
 
-var mockZoomInstance: any;
+var mockZoomInstance: Record<string, unknown>;
 
 jest.mock('@utils/Helper', () => {
 	const actualHelper = jest.requireActual('@utils/Helper');
 	return {
 		...actualHelper,
-		cloneDeep: (...args: any[]) => {
+		cloneDeep: (...args: unknown[]) => {
 			if (mockCloneDeep) {
 				return mockCloneDeep(...args);
 			}
@@ -44,13 +44,13 @@ jest.mock('@utils/Utils', () => {
 	const actualUtils = jest.requireActual('@utils/Utils');
 	return {
 		...actualUtils,
-		extractKeyValueFromEntity: (...args: any[]) => {
+		extractKeyValueFromEntity: (...args: unknown[]) => {
 			if (mockExtractKeyValueFromEntity) {
 				return mockExtractKeyValueFromEntity(...args);
 			}
 			return actualUtils.extractKeyValueFromEntity(...args);
 		},
-		customSortBy: (...args: any[]) => {
+		customSortBy: (...args: unknown[]) => {
 			if (mockCustomSortBy) {
 				return mockCustomSortBy(...args);
 			}
@@ -61,7 +61,7 @@ jest.mock('@utils/Utils', () => {
 
 // Mock D3 with proper hoisting
 jest.mock('d3', () => {
-	const mockEnterSelection: any = {
+	const mockEnterSelection: Record<string, unknown> = {
 		append: jest.fn(),
 		attr: jest.fn(),
 		text: jest.fn(),
@@ -70,7 +70,7 @@ jest.mock('d3', () => {
 		on: jest.fn()
 	};
 	Object.keys(mockEnterSelection).forEach((key) => {
-		mockEnterSelection[key].mockReturnValue(mockEnterSelection);
+		(mockEnterSelection[key] as jest.Mock).mockReturnValue(mockEnterSelection);
 	});
 
 	const mockTransition = {
@@ -78,12 +78,12 @@ jest.mock('d3', () => {
 		scaleBy: jest.fn().mockReturnThis()
 	};
 
-	const mockZoomInSelection: any = { on: jest.fn() };
-	const mockZoomOutSelection: any = { on: jest.fn() };
-	mockZoomInSelection.on.mockReturnValue(mockZoomInSelection);
-	mockZoomOutSelection.on.mockReturnValue(mockZoomOutSelection);
+	const mockZoomInSelection: Record<string, unknown> = { on: jest.fn() };
+	const mockZoomOutSelection: Record<string, unknown> = { on: jest.fn() };
+	(mockZoomInSelection.on as jest.Mock).mockReturnValue(mockZoomInSelection);
+	(mockZoomOutSelection.on as jest.Mock).mockReturnValue(mockZoomOutSelection);
 
-	const mockSelection: any = {
+	const mockSelection: Record<string, unknown> = {
 		attr: jest.fn(),
 		append: jest.fn(),
 		selectAll: jest.fn(),
@@ -99,17 +99,17 @@ jest.mock('d3', () => {
 	};
 	Object.keys(mockSelection).forEach((key) => {
 		if (key === 'enter') {
-			mockSelection[key].mockReturnValue(mockEnterSelection);
+			(mockSelection[key] as jest.Mock).mockReturnValue(mockEnterSelection);
 		} else if (key === 'transition') {
-			mockSelection[key].mockReturnValue(mockTransition);
+			(mockSelection[key] as jest.Mock).mockReturnValue(mockTransition);
 		} else {
-			mockSelection[key].mockReturnValue(mockSelection);
+			(mockSelection[key] as jest.Mock).mockReturnValue(mockSelection);
 		}
 	});
 
 	Object.keys(mockEnterSelection).forEach((key) => {
 		if (typeof mockEnterSelection[key] === 'function') {
-			mockEnterSelection[key].mockReturnValue(mockEnterSelection);
+			(mockEnterSelection[key] as jest.Mock).mockReturnValue(mockEnterSelection);
 		}
 	});
 
@@ -126,7 +126,7 @@ jest.mock('d3', () => {
 	};
 
 	const createMockForceLink = () => {
-		const forceLinkInstance: any = {
+		const forceLinkInstance: Record<string, unknown> = {
 			id: jest.fn().mockImplementation(function () {
 				return forceLinkInstance;
 			}),
@@ -144,9 +144,9 @@ jest.mock('d3', () => {
 	};
 
 	const createMockSimulation = () => {
-		const simulation: any = {
+		const simulation: Record<string, unknown> = {
 			nodes: jest.fn().mockReturnThis(),
-			force: jest.fn((name?: string, forceInstance?: any) => {
+			force: jest.fn((name?: string, forceInstance?: unknown) => {
 				if (name && forceInstance) {
 					if (name === 'link') {
 						simulation.linkForce = forceInstance;
@@ -183,9 +183,9 @@ jest.mock('d3', () => {
 				return [];
 			}
 			const values = Object.values(obj);
-			return values.map((node: any, index: number) => {
-				if (node && typeof node === 'object' && !node.id) {
-					return { ...node, id: node.name || `node-${index}` };
+			return values.map((node: unknown, index: number) => {
+				if (node && typeof node === 'object' && !(node as { id?: string }).id) {
+					return { ...node, id: (node as { name?: string }).name || `node-${index}` };
 				}
 				return node;
 			});
@@ -209,7 +209,7 @@ jest.mock('d3', () => {
 		enumerable: true
 	});
 
-	(globalThis as any).__relationshipLineageD3 = {
+	(globalThis as unknown as Record<string, unknown>).__relationshipLineageD3 = {
 		mockEnterSelection,
 		mockSelection,
 		mockTransition,
@@ -259,14 +259,14 @@ jest.mock('react-router-dom', () => {
 // Mock MUI Components
 jest.mock('@components/muiComponents', () => ({
 	CloseIcon: () => <span data-testid="close-icon">×</span>,
-	LightTooltip: ({ children, title }: any) => (
+	LightTooltip: ({ children, title }: { children: React.ReactNode; title: string }) => (
 		<div data-testid="light-tooltip" title={title}>
 			{children}
 		</div>
 	)
 }));
 
-const rld3 = (globalThis as any).__relationshipLineageD3;
+const rld3 = (globalThis as unknown as Record<string, Record<string, unknown>>).__relationshipLineageD3;
 
 const {
 	mockEnterSelection,
@@ -280,7 +280,7 @@ const mockD3EventObj = rld3.mockD3EventObj;
 
 const theme = createTheme();
 
-const triggerDrawerOpen = (overrides: Partial<{ name: string; value: any[] }> = {}) => {
+const triggerDrawerOpen = (overrides: Partial<{ name: string; value: Record<string, unknown>[] }> = {}) => {
 	const mockNode = {
 		name: 'Process',
 		value: [
@@ -412,17 +412,17 @@ describe('RelationshipLineage', () => {
 		
 		// Initialize mock functions with proper implementations
 		mockCloneDeep = jest.fn((obj) => JSON.parse(JSON.stringify(obj)));
-		mockExtractKeyValueFromEntity = jest.fn((entity: any, key?: string) => {
+		mockExtractKeyValueFromEntity = jest.fn((entity: Record<string, unknown>, key?: string) => {
 			if (key === 'displayText') {
-				return { name: entity?.displayText || entity?.name || entity?.attributes?.name || '' };
+				return { name: entity?.displayText || entity?.name || (entity?.attributes as Record<string, string>)?.name || '' };
 			}
-			return { name: entity?.name || entity?.displayText || entity?.attributes?.name || '' };
+			return { name: entity?.name || entity?.displayText || (entity?.attributes as Record<string, string>)?.name || '' };
 		});
-		mockCustomSortBy = jest.fn((arr: any[], keys: string[]) => {
+		mockCustomSortBy = jest.fn((arr: Record<string, unknown>[], keys: string[]) => {
 			return [...arr].sort((a, b) => {
 				for (const key of keys) {
-					const aVal = a[key] || '';
-					const bVal = b[key] || '';
+					const aVal = (a[key] as string) || '';
+					const bVal = (b[key] as string) || '';
 					if (aVal < bVal) return -1;
 					if (aVal > bVal) return 1;
 				}
@@ -468,7 +468,7 @@ describe('RelationshipLineage', () => {
 		mockEnterSelection.text.mockReturnValue(mockEnterSelection);
 		mockEnterSelection.style.mockReturnValue(mockEnterSelection);
 		mockEnterSelection.call.mockReturnValue(mockEnterSelection);
-		mockEnterSelection.on.mockImplementation((eventName: string, handler?: (data?: any) => void) => {
+		mockEnterSelection.on.mockImplementation((eventName: string, handler?: (data?: unknown) => void) => {
 			if (eventName === 'click' && typeof handler === 'function') {
 				mockEnterSelection.clickHandler = handler;
 			}
@@ -1106,7 +1106,7 @@ describe('RelationshipLineage', () => {
 			expect(screen.getByTestId('relationshipSVG')).toBeInTheDocument();
 		});
 
-		it('should apply deleted-relation class for deleted entities', () => {
+		it('should apply deleted-relation class for deleted entities', async () => {
 			const entityWithDeleted = {
 				guid: 'test-guid-123',
 				typeName: 'DataSet',
@@ -1128,7 +1128,25 @@ describe('RelationshipLineage', () => {
 				</TestWrapper>
 			);
 
-			expect(screen.getByTestId('relationshipSVG')).toBeInTheDocument();
+			triggerDrawerOpen({
+				name: 'deletedProcess',
+				value: [
+					{
+						guid: 'proc-1',
+						typeName: 'Process',
+						displayText: 'Deleted Process',
+						entityStatus: 'DELETED',
+						relationshipStatus: 'DELETED'
+					}
+				]
+			});
+
+			await waitFor(() => {
+				const deletedLink = screen.getByText('Deleted Process (Process)');
+				expect(deletedLink).toBeInTheDocument();
+				expect(deletedLink.closest('li')).toHaveClass('deleted-relation');
+				expect(deletedLink).toHaveClass('text-deleted');
+			});
 		});
 	});
 
@@ -1218,20 +1236,21 @@ describe('RelationshipLineage', () => {
 	});
 
 	describe('Tooltip Rendering', () => {
-		it('should render LightTooltip for relationship nodes in drawer', async () => {
+		it('should render LightTooltip for relationship nodes in drawer with full untruncated title', async () => {
 			render(
 				<TestWrapper>
 					<RelationshipLineage entity={mockEntityWithRelationships} />
 				</TestWrapper>
 			);
 
+			const longName = 'Very Long Entity Display Name For Testing Tooltip Full Text Truncation';
 			const mockNode = {
 				name: 'Process',
 				value: [
 					{
 						guid: 'proc-1',
 						typeName: 'Process',
-						displayText: 'Test Tooltip Name',
+						displayText: longName,
 						entityStatus: 'ACTIVE',
 						relationshipStatus: 'ACTIVE'
 					}
@@ -1246,8 +1265,80 @@ describe('RelationshipLineage', () => {
 
 			await waitFor(() => {
 				const tooltips = screen.getAllByTestId('light-tooltip');
-				const targetTooltip = tooltips.find(t => t.getAttribute('title') === 'Test Tooltip Name (Process)');
+				const targetTooltip = tooltips.find(t => t.getAttribute('title') === `${longName} (Process)`);
 				expect(targetTooltip).toBeInTheDocument();
+				expect(targetTooltip).toHaveAttribute('title', `${longName} (Process)`);
+			}, { timeout: 3000 });
+		});
+
+		it('should render LightTooltip with deleted status styling for deleted entity', async () => {
+			render(
+				<TestWrapper>
+					<RelationshipLineage entity={mockEntityWithRelationships} />
+				</TestWrapper>
+			);
+
+			const mockNode = {
+				name: 'Process',
+				value: [
+					{
+						guid: 'proc-deleted',
+						typeName: 'Process',
+						displayText: 'Deleted Process Entity',
+						entityStatus: 'DELETED',
+						relationshipStatus: 'DELETED'
+					}
+				]
+			};
+
+			act(() => {
+				if (mockEnterSelection.clickHandler) {
+					mockEnterSelection.clickHandler(mockNode);
+				}
+			});
+
+			await waitFor(() => {
+				const tooltips = screen.getAllByTestId('light-tooltip');
+				const targetTooltip = tooltips.find(t => t.getAttribute('title') === 'Deleted Process Entity (Process)');
+				expect(targetTooltip).toBeInTheDocument();
+
+				const link = screen.getByText('Deleted Process Entity (Process)');
+				expect(link).toHaveClass('text-deleted');
+				expect(link.closest('li')).toHaveClass('deleted-relation');
+			}, { timeout: 3000 });
+		});
+
+		it('should render LightTooltip without typeName in parentheses when typeName is missing', async () => {
+			render(
+				<TestWrapper>
+					<RelationshipLineage entity={mockEntityWithRelationships} />
+				</TestWrapper>
+			);
+
+			const mockNode = {
+				name: 'Process',
+				value: [
+					{
+						guid: 'proc-no-type',
+						typeName: '',
+						displayText: 'Entity Without Type',
+						entityStatus: 'ACTIVE',
+						relationshipStatus: 'ACTIVE'
+					}
+				]
+			};
+
+			act(() => {
+				if (mockEnterSelection.clickHandler) {
+					mockEnterSelection.clickHandler(mockNode);
+				}
+			});
+
+			await waitFor(() => {
+				const tooltips = screen.getAllByTestId('light-tooltip');
+				const targetTooltip = tooltips.find(t => t.getAttribute('title') === 'Entity Without Type');
+				expect(targetTooltip).toBeInTheDocument();
+				expect(targetTooltip).toHaveAttribute('title', 'Entity Without Type');
 			}, { timeout: 3000 });
 		});
 	});
@@ -1277,7 +1368,7 @@ describe('RelationshipLineage', () => {
 
 			render(
 				<TestWrapper>
-					<RelationshipLineage entity={entityWithNull as any} />
+					<RelationshipLineage entity={entityWithNull as unknown as Record<string, unknown>} />
 				</TestWrapper>
 			);
 
@@ -1293,7 +1384,7 @@ describe('RelationshipLineage', () => {
 
 			render(
 				<TestWrapper>
-					<RelationshipLineage entity={entityWithUndefined as any} />
+					<RelationshipLineage entity={entityWithUndefined as unknown as Record<string, unknown>} />
 				</TestWrapper>
 			);
 
@@ -1343,7 +1434,7 @@ describe('RelationshipLineage', () => {
 
 			render(
 				<TestWrapper>
-					<RelationshipLineage entity={entityWithoutTypeName as any} />
+					<RelationshipLineage entity={entityWithoutTypeName as unknown as Record<string, unknown>} />
 				</TestWrapper>
 			);
 

--- a/dashboard/src/views/DetailPage/EntityDetailTabs/__tests__/RelationshipLineage.test.tsx
+++ b/dashboard/src/views/DetailPage/EntityDetailTabs/__tests__/RelationshipLineage.test.tsx
@@ -1217,6 +1217,41 @@ describe('RelationshipLineage', () => {
 		});
 	});
 
+	describe('Tooltip Rendering', () => {
+		it('should render LightTooltip for relationship nodes in drawer', async () => {
+			render(
+				<TestWrapper>
+					<RelationshipLineage entity={mockEntityWithRelationships} />
+				</TestWrapper>
+			);
+
+			const mockNode = {
+				name: 'Process',
+				value: [
+					{
+						guid: 'proc-1',
+						typeName: 'Process',
+						displayText: 'Test Tooltip Name',
+						entityStatus: 'ACTIVE',
+						relationshipStatus: 'ACTIVE'
+					}
+				]
+			};
+
+			act(() => {
+				if (mockEnterSelection.clickHandler) {
+					mockEnterSelection.clickHandler(mockNode);
+				}
+			});
+
+			await waitFor(() => {
+				const tooltips = screen.getAllByTestId('light-tooltip');
+				const targetTooltip = tooltips.find(t => t.getAttribute('title') === 'Test Tooltip Name (Process)');
+				expect(targetTooltip).toBeInTheDocument();
+			}, { timeout: 3000 });
+		});
+	});
+
 	describe('Edge Cases', () => {
 		it('should handle entity without relationshipAttributes', () => {
 			const entityWithoutAttributes = {

--- a/dashboardv2/public/css/scss/graph.scss
+++ b/dashboardv2/public/css/scss/graph.scss
@@ -94,16 +94,25 @@
         padding-left: 15px;
     }
 
+    ol>li,
     ul>li {
         word-wrap: break-word;
         margin-bottom: 5px;
         text-align: left;
+        line-height: 1.5;
 
         &.entity-list-item {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
             max-width: 100%;
+
+            .entity-type-name {
+                display: inline-block;
+                max-width: calc(100% - 25px);
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                vertical-align: top;
+                line-height: inherit;
+            }
         }
 
         &.deleted-relation {

--- a/dashboardv2/public/css/scss/graph.scss
+++ b/dashboardv2/public/css/scss/graph.scss
@@ -99,6 +99,13 @@
         margin-bottom: 5px;
         text-align: left;
 
+        &.entity-list-item {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 100%;
+        }
+
         &.deleted-relation {
             .deleteBtn {
                 padding: 2px 8px !important;

--- a/dashboardv2/public/css/scss/relationship.scss
+++ b/dashboardv2/public/css/scss/relationship.scss
@@ -567,4 +567,3 @@
         color: #BB5838;
     }
 }
-.entity-type-name { &.active { color: #1976d2; } &.deleted { color: #BB5838; } }

--- a/dashboardv2/public/css/scss/relationship.scss
+++ b/dashboardv2/public/css/scss/relationship.scss
@@ -51,6 +51,27 @@
     }
 }
 
+.relationship-box,
+.relationship-node-details,
+.relationship-cards-container,
+.box-panel,
+.relationship-tooltip {
+    .tooltip-inner {
+        max-width: 300px;
+        word-break: break-all;
+        word-break: break-word;
+        overflow-wrap: break-word;
+    }
+}
+
+.tooltip.relationship-tooltip .tooltip-inner,
+.relationship-tooltip .tooltip-inner {
+    max-width: 300px;
+    word-break: break-all;
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
 // Relationship Cards Styles - Match React UI structure and breakpoints
 .relationship-cards-container {
     padding: 0;

--- a/dashboardv2/public/css/scss/relationship.scss
+++ b/dashboardv2/public/css/scss/relationship.scss
@@ -121,7 +121,7 @@
     flex-direction: column;
     gap: 12px;
     min-width: 280px;
-    flex: 0 0 auto;
+    flex: 1 1 0;
 }
 
 @media (max-width: 599px) {
@@ -220,6 +220,7 @@
         flex-direction: column;
         padding: 12px;
         min-height: 0;
+        min-width: 0;
         overflow: hidden;
 
         .relationship-card-search {
@@ -241,6 +242,7 @@
             overflow-y: auto;
             overflow-x: hidden;
             min-height: 0;
+            min-width: 0;
             position: relative;
 
             &::-webkit-scrollbar {
@@ -267,10 +269,14 @@
             padding: 0;
             margin: 0;
             text-align: left;
+            width: 100%;
+            overflow: hidden;
 
             .relationship-card-item {
                 padding: 8px 0;
                 border-bottom: 1px solid #f0f0f0;
+                width: 100%;
+                overflow: hidden;
 
                 &:last-child {
                     border-bottom: none;
@@ -290,7 +296,12 @@
                     font-size: 13px;
                     font-family: inherit;
                     line-height: 1.5;
-                    word-break: break-word;
+                    display: inline-block;
+                    max-width: 100%;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    vertical-align: middle;
 
                     &:hover {
                         text-decoration: underline;
@@ -548,3 +559,12 @@
         background-position: -200% 0;
     }
 }
+.entity-type-name {
+    &.active {
+        color: #1976d2;
+    }
+    &.deleted {
+        color: #BB5838;
+    }
+}
+.entity-type-name { &.active { color: #1976d2; } &.deleted { color: #BB5838; } }

--- a/dashboardv2/public/css/scss/theme.scss
+++ b/dashboardv2/public/css/scss/theme.scss
@@ -88,6 +88,7 @@ header.atlas-header {
     overflow: auto;
     padding-top: 15px !important;
     padding-bottom: 10px !important;
+    box-sizing: border-box;
 
     &>div {
         height: 100%;
@@ -536,7 +537,8 @@ hr[size="10"] {
 }
 
 .tooltip-inner {
-    max-width: none;
+    max-width: 300px;
+    word-break: break-all;
     color: #2c2c2c;
     background-color: #f9f9f9;
     box-shadow: 0px 0px 3px 0px #8080806b;

--- a/dashboardv2/public/css/scss/theme.scss
+++ b/dashboardv2/public/css/scss/theme.scss
@@ -538,7 +538,7 @@ hr[size="10"] {
 
 .tooltip-inner {
     max-width: 300px;
-    word-break: break-all;
+    word-wrap: break-word;
     color: #2c2c2c;
     background-color: #f9f9f9;
     box-shadow: 0px 0px 3px 0px #8080806b;

--- a/dashboardv2/public/css/scss/theme.scss
+++ b/dashboardv2/public/css/scss/theme.scss
@@ -537,7 +537,8 @@ hr[size="10"] {
 }
 
 .tooltip-inner {
-    max-width: 300px;
+    max-width: none;
+    overflow-wrap: break-word;
     word-wrap: break-word;
     color: #2c2c2c;
     background-color: #f9f9f9;

--- a/dashboardv2/public/js/views/detail_page/RelationshipCardsLayoutView.js
+++ b/dashboardv2/public/js/views/detail_page/RelationshipCardsLayoutView.js
@@ -691,6 +691,9 @@ define([
             }
             
             if (this.$el && this.$el.length) {
+                if ($.fn.tooltip) {
+                    this.$el.find('[title]').tooltip('destroy');
+                }
                 this.$el.html(html);
                 this.bindCardEvents();
                 if ($.fn.tooltip) {
@@ -701,6 +704,12 @@ define([
                 }
             } else {
                 console.warn("[RelationshipCardsLayoutView] $el not available, cannot render cards");
+            }
+        },
+
+        onDestroy: function() {
+            if ($.fn.tooltip && this.$el) {
+                this.$el.find('[title]').tooltip('destroy');
             }
         }
     });

--- a/dashboardv2/public/js/views/detail_page/RelationshipCardsLayoutView.js
+++ b/dashboardv2/public/js/views/detail_page/RelationshipCardsLayoutView.js
@@ -699,7 +699,8 @@ define([
                 if ($.fn.tooltip) {
                     this.$el.find('[title]').tooltip({
                         placement: 'bottom',
-                        container: 'body'
+                        container: 'body',
+                        template: '<div class="tooltip relationship-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
                     });
                 }
             } else {

--- a/dashboardv2/public/js/views/detail_page/RelationshipCardsLayoutView.js
+++ b/dashboardv2/public/js/views/detail_page/RelationshipCardsLayoutView.js
@@ -489,8 +489,8 @@ define([
                 var nameValue = item && item.attributes && item.attributes.name ? item.attributes.name : "";
                 var searchText = _.escape((displayText + " " + qualifiedName + " " + nameValue).toLowerCase());
                 return "<li class='relationship-card-item' data-search='" + searchText + "'>" +
-                    (href ? "<a class='relationship-card-link" + deletedClass + "' href='" + href + "'>" + _.escape(displayLabel) + "</a>" :
-                        "<span class='relationship-card-link" + deletedClass + "'>" + _.escape(displayLabel) + "</span>") +
+                    (href ? "<a class='relationship-card-link" + deletedClass + "' href='" + href + "' title='" + _.escape(displayLabel) + "'>" + _.escape(displayLabel) + "</a>" :
+                        "<span class='relationship-card-link" + deletedClass + "' title='" + _.escape(displayLabel) + "'>" + _.escape(displayLabel) + "</span>") +
                     "</li>";
             }).join("");
 
@@ -693,6 +693,12 @@ define([
             if (this.$el && this.$el.length) {
                 this.$el.html(html);
                 this.bindCardEvents();
+                if ($.fn.tooltip) {
+                    this.$el.find('[title]').tooltip({
+                        placement: 'bottom',
+                        container: 'body'
+                    });
+                }
             } else {
                 console.warn("[RelationshipCardsLayoutView] $el not available, cannot render cards");
             }

--- a/dashboardv2/public/js/views/graph/RelationshipLayoutView.js
+++ b/dashboardv2/public/js/views/graph/RelationshipLayoutView.js
@@ -29,7 +29,7 @@ define([
     "utils/Enums",
     "utils/UrlLinks",
     "platform"
-], function(require, Backbone, RelationshipLayoutViewtmpl, VLineageList, VEntity, Utils, CommonViewFunction, d3, d3Tip, Enums, UrlLinks, platform) {
+], function (require, Backbone, RelationshipLayoutViewtmpl, VLineageList, VEntity, Utils, CommonViewFunction, d3, d3Tip, Enums, UrlLinks, platform) {
     "use strict";
 
     var RelationshipLayoutView = Backbone.Marionette.LayoutView.extend(
@@ -60,17 +60,17 @@ define([
             },
 
             /** ui events hash */
-            events: function() {
+            events: function () {
                 var events = {};
-                events["click " + this.ui.relationshipDetailClose] = function() {
+                events["click " + this.ui.relationshipDetailClose] = function () {
                     this.toggleInformationSlider({ close: true });
                 };
                 events["keyup " + this.ui.searchNode] = "searchNode";
                 events["click " + this.ui.boxClose] = "toggleBoxPanel";
-                events["change " + this.ui.relationshipViewToggle] = function(e) {
+                events["change " + this.ui.relationshipViewToggle] = function (e) {
                     this.relationshipViewToggle(e.currentTarget.checked);
                 };
-                events["click " + this.ui.noValueToggle] = function(e) {
+                events["click " + this.ui.noValueToggle] = function (e) {
                     Utils.togglePropertyRelationshipTableEmptyValues({
                         inputType: this.ui.noValueToggle,
                         tableEl: this.ui.relationshipDetailValue
@@ -84,19 +84,19 @@ define([
              * intialize a new RelationshipLayoutView Layout
              * @constructs
              */
-            initialize: function(options) {
+            initialize: function (options) {
                 _.extend(this, _.pick(options, "entity", "entityName", "guid", "actionCallBack", "attributeDefs", "referredEntities", "entityDefCollection"));
                 this.graphData = this.createData(this.entity);
                 this.relationshipCardCounts = {};
                 this.relationshipLoadedCounts = {};
                 this.cardsViewLoadInProgress = false;
-                
-                this.handleRelationshipDataUpdate = _.bind(function(payload) {
+
+                this.handleRelationshipDataUpdate = _.bind(function (payload) {
                     var relationshipAttributes = payload && payload.data ? payload.data : payload;
                     var relationshipCounts = payload && payload.counts ? payload.counts : this.relationshipCardCounts;
                     var loadedCounts = payload && payload.loadedCounts ? payload.loadedCounts : this.relationshipLoadedCounts;
                     var referredEntities = payload && payload.referredEntities ? payload.referredEntities : null;
-                    
+
                     if (!relationshipAttributes) {
                         return;
                     }
@@ -116,7 +116,7 @@ define([
                         }
                     }
                 }, this);
-                this.handleRelationshipLoading = _.bind(function(isLoading) {
+                this.handleRelationshipLoading = _.bind(function (isLoading) {
                     if (isLoading) {
                         this.$(".fontLoader").show();
                     } else {
@@ -124,12 +124,12 @@ define([
                     }
                 }, this);
             },
-            createData: function(entity) {
+            createData: function (entity) {
                 var that = this,
                     links = [],
                     nodes = {};
                 if (entity && entity.relationshipAttributes) {
-                    _.each(entity.relationshipAttributes, function(obj, key) {
+                    _.each(entity.relationshipAttributes, function (obj, key) {
                         var relationValue = obj;
                         if (relationValue && relationValue.entities) {
                             relationValue = relationValue.entities;
@@ -152,14 +152,14 @@ define([
                 }
                 return { nodes: nodes, links: links };
             },
-            onRender: function() {
+            onRender: function () {
                 this.isRendered = true;
 
                 // Initialize: show card view by default (checked = Card)
                 this.ui.relationshipViewToggle.prop('checked', true);
                 this.relationshipViewToggle(true);
             },
-            onShow: function(argument) {
+            onShow: function (argument) {
                 // Always create graph on show if graph view is active
                 var isGraphView = !this.ui.relationshipViewToggle.is(':checked');
                 if (isGraphView) {
@@ -170,12 +170,12 @@ define([
                     }
                 }
                 this.createTable();
-                
+
                 this.ensureCardsView();
             },
-            ensureCardsView: function(forceRefresh) {
+            ensureCardsView: function (forceRefresh) {
                 var that = this;
-                
+
                 if (this.relationshipCardsViewInstance) {
                     if (forceRefresh) {
                         this.relationshipCardsViewInstance.cardData = {};
@@ -198,7 +198,7 @@ define([
                     return;
                 }
                 this.cardsViewLoadInProgress = true;
-                require(['views/detail_page/RelationshipCardsLayoutView'], function(RelationshipCardsLayoutView) {
+                require(['views/detail_page/RelationshipCardsLayoutView'], function (RelationshipCardsLayoutView) {
                     try {
                         if (!that.relationshipCardsView) {
                             console.warn("[RelationshipLayoutView] Region not available");
@@ -221,22 +221,22 @@ define([
                     } finally {
                         that.cardsViewLoadInProgress = false;
                     }
-                }, function(err) {
+                }, function (err) {
                     console.error("[RelationshipLayoutView] Failed to load RelationshipCardsLayoutView:", err);
                     that.cardsViewLoadInProgress = false;
                 });
             },
-            updateCardsShowEmptyValues: function(showEmptyValues) {
+            updateCardsShowEmptyValues: function (showEmptyValues) {
                 if (!this.relationshipCardsViewInstance) {
                     return;
                 }
                 this.relationshipCardsViewInstance.showEmptyValues = !!showEmptyValues;
                 this.relationshipCardsViewInstance.renderCards();
             },
-            noRelationship: function() {
+            noRelationship: function () {
                 this.$("svg").html('<text x="50%" y="50%" alignment-baseline="middle" text-anchor="middle">No relationship data found</text>');
             },
-            toggleInformationSlider: function(options) {
+            toggleInformationSlider: function (options) {
                 var panel = this.$(".relationship-node-details");
                 if (options && options.close) {
                     panel.removeClass("slide-to-left").addClass("slide-from-left");
@@ -248,10 +248,10 @@ define([
                     }
                 }
             },
-            toggleBoxPanel: function() {
+            toggleBoxPanel: function () {
                 this.$(".relationship-node-details").removeClass("slide-to-left").addClass("slide-from-left");
             },
-            searchNode: function(e) {
+            searchNode: function (e) {
                 var searchString = $(e.currentTarget).val(),
                     listString = "",
                     data = this.selectedNodeData,
@@ -259,7 +259,7 @@ define([
                     activeEntityColor = "#1976d2",
                     deletedEntityColor = "#BB5838",
                     defaultEntityColor = "#e0e0e0",
-                    normalizeEntity = function(entity) {
+                    normalizeEntity = function (entity) {
                         if (!entity) {
                             return entity;
                         }
@@ -271,27 +271,29 @@ define([
                         }
                         return entity;
                     }.bind(this),
-                    getdefault = function(options) {
-                        return "<pre class='entity-type-name' style='color:" + options.color + "'>" + options.name + "</pre>";
+                    getdefault = function (options) {
+                        var colorClass = options.color === deletedEntityColor ? "deleted" : "active";
+                        return "<pre class='entity-type-name " + colorClass + "'>" + options.name + "</pre>";
                     },
-                    getWithButton = function(options) {
+                    getWithButton = function (options) {
                         var name = options.name,
                             guid = options.options.guid,
-                            entityTypeButton = "";
+                            entityTypeButton = "",
+                            colorClass = options.color === deletedEntityColor ? "deleted" : "active";
                         if (guid) {
                             if (options.entity) {
-                                entityTypeButton = "<a href='#!/detailPage/" + guid + "' class='entity-type-name' style='color:" + options.color + "'>" + name + "</a>";
+                                entityTypeButton = "<a href='#!/detailPage/" + guid + "' class='entity-type-name " + colorClass + "'>" + name + "</a>";
                             } else if (options.relationship) {
-                                entityTypeButton = "<a href='#/relationshipDetailPage/" + guid + "' class='entity-type-name' style='color:" + options.color + "'>" + name + "</a>";
+                                entityTypeButton = "<a href='#/relationshipDetailPage/" + guid + "' class='entity-type-name " + colorClass + "'>" + name + "</a>";
                             } else {
-                                entityTypeButton = "<a href='#!/detailPage/" + guid + "' class='entity-type-name' style='color:" + options.color + "'>" + name + "</a>";
+                                entityTypeButton = "<a href='#!/detailPage/" + guid + "' class='entity-type-name " + colorClass + "'>" + name + "</a>";
                             }
                         } else {
-                            entityTypeButton = "<pre class='entity-type-name' style='color:" + options.color + "'>" + name + "</pre>";
+                            entityTypeButton = "<pre class='entity-type-name " + colorClass + "'>" + name + "</pre>";
                         }
                         return entityTypeButton;
                     },
-                    getEntityTypelist = function(options) {
+                    getEntityTypelist = function (options) {
                         var name = options.entityName ? options.entityName : Utils.getName(options, "displayText"),
                             entityTypeHtml = "";
                         if (options.entityStatus == "ACTIVE" || options.status == "ACTIVE") {
@@ -327,12 +329,12 @@ define([
                     };
                 this.ui.searchNode.hide();
                 this.$("[data-id='typeName']").text(typeName);
-                var getElement = function(options) {
+                var getElement = function (options) {
                     var name = options.entityName ? options.entityName : Utils.getName(options, "displayText");
                     var entityTypeButton = getEntityTypelist(options);
                     return entityTypeButton;
                 };
-                var buildEntityObj = function(item) {
+                var buildEntityObj = function (item) {
                     var normalized = normalizeEntity(item);
                     var ref = normalized && normalized.guid ? this.referredEntities && this.referredEntities[normalized.guid] : null;
                     var displayText = (ref && (ref.displayText || (ref.attributes && ref.attributes.name))) ||
@@ -347,26 +349,26 @@ define([
                         typeName: typeName
                     });
                 }.bind(this);
-                var buildListItem = function(item) {
+                var buildListItem = function (item) {
                     var name = item.entityName || Utils.getName(item, "displayText");
                     var typeName = item.typeName || "";
                     var displayLabel = typeName ? name + " (" + typeName + ")" : name;
                     var href = item.guid ? "#!/detailPage/" + item.guid + "?tabActive=relationship" : "";
                     var isDeleted = (item.entityStatus || item.status) == "DELETED";
-                    var color = isDeleted ? deletedEntityColor : activeEntityColor;
+                    var colorClass = isDeleted ? "deleted" : "active";
                     var content = href
-                        ? "<a href='" + href + "' class='entity-type-name' style='color:" + color + "'>" + _.escape(displayLabel) + "</a>"
-                        : "<span class='entity-type-name' style='color:" + color + "'>" + _.escape(displayLabel) + "</span>";
-                    return "<li class='entity-list-item'>" + content + "</li>";
+                        ? "<a href='" + href + "' class='entity-type-name " + colorClass + "' title='" + _.escape(displayLabel) + "'>" + _.escape(displayLabel) + "</a>"
+                        : "<span class='entity-type-name " + colorClass + "' title='" + _.escape(displayLabel) + "'>" + _.escape(displayLabel) + "</span>";
+                    return "<li class='entity-list-item' title='" + _.escape(displayLabel) + "'>" + content + "</li>";
                 };
                 if (_.isArray(data)) {
-                    data = _.map(data, function(item) {
+                    data = _.map(data, function (item) {
                         return buildEntityObj(item);
                     });
                     if (data.length > 1) {
                         this.ui.searchNode.show();
                     }
-                    _.each(_.sortBy(data, "entityName"), function(val) {
+                    _.each(_.sortBy(data, "entityName"), function (val) {
                         var name = val.entityName || Utils.getName(val, "displayText");
                         var searchTarget = (name + " " + (val.typeName || "")).toLowerCase();
                         if (searchString) {
@@ -384,8 +386,14 @@ define([
                     listString += buildListItem(data);
                 }
                 this.$("[data-id='entityList']").html(listString);
+                if ($.fn.tooltip) {
+                    this.$("[data-id='entityList']").find('[title]').tooltip({
+                        placement: 'bottom',
+                        container: 'body'
+                    });
+                }
             },
-            createGraph: function(data) {
+            createGraph: function (data) {
                 //Ref - http://bl.ocks.org/fancellu/2c782394602a93921faff74e594d1bb1
 
                 var that = this,
@@ -398,7 +406,7 @@ define([
                     deletedEntityColor = "#BB5838",
                     defaultEntityColor = "#e0e0e0",
                     selectedNodeColor = "#4a90e2";
-                var getNodeCount = function(node) {
+                var getNodeCount = function (node) {
                     if (!node) {
                         return 0;
                     }
@@ -434,7 +442,7 @@ define([
                 var zoom = d3
                     .zoom()
                     .scaleExtent([0.1, 4])
-                    .on("zoom", function() {
+                    .on("zoom", function () {
                         container.attr("transform", d3.event.transform);
                     });
 
@@ -456,7 +464,7 @@ define([
                     .attr("xoverflow", "visible")
                     .append("svg:path")
                     .attr("d", "M 0,-5 L 10,0 L 0,5")
-                    .attr("fill", function(d) {
+                    .attr("fill", function (d) {
                         return d === "deletedLink" ? deletedEntityColor : activeEntityColor;
                     })
                     .attr("stroke", "none");
@@ -467,7 +475,7 @@ define([
                         "link",
                         d3
                             .forceLink(links)
-                            .id(function(d) {
+                            .id(function (d) {
                                 return d.name;
                             })
                             .distance(150)
@@ -476,45 +484,45 @@ define([
                     .force("center", d3.forceCenter(width / 2, height / 2))
                     .force("collision", d3.forceCollide().radius(50));
 
-                    path = container
+                path = container
                     .append("g")
-                        .selectAll("path")
-                        .data(links)
-                        .enter()
+                    .selectAll("path")
+                    .data(links)
+                    .enter()
                     .append("path")
-                        .attr("class", "relatioship-link")
-                    .attr("marker-end", function(d) {
+                    .attr("class", "relatioship-link")
+                    .attr("marker-end", function (d) {
                         return isAllEntityRelationDeleted({ data: d, type: "link" }) ? "url(#deletedLink)" : "url(#activeLink)";
                     })
-                        .attr("stroke", function(d) {
+                    .attr("stroke", function (d) {
                         return isAllEntityRelationDeleted({ data: d, type: "link" }) ? deletedEntityColor : activeEntityColor;
-                        });
+                    });
 
-                    node = container
+                node = container
                     .append("g")
-                        .selectAll(".node")
-                        .data(nodes)
-                        .enter()
-                        .append("g")
-                        .attr("class", "node")
-                        .on("mousedown", function() {
-                            d3.event.preventDefault();
-                        })
-                        .on("click", function(d) {
-                            if (d3.event.defaultPrevented) return; // ignore drag
-                            if (d && d.value && d.value.guid == that.guid) {
-                                that.ui.boxClose.trigger("click");
-                                return;
-                            }
-                            that.toggleBoxPanel({ el: that.$(".relationship-node-details") });
-                            that.ui.searchNode.data({ obj: d });
-                            $(this)
-                                .find("circle")
-                                .addClass("node-detail-highlight");
-                            that.updateRelationshipDetails({ obj: d });
-                        })
-                        .call(
-                            d3
+                    .selectAll(".node")
+                    .data(nodes)
+                    .enter()
+                    .append("g")
+                    .attr("class", "node")
+                    .on("mousedown", function () {
+                        d3.event.preventDefault();
+                    })
+                    .on("click", function (d) {
+                        if (d3.event.defaultPrevented) return; // ignore drag
+                        if (d && d.value && d.value.guid == that.guid) {
+                            that.ui.boxClose.trigger("click");
+                            return;
+                        }
+                        that.toggleBoxPanel({ el: that.$(".relationship-node-details") });
+                        that.ui.searchNode.data({ obj: d });
+                        $(this)
+                            .find("circle")
+                            .addClass("node-detail-highlight");
+                        that.updateRelationshipDetails({ obj: d });
+                    })
+                    .call(
+                        d3
                             .drag()
                             .on("start", dragstarted)
                             .on("drag", dragged)
@@ -522,105 +530,105 @@ define([
                     );
 
                 node.append("circle")
-                        .attr("r", function() {
+                    .attr("r", function () {
                         return 25;
-                        })
-                        .attr("fill", function(d) {
+                    })
+                    .attr("fill", function (d) {
                         if (d.name === that.entity.typeName) {
-                                    return selectedNodeColor;
-                            } else {
+                            return selectedNodeColor;
+                        } else {
                             return isAllEntityRelationDeleted({ data: d, type: "node" }) ? deletedEntityColor : activeEntityColor;
-                            }
-                        })
+                        }
+                    })
                     .attr("stroke", "#fff")
                     .attr("stroke-width", "2px")
                     .style("cursor", "pointer")
-                    .on("click", function(d) {
+                    .on("click", function (d) {
                         if (d && d.value && d.value.guid == that.guid) {
                             return;
                         }
                         that.selectedNodeData = d.value;
                         that.selectedNodeType = d.name;
-                        
+
                         // Show the panel
                         var panel = that.$(".relationship-node-details");
                         panel.removeClass("slide-to-left").addClass("slide-from-left");
-                        
+
                         // Trigger after a small delay to ensure DOM is ready
-                        setTimeout(function() {
+                        setTimeout(function () {
                             panel.removeClass("slide-from-left").addClass("slide-to-left");
                             that.searchNode({ currentTarget: that.ui.searchNode });
                         }, 10);
-                        });
+                    });
 
-                    node.append("text")
-                        .attr("x", 0)
-                        .attr("y", 0)
-                        .attr("dy", function() {
-                            return 25 - 17;
-                        })
-                        .attr("text-anchor", "middle")
-                        .style("font-family", "FontAwesome")
-                        .style("font-size", "25px")
-                        .attr("class", "relationship-node-icon")
-                        .text(function(d) {
-                            var iconObj = Enums.graphIcon[d.name];
-                            if (iconObj && iconObj.textContent) {
-                                return iconObj.textContent;
-                            }
-                            if (d && _.isArray(d.value) && d.value.length > 1) {
-                                return "\uf0c5";
-                            }
-                            return "\uf016";
-                        })
-                        .attr("fill", "#fff");
+                node.append("text")
+                    .attr("x", 0)
+                    .attr("y", 0)
+                    .attr("dy", function () {
+                        return 25 - 17;
+                    })
+                    .attr("text-anchor", "middle")
+                    .style("font-family", "FontAwesome")
+                    .style("font-size", "25px")
+                    .attr("class", "relationship-node-icon")
+                    .text(function (d) {
+                        var iconObj = Enums.graphIcon[d.name];
+                        if (iconObj && iconObj.textContent) {
+                            return iconObj.textContent;
+                        }
+                        if (d && _.isArray(d.value) && d.value.length > 1) {
+                            return "\uf0c5";
+                        }
+                        return "\uf016";
+                    })
+                    .attr("fill", "#fff");
 
-                    var countBox = node.append("g");
+                var countBox = node.append("g");
 
-                    countBox
-                        .append("circle")
-                        .attr("cx", 18)
-                        .attr("cy", -20)
-                        .attr("class", "relationship-node-count")
-                        .attr("r", function(d) {
-                            var count = getNodeCount(d);
-                            if (count > 1) {
-                                return 9;
-                            }
-                        });
+                countBox
+                    .append("circle")
+                    .attr("cx", 18)
+                    .attr("cy", -20)
+                    .attr("class", "relationship-node-count")
+                    .attr("r", function (d) {
+                        var count = getNodeCount(d);
+                        if (count > 1) {
+                            return 9;
+                        }
+                    });
 
-                    countBox
-                        .append("text")
-                        .attr("dx", 18)
-                        .attr("dy", -16)
-                        .attr("text-anchor", "middle")
-                        .attr("fill", defaultEntityColor)
-                        .attr("class", "relationship-node-count")
-                        .text(function(d) {
-                            var count = getNodeCount(d);
-                            if (count > 1) {
-                                return count;
-                            }
-                        });
+                countBox
+                    .append("text")
+                    .attr("dx", 18)
+                    .attr("dy", -16)
+                    .attr("text-anchor", "middle")
+                    .attr("fill", defaultEntityColor)
+                    .attr("class", "relationship-node-count")
+                    .text(function (d) {
+                        var count = getNodeCount(d);
+                        if (count > 1) {
+                            return count;
+                        }
+                    });
 
-                    node
-                        .append("text")
-                        .attr("x", -15)
-                        .attr("y", "35")
-                        .attr("class", "relationship-node-label")
-                        .text(function(d) {
-                            return d.name;
-                        });
+                node
+                    .append("text")
+                    .attr("x", -15)
+                    .attr("y", "35")
+                    .attr("class", "relationship-node-label")
+                    .text(function (d) {
+                        return d.name;
+                    });
 
-                simulation.on("tick", function() {
-                    path.attr("d", function(d) {
+                simulation.on("tick", function () {
+                    path.attr("d", function (d) {
                         var dx = d.target.x - d.source.x,
                             dy = d.target.y - d.source.y,
                             dr = Math.sqrt(dx * dx + dy * dy);
                         return "M" + d.source.x + "," + d.source.y + "A" + dr + "," + dr + " 0 0,1 " + d.target.x + "," + d.target.y;
                     });
 
-                    node.attr("transform", function(d) {
+                    node.attr("transform", function (d) {
                         return "translate(" + d.x + "," + d.y + ")";
                     });
                 });
@@ -659,7 +667,7 @@ define([
                     }
 
                     return (
-                        _.findIndex(d.value, function(val) {
+                        _.findIndex(d.value, function (val) {
                             if (type == "node") {
                                 return (val.entityStatus || val.status) == "ACTIVE";
                             } else {
@@ -668,7 +676,7 @@ define([
                         }) == -1
                     );
                 }
-                var zoomClick = function() {
+                var zoomClick = function () {
                     var scaleFactor = 0.8;
                     if (this.id === 'zoom_in') {
                         scaleFactor = 1.3;
@@ -678,7 +686,7 @@ define([
 
                 d3.selectAll(this.$('.lineageZoomButton')).on('click', zoomClick);
             },
-            createTable: function() {
+            createTable: function () {
                 this.entityModel = new VEntity({});
                 var table = CommonViewFunction.propertyTable({
                     scope: this,
@@ -691,7 +699,7 @@ define([
                     tableEl: this.ui.relationshipDetailValue
                 });
             },
-            relationshipViewToggle: function(checked) {
+            relationshipViewToggle: function (checked) {
                 var that = this;
 
                 // In the original code: checked = Table, unchecked = Graph
@@ -705,12 +713,12 @@ define([
                     this.ui.relationshipDetailTable.hide();
                     this.ui.relationshipDetailValue.hide();
                     this.ui.relationshipCardsView.show();
-                    
+
                     // Render card view if not already rendered
                     this.ensureCardsView();
-                    
+
                     // Force a re-render after a short delay to ensure DOM is ready
-                    setTimeout(function() {
+                    setTimeout(function () {
                         if (that.relationshipCardsViewInstance) {
                             that.relationshipCardsViewInstance.renderCards();
                         }
@@ -724,7 +732,7 @@ define([
                     this.ui.relationshipDetailTable.show();
                     this.ui.relationshipDetailValue.show();
                     this.ui.relationshipCardsView.hide();
-                    
+
                     // Ensure graph is created if it hasn't been created yet
                     if (this.graphData && !_.isEmpty(this.graphData.links)) {
                         // Clear existing graph and recreate
@@ -735,8 +743,8 @@ define([
                     }
                 }
             },
-            
-            onDestroy: function() {
+
+            onDestroy: function () {
                 this.cardsViewLoadInProgress = false;
                 if (this.relationshipCardsViewInstance) {
                     this.relationshipCardsViewInstance.destroy();

--- a/dashboardv2/public/js/views/graph/RelationshipLayoutView.js
+++ b/dashboardv2/public/js/views/graph/RelationshipLayoutView.js
@@ -359,7 +359,7 @@ define([
                     var content = href
                         ? "<a href='" + href + "' class='entity-type-name " + colorClass + "' title='" + _.escape(displayLabel) + "'>" + _.escape(displayLabel) + "</a>"
                         : "<span class='entity-type-name " + colorClass + "' title='" + _.escape(displayLabel) + "'>" + _.escape(displayLabel) + "</span>";
-                    return "<li class='entity-list-item' title='" + _.escape(displayLabel) + "'>" + content + "</li>";
+                    return "<li class='entity-list-item'>" + content + "</li>";
                 };
                 if (_.isArray(data)) {
                     data = _.map(data, function (item) {
@@ -384,6 +384,9 @@ define([
                 } else {
                     data = buildEntityObj(data);
                     listString += buildListItem(data);
+                }
+                if ($.fn.tooltip) {
+                    this.$("[data-id='entityList']").find('[title]').tooltip('destroy');
                 }
                 this.$("[data-id='entityList']").html(listString);
                 if ($.fn.tooltip) {
@@ -745,6 +748,9 @@ define([
             },
 
             onDestroy: function () {
+                if ($.fn.tooltip && this.$el) {
+                    this.$el.find('[title]').tooltip('destroy');
+                }
                 this.cardsViewLoadInProgress = false;
                 if (this.relationshipCardsViewInstance) {
                     this.relationshipCardsViewInstance.destroy();

--- a/dashboardv2/public/js/views/graph/RelationshipLayoutView.js
+++ b/dashboardv2/public/js/views/graph/RelationshipLayoutView.js
@@ -29,7 +29,7 @@ define([
     "utils/Enums",
     "utils/UrlLinks",
     "platform"
-], function (require, Backbone, RelationshipLayoutViewtmpl, VLineageList, VEntity, Utils, CommonViewFunction, d3, d3Tip, Enums, UrlLinks, platform) {
+], function(require, Backbone, RelationshipLayoutViewtmpl, VLineageList, VEntity, Utils, CommonViewFunction, d3, d3Tip, Enums, UrlLinks, platform) {
     "use strict";
 
     var RelationshipLayoutView = Backbone.Marionette.LayoutView.extend(
@@ -60,17 +60,17 @@ define([
             },
 
             /** ui events hash */
-            events: function () {
+            events: function() {
                 var events = {};
-                events["click " + this.ui.relationshipDetailClose] = function () {
+                events["click " + this.ui.relationshipDetailClose] = function() {
                     this.toggleInformationSlider({ close: true });
                 };
                 events["keyup " + this.ui.searchNode] = "searchNode";
                 events["click " + this.ui.boxClose] = "toggleBoxPanel";
-                events["change " + this.ui.relationshipViewToggle] = function (e) {
+                events["change " + this.ui.relationshipViewToggle] = function(e) {
                     this.relationshipViewToggle(e.currentTarget.checked);
                 };
-                events["click " + this.ui.noValueToggle] = function (e) {
+                events["click " + this.ui.noValueToggle] = function(e) {
                     Utils.togglePropertyRelationshipTableEmptyValues({
                         inputType: this.ui.noValueToggle,
                         tableEl: this.ui.relationshipDetailValue
@@ -84,19 +84,19 @@ define([
              * intialize a new RelationshipLayoutView Layout
              * @constructs
              */
-            initialize: function (options) {
+            initialize: function(options) {
                 _.extend(this, _.pick(options, "entity", "entityName", "guid", "actionCallBack", "attributeDefs", "referredEntities", "entityDefCollection"));
                 this.graphData = this.createData(this.entity);
                 this.relationshipCardCounts = {};
                 this.relationshipLoadedCounts = {};
                 this.cardsViewLoadInProgress = false;
-
-                this.handleRelationshipDataUpdate = _.bind(function (payload) {
+                
+                this.handleRelationshipDataUpdate = _.bind(function(payload) {
                     var relationshipAttributes = payload && payload.data ? payload.data : payload;
                     var relationshipCounts = payload && payload.counts ? payload.counts : this.relationshipCardCounts;
                     var loadedCounts = payload && payload.loadedCounts ? payload.loadedCounts : this.relationshipLoadedCounts;
                     var referredEntities = payload && payload.referredEntities ? payload.referredEntities : null;
-
+                    
                     if (!relationshipAttributes) {
                         return;
                     }
@@ -116,7 +116,7 @@ define([
                         }
                     }
                 }, this);
-                this.handleRelationshipLoading = _.bind(function (isLoading) {
+                this.handleRelationshipLoading = _.bind(function(isLoading) {
                     if (isLoading) {
                         this.$(".fontLoader").show();
                     } else {
@@ -124,12 +124,12 @@ define([
                     }
                 }, this);
             },
-            createData: function (entity) {
+            createData: function(entity) {
                 var that = this,
                     links = [],
                     nodes = {};
                 if (entity && entity.relationshipAttributes) {
-                    _.each(entity.relationshipAttributes, function (obj, key) {
+                    _.each(entity.relationshipAttributes, function(obj, key) {
                         var relationValue = obj;
                         if (relationValue && relationValue.entities) {
                             relationValue = relationValue.entities;
@@ -152,14 +152,14 @@ define([
                 }
                 return { nodes: nodes, links: links };
             },
-            onRender: function () {
+            onRender: function() {
                 this.isRendered = true;
 
                 // Initialize: show card view by default (checked = Card)
                 this.ui.relationshipViewToggle.prop('checked', true);
                 this.relationshipViewToggle(true);
             },
-            onShow: function (argument) {
+            onShow: function(argument) {
                 // Always create graph on show if graph view is active
                 var isGraphView = !this.ui.relationshipViewToggle.is(':checked');
                 if (isGraphView) {
@@ -170,12 +170,12 @@ define([
                     }
                 }
                 this.createTable();
-
+                
                 this.ensureCardsView();
             },
-            ensureCardsView: function (forceRefresh) {
+            ensureCardsView: function(forceRefresh) {
                 var that = this;
-
+                
                 if (this.relationshipCardsViewInstance) {
                     if (forceRefresh) {
                         this.relationshipCardsViewInstance.cardData = {};
@@ -198,7 +198,7 @@ define([
                     return;
                 }
                 this.cardsViewLoadInProgress = true;
-                require(['views/detail_page/RelationshipCardsLayoutView'], function (RelationshipCardsLayoutView) {
+                require(['views/detail_page/RelationshipCardsLayoutView'], function(RelationshipCardsLayoutView) {
                     try {
                         if (!that.relationshipCardsView) {
                             console.warn("[RelationshipLayoutView] Region not available");
@@ -221,22 +221,22 @@ define([
                     } finally {
                         that.cardsViewLoadInProgress = false;
                     }
-                }, function (err) {
+                }, function(err) {
                     console.error("[RelationshipLayoutView] Failed to load RelationshipCardsLayoutView:", err);
                     that.cardsViewLoadInProgress = false;
                 });
             },
-            updateCardsShowEmptyValues: function (showEmptyValues) {
+            updateCardsShowEmptyValues: function(showEmptyValues) {
                 if (!this.relationshipCardsViewInstance) {
                     return;
                 }
                 this.relationshipCardsViewInstance.showEmptyValues = !!showEmptyValues;
                 this.relationshipCardsViewInstance.renderCards();
             },
-            noRelationship: function () {
+            noRelationship: function() {
                 this.$("svg").html('<text x="50%" y="50%" alignment-baseline="middle" text-anchor="middle">No relationship data found</text>');
             },
-            toggleInformationSlider: function (options) {
+            toggleInformationSlider: function(options) {
                 var panel = this.$(".relationship-node-details");
                 if (options && options.close) {
                     panel.removeClass("slide-to-left").addClass("slide-from-left");
@@ -248,18 +248,15 @@ define([
                     }
                 }
             },
-            toggleBoxPanel: function () {
+            toggleBoxPanel: function() {
                 this.$(".relationship-node-details").removeClass("slide-to-left").addClass("slide-from-left");
             },
-            searchNode: function (e) {
+            searchNode: function(e) {
                 var searchString = $(e.currentTarget).val(),
                     listString = "",
                     data = this.selectedNodeData,
                     typeName = this.selectedNodeType,
-                    activeEntityColor = "#1976d2",
-                    deletedEntityColor = "#BB5838",
-                    defaultEntityColor = "#e0e0e0",
-                    normalizeEntity = function (entity) {
+                    normalizeEntity = function(entity) {
                         if (!entity) {
                             return entity;
                         }
@@ -270,71 +267,10 @@ define([
                             return _.extend({}, entity, this.referredEntities[entity.guid]);
                         }
                         return entity;
-                    }.bind(this),
-                    getdefault = function (options) {
-                        var colorClass = options.color === deletedEntityColor ? "deleted" : "active";
-                        return "<pre class='entity-type-name " + colorClass + "'>" + options.name + "</pre>";
-                    },
-                    getWithButton = function (options) {
-                        var name = options.name,
-                            guid = options.options.guid,
-                            entityTypeButton = "",
-                            colorClass = options.color === deletedEntityColor ? "deleted" : "active";
-                        if (guid) {
-                            if (options.entity) {
-                                entityTypeButton = "<a href='#!/detailPage/" + guid + "' class='entity-type-name " + colorClass + "'>" + name + "</a>";
-                            } else if (options.relationship) {
-                                entityTypeButton = "<a href='#/relationshipDetailPage/" + guid + "' class='entity-type-name " + colorClass + "'>" + name + "</a>";
-                            } else {
-                                entityTypeButton = "<a href='#!/detailPage/" + guid + "' class='entity-type-name " + colorClass + "'>" + name + "</a>";
-                            }
-                        } else {
-                            entityTypeButton = "<pre class='entity-type-name " + colorClass + "'>" + name + "</pre>";
-                        }
-                        return entityTypeButton;
-                    },
-                    getEntityTypelist = function (options) {
-                        var name = options.entityName ? options.entityName : Utils.getName(options, "displayText"),
-                            entityTypeHtml = "";
-                        if (options.entityStatus == "ACTIVE" || options.status == "ACTIVE") {
-                            if (options.relationshipStatus == "ACTIVE") {
-                                entityTypeHtml = getWithButton({
-                                    color: activeEntityColor,
-                                    options: options,
-                                    name: name
-                                });
-                            } else if (options.relationshipStatus == "DELETED") {
-                                entityTypeHtml = getWithButton({
-                                    color: activeEntityColor,
-                                    options: options,
-                                    name: name,
-                                    relationship: true
-                                });
-                            }
-                        } else if (options.entityStatus == "DELETED") {
-                            entityTypeHtml = getWithButton({
-                                color: deletedEntityColor,
-                                options: options,
-                                name: name,
-                                entity: true
-                            });
-                        } else {
-                            entityTypeHtml = getdefault({
-                                color: activeEntityColor,
-                                options: options,
-                                name: name
-                            });
-                        }
-                        return entityTypeHtml + "</pre>";
-                    };
+                    }.bind(this);
                 this.ui.searchNode.hide();
                 this.$("[data-id='typeName']").text(typeName);
-                var getElement = function (options) {
-                    var name = options.entityName ? options.entityName : Utils.getName(options, "displayText");
-                    var entityTypeButton = getEntityTypelist(options);
-                    return entityTypeButton;
-                };
-                var buildEntityObj = function (item) {
+                var buildEntityObj = function(item) {
                     var normalized = normalizeEntity(item);
                     var ref = normalized && normalized.guid ? this.referredEntities && this.referredEntities[normalized.guid] : null;
                     var displayText = (ref && (ref.displayText || (ref.attributes && ref.attributes.name))) ||
@@ -349,7 +285,7 @@ define([
                         typeName: typeName
                     });
                 }.bind(this);
-                var buildListItem = function (item) {
+                var buildListItem = function(item) {
                     var name = item.entityName || Utils.getName(item, "displayText");
                     var typeName = item.typeName || "";
                     var displayLabel = typeName ? name + " (" + typeName + ")" : name;
@@ -362,13 +298,13 @@ define([
                     return "<li class='entity-list-item'>" + content + "</li>";
                 };
                 if (_.isArray(data)) {
-                    data = _.map(data, function (item) {
+                    data = _.map(data, function(item) {
                         return buildEntityObj(item);
                     });
                     if (data.length > 1) {
                         this.ui.searchNode.show();
                     }
-                    _.each(_.sortBy(data, "entityName"), function (val) {
+                    _.each(_.sortBy(data, "entityName"), function(val) {
                         var name = val.entityName || Utils.getName(val, "displayText");
                         var searchTarget = (name + " " + (val.typeName || "")).toLowerCase();
                         if (searchString) {
@@ -392,11 +328,12 @@ define([
                 if ($.fn.tooltip) {
                     this.$("[data-id='entityList']").find('[title]').tooltip({
                         placement: 'bottom',
-                        container: 'body'
+                        container: 'body',
+                        template: '<div class="tooltip relationship-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
                     });
                 }
             },
-            createGraph: function (data) {
+            createGraph: function(data) {
                 //Ref - http://bl.ocks.org/fancellu/2c782394602a93921faff74e594d1bb1
 
                 var that = this,
@@ -409,7 +346,7 @@ define([
                     deletedEntityColor = "#BB5838",
                     defaultEntityColor = "#e0e0e0",
                     selectedNodeColor = "#4a90e2";
-                var getNodeCount = function (node) {
+                var getNodeCount = function(node) {
                     if (!node) {
                         return 0;
                     }
@@ -445,7 +382,7 @@ define([
                 var zoom = d3
                     .zoom()
                     .scaleExtent([0.1, 4])
-                    .on("zoom", function () {
+                    .on("zoom", function() {
                         container.attr("transform", d3.event.transform);
                     });
 
@@ -467,7 +404,7 @@ define([
                     .attr("xoverflow", "visible")
                     .append("svg:path")
                     .attr("d", "M 0,-5 L 10,0 L 0,5")
-                    .attr("fill", function (d) {
+                    .attr("fill", function(d) {
                         return d === "deletedLink" ? deletedEntityColor : activeEntityColor;
                     })
                     .attr("stroke", "none");
@@ -478,7 +415,7 @@ define([
                         "link",
                         d3
                             .forceLink(links)
-                            .id(function (d) {
+                            .id(function(d) {
                                 return d.name;
                             })
                             .distance(150)
@@ -487,45 +424,45 @@ define([
                     .force("center", d3.forceCenter(width / 2, height / 2))
                     .force("collision", d3.forceCollide().radius(50));
 
-                path = container
+                    path = container
                     .append("g")
-                    .selectAll("path")
-                    .data(links)
-                    .enter()
+                        .selectAll("path")
+                        .data(links)
+                        .enter()
                     .append("path")
-                    .attr("class", "relatioship-link")
-                    .attr("marker-end", function (d) {
+                        .attr("class", "relatioship-link")
+                    .attr("marker-end", function(d) {
                         return isAllEntityRelationDeleted({ data: d, type: "link" }) ? "url(#deletedLink)" : "url(#activeLink)";
                     })
-                    .attr("stroke", function (d) {
+                        .attr("stroke", function(d) {
                         return isAllEntityRelationDeleted({ data: d, type: "link" }) ? deletedEntityColor : activeEntityColor;
-                    });
+                        });
 
-                node = container
+                    node = container
                     .append("g")
-                    .selectAll(".node")
-                    .data(nodes)
-                    .enter()
-                    .append("g")
-                    .attr("class", "node")
-                    .on("mousedown", function () {
-                        d3.event.preventDefault();
-                    })
-                    .on("click", function (d) {
-                        if (d3.event.defaultPrevented) return; // ignore drag
-                        if (d && d.value && d.value.guid == that.guid) {
-                            that.ui.boxClose.trigger("click");
-                            return;
-                        }
-                        that.toggleBoxPanel({ el: that.$(".relationship-node-details") });
-                        that.ui.searchNode.data({ obj: d });
-                        $(this)
-                            .find("circle")
-                            .addClass("node-detail-highlight");
-                        that.updateRelationshipDetails({ obj: d });
-                    })
-                    .call(
-                        d3
+                        .selectAll(".node")
+                        .data(nodes)
+                        .enter()
+                        .append("g")
+                        .attr("class", "node")
+                        .on("mousedown", function() {
+                            d3.event.preventDefault();
+                        })
+                        .on("click", function(d) {
+                            if (d3.event.defaultPrevented) return; // ignore drag
+                            if (d && d.value && d.value.guid == that.guid) {
+                                that.ui.boxClose.trigger("click");
+                                return;
+                            }
+                            that.toggleBoxPanel({ el: that.$(".relationship-node-details") });
+                            that.ui.searchNode.data({ obj: d });
+                            $(this)
+                                .find("circle")
+                                .addClass("node-detail-highlight");
+                            that.updateRelationshipDetails({ obj: d });
+                        })
+                        .call(
+                            d3
                             .drag()
                             .on("start", dragstarted)
                             .on("drag", dragged)
@@ -533,105 +470,105 @@ define([
                     );
 
                 node.append("circle")
-                    .attr("r", function () {
+                        .attr("r", function() {
                         return 25;
-                    })
-                    .attr("fill", function (d) {
+                        })
+                        .attr("fill", function(d) {
                         if (d.name === that.entity.typeName) {
-                            return selectedNodeColor;
-                        } else {
+                                    return selectedNodeColor;
+                            } else {
                             return isAllEntityRelationDeleted({ data: d, type: "node" }) ? deletedEntityColor : activeEntityColor;
-                        }
-                    })
+                            }
+                        })
                     .attr("stroke", "#fff")
                     .attr("stroke-width", "2px")
                     .style("cursor", "pointer")
-                    .on("click", function (d) {
+                    .on("click", function(d) {
                         if (d && d.value && d.value.guid == that.guid) {
                             return;
                         }
                         that.selectedNodeData = d.value;
                         that.selectedNodeType = d.name;
-
+                        
                         // Show the panel
                         var panel = that.$(".relationship-node-details");
                         panel.removeClass("slide-to-left").addClass("slide-from-left");
-
+                        
                         // Trigger after a small delay to ensure DOM is ready
-                        setTimeout(function () {
+                        setTimeout(function() {
                             panel.removeClass("slide-from-left").addClass("slide-to-left");
                             that.searchNode({ currentTarget: that.ui.searchNode });
                         }, 10);
-                    });
+                        });
 
-                node.append("text")
-                    .attr("x", 0)
-                    .attr("y", 0)
-                    .attr("dy", function () {
-                        return 25 - 17;
-                    })
-                    .attr("text-anchor", "middle")
-                    .style("font-family", "FontAwesome")
-                    .style("font-size", "25px")
-                    .attr("class", "relationship-node-icon")
-                    .text(function (d) {
-                        var iconObj = Enums.graphIcon[d.name];
-                        if (iconObj && iconObj.textContent) {
-                            return iconObj.textContent;
-                        }
-                        if (d && _.isArray(d.value) && d.value.length > 1) {
-                            return "\uf0c5";
-                        }
-                        return "\uf016";
-                    })
-                    .attr("fill", "#fff");
+                    node.append("text")
+                        .attr("x", 0)
+                        .attr("y", 0)
+                        .attr("dy", function() {
+                            return 25 - 17;
+                        })
+                        .attr("text-anchor", "middle")
+                        .style("font-family", "FontAwesome")
+                        .style("font-size", "25px")
+                        .attr("class", "relationship-node-icon")
+                        .text(function(d) {
+                            var iconObj = Enums.graphIcon[d.name];
+                            if (iconObj && iconObj.textContent) {
+                                return iconObj.textContent;
+                            }
+                            if (d && _.isArray(d.value) && d.value.length > 1) {
+                                return "\uf0c5";
+                            }
+                            return "\uf016";
+                        })
+                        .attr("fill", "#fff");
 
-                var countBox = node.append("g");
+                    var countBox = node.append("g");
 
-                countBox
-                    .append("circle")
-                    .attr("cx", 18)
-                    .attr("cy", -20)
-                    .attr("class", "relationship-node-count")
-                    .attr("r", function (d) {
-                        var count = getNodeCount(d);
-                        if (count > 1) {
-                            return 9;
-                        }
-                    });
+                    countBox
+                        .append("circle")
+                        .attr("cx", 18)
+                        .attr("cy", -20)
+                        .attr("class", "relationship-node-count")
+                        .attr("r", function(d) {
+                            var count = getNodeCount(d);
+                            if (count > 1) {
+                                return 9;
+                            }
+                        });
 
-                countBox
-                    .append("text")
-                    .attr("dx", 18)
-                    .attr("dy", -16)
-                    .attr("text-anchor", "middle")
-                    .attr("fill", defaultEntityColor)
-                    .attr("class", "relationship-node-count")
-                    .text(function (d) {
-                        var count = getNodeCount(d);
-                        if (count > 1) {
-                            return count;
-                        }
-                    });
+                    countBox
+                        .append("text")
+                        .attr("dx", 18)
+                        .attr("dy", -16)
+                        .attr("text-anchor", "middle")
+                        .attr("fill", defaultEntityColor)
+                        .attr("class", "relationship-node-count")
+                        .text(function(d) {
+                            var count = getNodeCount(d);
+                            if (count > 1) {
+                                return count;
+                            }
+                        });
 
-                node
-                    .append("text")
-                    .attr("x", -15)
-                    .attr("y", "35")
-                    .attr("class", "relationship-node-label")
-                    .text(function (d) {
-                        return d.name;
-                    });
+                    node
+                        .append("text")
+                        .attr("x", -15)
+                        .attr("y", "35")
+                        .attr("class", "relationship-node-label")
+                        .text(function(d) {
+                            return d.name;
+                        });
 
-                simulation.on("tick", function () {
-                    path.attr("d", function (d) {
+                simulation.on("tick", function() {
+                    path.attr("d", function(d) {
                         var dx = d.target.x - d.source.x,
                             dy = d.target.y - d.source.y,
                             dr = Math.sqrt(dx * dx + dy * dy);
                         return "M" + d.source.x + "," + d.source.y + "A" + dr + "," + dr + " 0 0,1 " + d.target.x + "," + d.target.y;
                     });
 
-                    node.attr("transform", function (d) {
+                    node.attr("transform", function(d) {
                         return "translate(" + d.x + "," + d.y + ")";
                     });
                 });
@@ -670,7 +607,7 @@ define([
                     }
 
                     return (
-                        _.findIndex(d.value, function (val) {
+                        _.findIndex(d.value, function(val) {
                             if (type == "node") {
                                 return (val.entityStatus || val.status) == "ACTIVE";
                             } else {
@@ -679,7 +616,7 @@ define([
                         }) == -1
                     );
                 }
-                var zoomClick = function () {
+                var zoomClick = function() {
                     var scaleFactor = 0.8;
                     if (this.id === 'zoom_in') {
                         scaleFactor = 1.3;
@@ -689,7 +626,7 @@ define([
 
                 d3.selectAll(this.$('.lineageZoomButton')).on('click', zoomClick);
             },
-            createTable: function () {
+            createTable: function() {
                 this.entityModel = new VEntity({});
                 var table = CommonViewFunction.propertyTable({
                     scope: this,
@@ -702,7 +639,7 @@ define([
                     tableEl: this.ui.relationshipDetailValue
                 });
             },
-            relationshipViewToggle: function (checked) {
+            relationshipViewToggle: function(checked) {
                 var that = this;
 
                 // In the original code: checked = Table, unchecked = Graph
@@ -716,12 +653,12 @@ define([
                     this.ui.relationshipDetailTable.hide();
                     this.ui.relationshipDetailValue.hide();
                     this.ui.relationshipCardsView.show();
-
+                    
                     // Render card view if not already rendered
                     this.ensureCardsView();
-
+                    
                     // Force a re-render after a short delay to ensure DOM is ready
-                    setTimeout(function () {
+                    setTimeout(function() {
                         if (that.relationshipCardsViewInstance) {
                             that.relationshipCardsViewInstance.renderCards();
                         }
@@ -735,7 +672,7 @@ define([
                     this.ui.relationshipDetailTable.show();
                     this.ui.relationshipDetailValue.show();
                     this.ui.relationshipCardsView.hide();
-
+                    
                     // Ensure graph is created if it hasn't been created yet
                     if (this.graphData && !_.isEmpty(this.graphData.links)) {
                         // Clear existing graph and recreate
@@ -746,8 +683,8 @@ define([
                     }
                 }
             },
-
-            onDestroy: function () {
+            
+            onDestroy: function() {
                 if ($.fn.tooltip && this.$el) {
                     this.$el.find('[title]').tooltip('destroy');
                 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

**ATLAS-5376: Atlas UI: Relationship cards layout breaking, overlapping, and tooltip placement issues with long entity names (React & Classic UI)**

This patch addresses several layout, rendering, and type-safety issues on the Entity Detail "Relationships" tab when dealing with extremely long relationship item names (e.g., massive queries or Kafka topic names without spaces).

### **React UI Changes:**
- **Ref Forwarding & Console Warning Fix:** Wrapped `<MUILink>` components inside `<span>` elements under `<LightTooltip>` in both `CustomLink` and `getWithButton` in `RelationshipLineage.tsx`. This guarantees proper ref forwarding to MUI Tooltip and prevents React Router console warnings.
- **Strict Type Safety:** Removed the `// @ts-nocheck` directive from `RelationshipLineage.tsx`. Refactored both `RelationshipLineage.tsx` and `RelationshipLineage.test.tsx` to eliminate all `any` types, introducing strict interfaces (`GraphNode`, `GraphLink`) and type guards (`Record<string, unknown>`).
- **DOM & Testability Attributes:** Utilized `guid` on `CustomLink` by attaching `data-guid={guid}` to list items and `data-testid={`relationship-link-${guid}`}` to links.

### **Classic UI Changes:**
- **Tooltip Width & Scoping:** Restored `.tooltip-inner { max-width: none; }` globally in `theme.scss` to prevent global UI regressions across Classic UI. Scoped `max-width: 300px; word-break: break-all; word-break: break-word; overflow-wrap: break-word;` under `.relationship-tooltip` and relationship containers in `relationship.scss`.
- **Bootstrap Tooltip Template:** Configured Bootstrap tooltips (`$.fn.tooltip`) in `RelationshipLayoutView.js` and `RelationshipCardsLayoutView.js` using `template: '<div class="tooltip relationship-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'` to enforce proper wrapping and max-width when tooltips are appended to `body`.
- **Sidebar Truncation & Number Alignment:**
  - Moved truncation styles from `ul > li.entity-list-item` to `.entity-list-item .entity-type-name` in `graph.scss`.
  - Updated list selectors to include `ol > li` alongside `ul > li`.
  - Applied `max-width: calc(100% - 25px); vertical-align: top; line-height: 1.5;` to `.entity-type-name`. This ensures that long names truncate cleanly with `...` while keeping the list number `1.` and text aligned on the exact same baseline without dropping to a second line.
- **Dead Code Cleanup & Clean Diff:** Removed unused functions (`getdefault`, `getWithButton`, `getEntityTypelist`, `getElement`) in `RelationshipLayoutView.js` and reverted formatting-only whitespace diffs to preserve master's code style.

---

## How was this patch tested?

- **Manual Testing:**
  - Created test entities with exceptionally long relationship names (300+ characters without spaces).
  - Verified in both React and Classic UI that long relationship names truncate cleanly with `...` without breaking layout boundaries or dropping text below list numbers (`1.`).
  - Verified that list numbers and truncated entity names align on the exact same top baseline in the graph sidebar drawer.
  - Hovered over truncated items in both UIs; verified that tooltips wrap within a `300px` boundary without spilling off-screen.
  - Inspected browser console to confirm zero React ref/routing warnings when hovering or clicking tooltips and links.
  - Verified that tooltips are properly destroyed on component unmount / view re-renders, preventing orphaned DOM nodes.

- **Automated Testing & Type Checks:**
  - Ran Jest unit tests (`RelationshipLineage.test.tsx` - 61 tests passed), covering deleted status class assertions (`deleted-relation`, `text-deleted`), missing `typeName` fallback, and full untruncated tooltip titles.
  - Validated strict TypeScript compilation (`npx tsc --noEmit -p tsconfig.build.json`).
  - Verified linting (`npx eslint`) across staged and unstaged files.

***