### PR TITLE
ATLAS-5387 : Add WhatsNew-2.6 release notes

### DIFF
--- a/docs/docz-lib/config/menu.js
+++ b/docs/docz-lib/config/menu.js
@@ -87,7 +87,7 @@ export default [
             "Download",
             {
                 name: "Whats New",
-                menu: ["WhatsNew-2.5", "WhatsNew-2.4", "WhatsNew-2.3", "WhatsNew-2.2", "WhatsNew-2.1", "WhatsNew-2.0", "WhatsNew-1.0"]
+                menu: ["WhatsNew-2.6", "WhatsNew-2.5", "WhatsNew-2.4", "WhatsNew-2.3", "WhatsNew-2.2", "WhatsNew-2.1", "WhatsNew-2.0", "WhatsNew-1.0"]
             },
             "Migration"
         ]

--- a/docs/src/documents/Overview.md
+++ b/docs/src/documents/Overview.md
@@ -48,7 +48,7 @@ capabilities around these data assets for data scientists, analysts and the data
 
 ## Getting Started
 
-   * [What's new in Apache Atlas 2.5?](#/WhatsNew-2.5)
+   * [What's new in Apache Atlas 2.6?](#/WhatsNew-2.6)
    * [Build & Install](#/Installation)
    * [Quick Start](#/QuickStart)
 

--- a/docs/src/documents/Whats-New/WhatsNew-2.6.md
+++ b/docs/src/documents/Whats-New/WhatsNew-2.6.md
@@ -1,0 +1,41 @@
+---
+name: WhatsNew-2.6
+route: /WhatsNew-2.6
+menu: Downloads
+submenu: Whats New
+---
+
+# What's new in Apache Atlas 2.6?
+
+## Features
+* **React UI**: Dashboard Overview; Vite-based build optimizations and lazy route loading; broad React UI coverage for search, glossary, lineage, audit, and administration
+* **Authentication**: JWT authentication support; header-based authentication for trusted proxy / gateway deployments
+* **Notifications**: Distributed notification processing
+* **Export / Import**: Concurrent ingest; export/import improvements for tag attributes and relationship types
+* **Propagation**: Rename and delete propagation support
+* **Graph / persistence**: RDBMS backend and audit repository support (with follow-on fixes)
+* **Admin / Purge**: Authorization on Admin REST endpoints; Auto Purge UI improvements
+* **Docker**: Immutable container setup updates
+
+## Enhancements
+* **Platform**
+  * Upgrade to Hadoop 3.4.2 and HBase 2.6.x
+  * Upgrade JanusGraph to 1.1.0
+  * Migrate from commons-configuration1 to commons-configuration2
+  * Replace HBase dependencies with hbase-shaded-*-hadoop3 variants
+* **Dependencies**
+  * Netty, dompurify, handlebars, and frontend npm dependency upgrades
+* **Search**
+  * CONTAINS query handling with JanusGraph indexing improvements
+* **Hooks**
+  * Impala lineage fix for self-referencing INSERT OVERWRITE
+  * Ignore/rename pattern fixes
+* **Export / Import**
+  * Incremental export fixes; import script and Kafka import improvements
+* **UI**
+  * Classic/React UI coexistence fixes; relationship tab UX; glossary and business metadata fixes
+* **Security**
+  * XSS fix in sanitize-html; Swagger apidocs static asset access adjustment
+* **Release / build**
+  * Release artifact checksums; WAR size and build stabilization for atlas-2.6
+* [List of JIRAs resolved in Apache Atlas 2.6.0 release](https://issues.apache.org/jira/issues/?jql=project%20%3D%20ATLAS%20AND%20fixVersion%20%3D%202.6.0%20ORDER%20BY%20key%20DESC)

--- a/docs/src/documents/Whats-New/WhatsNew-2.6.md
+++ b/docs/src/documents/Whats-New/WhatsNew-2.6.md
@@ -36,6 +36,7 @@ submenu: Whats New
   * Classic/React UI coexistence fixes; relationship tab UX; glossary and business metadata fixes
 * **Security**
   * XSS fix in sanitize-html; Swagger apidocs static asset access adjustment
+  * Header auth configuration keys renamed to `atlas.authentication.method.header.*` (see `atlas-application.properties`)
 * **Release / build**
   * Release artifact checksums; WAR size and build stabilization for atlas-2.6
 * [List of JIRAs resolved in Apache Atlas 2.6.0 release](https://issues.apache.org/jira/issues/?jql=project%20%3D%20ATLAS%20AND%20fixVersion%20%3D%202.6.0%20ORDER%20BY%20key%20DESC)

--- a/docs/src/documents/Whats-New/WhatsNew-2.6.md
+++ b/docs/src/documents/Whats-New/WhatsNew-2.6.md
@@ -36,7 +36,7 @@ submenu: Whats New
   * Classic/React UI coexistence fixes; relationship tab UX; glossary and business metadata fixes
 * **Security**
   * XSS fix in sanitize-html; Swagger apidocs static asset access adjustment
-  * **Header-based authentication** (trusted proxy): when `atlas.authentication.method.header.enabled=true`, Atlas reads configured HTTP headers for username, comma-separated roles, and optional request ID from a trusted gateway and authenticates REST calls without Basic auth (e.g. `curl -H "username: ramk" -H "roles: dev" -H "requestid: test-1" http://localhost:21000/api/atlas/admin/version`).
+  * **Header-based authentication** (trusted proxy): when `atlas.authentication.method.header.enabled=true`, Atlas reads configured HTTP headers for username, comma-separated roles, and optional request ID from a trusted gateway and authenticates REST calls without Basic auth (e.g. `curl -H "username: alice" -H "roles: dev" -H "requestid: test-1" http://localhost:21000/api/atlas/admin/version`).
   * Header auth settings use `atlas.authentication.method.header.*` keys in `atlas-application.properties`—map each logical field (`username`, `roles`, `request-id`) to the HTTP header name your proxy sends (renamed from `atlas.authn.header.*`).
 * **Release / build**
   * Release artifact checksums; WAR size and build stabilization for atlas-2.6

--- a/docs/src/documents/Whats-New/WhatsNew-2.6.md
+++ b/docs/src/documents/Whats-New/WhatsNew-2.6.md
@@ -36,7 +36,8 @@ submenu: Whats New
   * Classic/React UI coexistence fixes; relationship tab UX; glossary and business metadata fixes
 * **Security**
   * XSS fix in sanitize-html; Swagger apidocs static asset access adjustment
-  * Header auth configuration keys renamed to `atlas.authentication.method.header.*` (see `atlas-application.properties`)
+  * **Header-based authentication** (trusted proxy): when `atlas.authentication.method.header.enabled=true`, Atlas reads configured HTTP headers for username, comma-separated roles, and optional request ID from a trusted gateway and authenticates REST calls without Basic auth (e.g. `curl -H "username: ramk" -H "roles: dev" -H "requestid: test-1" http://localhost:21000/api/atlas/admin/version`).
+  * Header auth settings use `atlas.authentication.method.header.*` keys in `atlas-application.properties`—map each logical field (`username`, `roles`, `request-id`) to the HTTP header name your proxy sends (renamed from `atlas.authn.header.*`).
 * **Release / build**
   * Release artifact checksums; WAR size and build stabilization for atlas-2.6
 * [List of JIRAs resolved in Apache Atlas 2.6.0 release](https://issues.apache.org/jira/issues/?jql=project%20%3D%20ATLAS%20AND%20fixVersion%20%3D%202.6.0%20ORDER%20BY%20key%20DESC)


### PR DESCRIPTION
## Summary
- Add `WhatsNew-2.6.md` following the same structure as `WhatsNew-2.5.md`
- Document 2.6 features (React UI, JWT/header authentication, distributed notifications, propagation, RDBMS, admin/purge, Docker) and enhancements (platform upgrades, search, hooks, security fixes, release/build)
- Wire the page into the docs site menu and Overview Getting Started link

## Test plan
- [ ] Verify `WhatsNew-2.6` renders in the docs site under Downloads → Whats New
- [ ] Confirm Overview Getting Started link points to `#/WhatsNew-2.6`
- [ ] Spot-check feature/enhancement bullets against the 2.6.0 JIRA fixVersion list


Refer:https://issues.apache.org/jira/browse/ATLAS-5387