### PR TITLE
ATLAS-5385: Rename header authentication config to atlas.authentication.method.header.* (2.6)

### DIFF
--- a/distro/src/conf/atlas-application.properties
+++ b/distro/src/conf/atlas-application.properties
@@ -167,6 +167,12 @@ atlas.authentication.method.file.filename=${sys:atlas.home}/conf/users-credentia
 #atlas.authentication.method.ldap.ad.user.searchfilter=(sAMAccountName={0})
 #atlas.authentication.method.ldap.ad.default.role=<default role>
 
+######### Header Based Authentication #########
+#atlas.authentication.method.header.enabled=false
+#atlas.authentication.method.header.username=username
+#atlas.authentication.method.header.roles=roles
+#atlas.authentication.method.header.request-id=requestid
+
 #########  JAAS Configuration ########
 
 #atlas.jaas.KafkaClient.loginModuleName = com.sun.security.auth.module.Krb5LoginModule
@@ -282,9 +288,3 @@ atlas.search.gremlin.enable=false
 ######### Skip check for the same attribute name in Parent type and Child type #########
 
 #atlas.skip.check.for.parent.child.attribute.name=true
-
-######### Header Based Authentication #########
-#atlas.authn.header.enabled=false
-#atlas.authn.header.username=x-awc-username
-#atlas.authn.header.roles=x-awc-roles
-#atlas.authn.header.requestid=x-awc-requestid

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AtlasHeaderPreAuthFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AtlasHeaderPreAuthFilter.java
@@ -50,10 +50,10 @@ import java.util.UUID;
 public class AtlasHeaderPreAuthFilter implements Filter {
     private static final Logger LOG = LoggerFactory.getLogger(AtlasHeaderPreAuthFilter.class);
 
-    public static final String PROP_HEADER_AUTH_ENABLED = "atlas.authn.header.enabled";
-    public static final String PROP_USERNAME_HEADER     = "atlas.authn.header.username";
-    public static final String PROP_ROLES_HEADER        = "atlas.authn.header.roles";
-    public static final String PROP_REQUEST_ID_HEADER   = "atlas.authn.header.requestid";
+    public static final String PROP_HEADER_AUTH_ENABLED = "atlas.authentication.method.header.enabled";
+    public static final String PROP_USERNAME_HEADER     = "atlas.authentication.method.header.username";
+    public static final String PROP_ROLES_HEADER        = "atlas.authentication.method.header.roles";
+    public static final String PROP_REQUEST_ID_HEADER   = "atlas.authentication.method.header.request-id";
     public static final String REQUEST_ID_ATTRIBUTE     = "atlas.request.id";
 
     private Configuration configuration;

--- a/webapp/src/test/java/org/apache/atlas/web/filters/AtlasHeaderPreAuthFilterTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/filters/AtlasHeaderPreAuthFilterTest.java
@@ -74,11 +74,11 @@ public class AtlasHeaderPreAuthFilterTest {
     public void testDoFilterEnabledWithUsernameAndRoles() throws Exception {
         when(configuration.getBoolean(AtlasHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, false)).thenReturn(true);
         when(configuration.getString(AtlasHeaderPreAuthFilter.PROP_USERNAME_HEADER, ""))
-                .thenReturn("x-user");
+                .thenReturn("X-Forwarded-User");
         when(configuration.getString(AtlasHeaderPreAuthFilter.PROP_ROLES_HEADER, ""))
-                .thenReturn("x-roles");
-        when(request.getHeader("x-user")).thenReturn("alice");
-        when(request.getHeader("x-roles")).thenReturn("ROLE_ADMIN, ROLE_USER");
+                .thenReturn("X-Forwarded-Groups");
+        when(request.getHeader("X-Forwarded-User")).thenReturn("alice");
+        when(request.getHeader("X-Forwarded-Groups")).thenReturn("ROLE_ADMIN, ROLE_USER");
 
         try (MockedStatic<ApplicationProperties> appProps = org.mockito.Mockito.mockStatic(ApplicationProperties.class)) {
             appProps.when(ApplicationProperties::get).thenReturn(configuration);
@@ -104,10 +104,10 @@ public class AtlasHeaderPreAuthFilterTest {
     public void testDoFilterEnabledWithoutUsernameDoesNotAuthenticate() throws IOException, ServletException {
         when(configuration.getBoolean(AtlasHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, false)).thenReturn(true);
         when(configuration.getString(AtlasHeaderPreAuthFilter.PROP_USERNAME_HEADER, ""))
-                .thenReturn("x-user");
+                .thenReturn("X-Forwarded-User");
         when(configuration.getString(AtlasHeaderPreAuthFilter.PROP_ROLES_HEADER, ""))
-                .thenReturn("x-roles");
-        when(request.getHeader("x-user")).thenReturn("   ");
+                .thenReturn("X-Forwarded-Groups");
+        when(request.getHeader("X-Forwarded-User")).thenReturn("   ");
 
         try (MockedStatic<ApplicationProperties> appProps = org.mockito.Mockito.mockStatic(ApplicationProperties.class)) {
             appProps.when(ApplicationProperties::get).thenReturn(configuration);
@@ -128,10 +128,8 @@ public class AtlasHeaderPreAuthFilterTest {
 
         when(configuration.getBoolean(AtlasHeaderPreAuthFilter.PROP_HEADER_AUTH_ENABLED, false)).thenReturn(true);
         when(configuration.getString(AtlasHeaderPreAuthFilter.PROP_USERNAME_HEADER, ""))
-                .thenReturn("x-user");
-        when(configuration.getString(AtlasHeaderPreAuthFilter.PROP_ROLES_HEADER, ""))
-                .thenReturn("x-roles");
-        when(request.getHeader("x-user")).thenReturn("alice");
+                .thenReturn("X-Forwarded-User");
+        when(request.getHeader("X-Forwarded-User")).thenReturn("alice");
 
         try (MockedStatic<ApplicationProperties> appProps = org.mockito.Mockito.mockStatic(ApplicationProperties.class)) {
             appProps.when(ApplicationProperties::get).thenReturn(configuration);


### PR DESCRIPTION
## Summary

Same change as #735, targeted at **atlas-2.6** branch.

Rename header authentication properties from `atlas.authn.header.*` to `atlas.authentication.method.header.*` in the existing `AtlasHeaderPreAuthFilter`. No behavior change; same filter logic.

## Migration

```properties
# Before
atlas.authn.header.enabled=true
atlas.authn.header.username=<header-name>
atlas.authn.header.roles=<header-name>
atlas.authn.header.requestid=<header-name>

# After
atlas.authentication.method.header.enabled=true
atlas.authentication.method.header.username=<header-name>
atlas.authentication.method.header.roles=<header-name>
atlas.authentication.method.header.request-id=<header-name>
```

## Test plan

- [ ] Enable header auth with updated property keys in `atlas-application.properties`
- [ ] Verify API access with curl using configured identity headers
- [ ] Run `AtlasHeaderPreAuthFilterTest`

https://issues.apache.org/jira/browse/ATLAS-5385

Related: #735

Made with [Cursor](https://cursor.com)