### PR TITLE
ATLAS-5386: Harden CSP headers by removing unsafe directives (unsafe-…

### DIFF
--- a/server-common/pom.xml
+++ b/server-common/pom.xml
@@ -196,5 +196,15 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/server-common/src/main/java/org/apache/atlas/server/common/filters/AtlasAuthenticationFilter.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/filters/AtlasAuthenticationFilter.java
@@ -421,7 +421,7 @@ public class AtlasAuthenticationFilter extends AuthenticationFilter {
             String                      action          = httpRequest.getParameter("action");
             String                      doAsUser        = request.getParameter("doAs");
 
-            HeadersUtil.setSecurityHeaders(responseWrapper);
+            HeadersUtil.setSecurityHeaders(responseWrapper, request);
 
             if (logoutHandler != null && supportTrustedProxy && StringUtils.isNotEmpty(doAsUser) && StringUtils.equals(action, RestUtil.TIMEOUT_ACTION)) {
                 if (existingAuth != null) {

--- a/server-common/src/main/java/org/apache/atlas/server/common/filters/AtlasCSRFPreventionFilter.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/filters/AtlasCSRFPreventionFilter.java
@@ -104,7 +104,7 @@ public class AtlasCSRFPreventionFilter implements Filter {
         final HttpServletResponse   httpResponse    = (HttpServletResponse) response;
         AtlasResponseRequestWrapper responseWrapper = new AtlasResponseRequestWrapper(httpResponse);
 
-        HeadersUtil.setSecurityHeaders(responseWrapper);
+        HeadersUtil.setSecurityHeaders(responseWrapper, request);
 
         if (isCSRF_ENABLED) {
             handleHttpInteraction(new ServletFilterHttpInteraction(httpRequest, httpResponse, chain));

--- a/server-common/src/main/java/org/apache/atlas/server/common/filters/AtlasHeaderFilter.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/filters/AtlasHeaderFilter.java
@@ -34,7 +34,7 @@ public class AtlasHeaderFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
-        setHeaders((HttpServletResponse) response);
+        setHeaders((HttpServletResponse) response, request);
         filterChain.doFilter(request, response);
     }
 
@@ -42,9 +42,15 @@ public class AtlasHeaderFilter implements Filter {
     public void destroy() {
     }
 
-    public void setHeaders(HttpServletResponse httpResponse) {
+    public void setHeaders(HttpServletResponse httpResponse, ServletRequest request) {
         AtlasResponseRequestWrapper responseWrapper = new AtlasResponseRequestWrapper(httpResponse);
 
-        HeadersUtil.setSecurityHeaders(responseWrapper);
+        HeadersUtil.setSecurityHeaders(responseWrapper, request);
+    }
+
+    public void setHeaders(HttpServletResponse httpResponse, String cspNonce) {
+        AtlasResponseRequestWrapper responseWrapper = new AtlasResponseRequestWrapper(httpResponse);
+
+        HeadersUtil.setSecurityHeaders(responseWrapper, cspNonce);
     }
 }

--- a/server-common/src/main/java/org/apache/atlas/server/common/filters/AtlasKnoxSSOAuthenticationFilter.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/filters/AtlasKnoxSSOAuthenticationFilter.java
@@ -165,7 +165,7 @@ public class AtlasKnoxSSOAuthenticationFilter implements Filter {
         HttpServletResponse         httpResponse    = (HttpServletResponse) servletResponse;
         AtlasResponseRequestWrapper responseWrapper = new AtlasResponseRequestWrapper(httpResponse);
 
-        HeadersUtil.setSecurityHeaders(responseWrapper);
+        HeadersUtil.setSecurityHeaders(responseWrapper, servletRequest);
 
         if (!ssoEnabled) {
             filterChain.doFilter(servletRequest, servletResponse);

--- a/server-common/src/main/java/org/apache/atlas/server/common/filters/HeadersUtil.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/filters/HeadersUtil.java
@@ -26,10 +26,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import javax.servlet.ServletRequest;
+
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
 public class HeadersUtil {
@@ -40,11 +45,13 @@ public class HeadersUtil {
     public static final String X_XSS_PROTECTION_KEY                = "X-XSS-Protection";
     public static final String STRICT_TRANSPORT_SEC_KEY            = "Strict-Transport-Security";
     public static final String CONTENT_SEC_POLICY_KEY              = "Content-Security-Policy";
+    public static final String CONTENT_SEC_POLICY_NONCE_PLACEHOLDER = "${nonce}";
+    public static final String CONTENT_SEC_POLICY_NONCE_REQUEST_ATTRIBUTE = "atlas.csp.nonce";
     public static final String X_FRAME_OPTIONS_VAL                 = "DENY";
     public static final String X_CONTENT_TYPE_OPTIONS_VAL          = "nosniff";
     public static final String X_XSS_PROTECTION_VAL                = "1; mode=block";
     public static final String STRICT_TRANSPORT_SEC_VAL            = "max-age=31536000; includeSubDomains";
-    public static final String CONTENT_SEC_POLICY_VAL              = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data:; connect-src 'self'; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline';font-src 'self' data:";
+    public static final String CONTENT_SEC_POLICY_VAL              = "default-src 'self'; script-src 'self' 'nonce-${nonce}' blob:; connect-src 'self'; img-src 'self' blob: data:; style-src 'self' 'nonce-${nonce}'; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none';";
     public static final String SERVER_KEY                          = "Server";
     public static final String USER_AGENT_KEY                      = "User-Agent";
     public static final String USER_AGENT_VALUE                    = "Mozilla";
@@ -54,6 +61,9 @@ public class HeadersUtil {
     public static final String CONFIG_PREFIX_HTTP_RESPONSE_HEADER  = "atlas.headers";
 
     private static final Map<String, String> HEADER_MAP = new HashMap<>();
+    private static final SecureRandom CSP_NONCE_RANDOM  = new SecureRandom();
+    private static final int          CSP_NONCE_BYTES   = 16;
+    private static final AtomicBoolean CSP_NONCE_PLACEHOLDER_WARNING_LOGGED = new AtomicBoolean(false);
 
     private HeadersUtil() {
         // to block instantiation
@@ -71,8 +81,71 @@ public class HeadersUtil {
         responseWrapper.setHeader(headerKey, HEADER_MAP.get(headerKey));
     }
 
+    public static String generateCspNonce() {
+        byte[] nonceBytes = new byte[CSP_NONCE_BYTES];
+
+        CSP_NONCE_RANDOM.nextBytes(nonceBytes);
+
+        return Base64.getEncoder().withoutPadding().encodeToString(nonceBytes);
+    }
+
+    public static String getOrCreateCspNonce(ServletRequest request) {
+        if (request == null) {
+            return generateCspNonce();
+        }
+
+        Object existingNonce = request.getAttribute(CONTENT_SEC_POLICY_NONCE_REQUEST_ATTRIBUTE);
+        if (existingNonce instanceof String) {
+            String nonce = ((String) existingNonce).trim();
+            if (!nonce.isEmpty()) {
+                return nonce;
+            }
+        }
+
+        String generatedNonce = generateCspNonce();
+        request.setAttribute(CONTENT_SEC_POLICY_NONCE_REQUEST_ATTRIBUTE, generatedNonce);
+
+        return generatedNonce;
+    }
+
+    public static String getContentSecurityPolicyValue(String cspNonce) {
+        String cspTemplate = HEADER_MAP.get(CONTENT_SEC_POLICY_KEY);
+
+        if (cspTemplate == null) {
+            return null;
+        }
+
+        if (!cspTemplate.contains(CONTENT_SEC_POLICY_NONCE_PLACEHOLDER)) {
+            if (CSP_NONCE_PLACEHOLDER_WARNING_LOGGED.compareAndSet(false, true)) {
+                LOG.warn("Configured {} does not include '{}' placeholder; CSP nonce will not be applied.",
+                        CONTENT_SEC_POLICY_KEY, CONTENT_SEC_POLICY_NONCE_PLACEHOLDER);
+            }
+            return cspTemplate;
+        }
+
+        if (cspNonce == null || cspNonce.trim().isEmpty()) {
+            cspNonce = generateCspNonce();
+        }
+
+        return cspTemplate.replace(CONTENT_SEC_POLICY_NONCE_PLACEHOLDER, cspNonce);
+    }
+
+    public static void setSecurityHeaders(AtlasResponseRequestWrapper responseWrapper, String cspNonce) {
+        HEADER_MAP.forEach((key, value) -> {
+            if (CONTENT_SEC_POLICY_KEY.equals(key)) {
+                responseWrapper.setHeader(key, getContentSecurityPolicyValue(cspNonce));
+            } else {
+                responseWrapper.setHeader(key, value);
+            }
+        });
+    }
+
+    public static void setSecurityHeaders(AtlasResponseRequestWrapper responseWrapper, ServletRequest request) {
+        setSecurityHeaders(responseWrapper, getOrCreateCspNonce(request));
+    }
+
     public static void setSecurityHeaders(AtlasResponseRequestWrapper responseWrapper) {
-        HEADER_MAP.forEach((key, value) -> responseWrapper.setHeader(key, value));
+        setSecurityHeaders(responseWrapper, generateCspNonce());
     }
 
     @VisibleForTesting

--- a/server-common/src/main/java/org/apache/atlas/server/common/security/AtlasSecurityConfig.java
+++ b/server-common/src/main/java/org/apache/atlas/server/common/security/AtlasSecurityConfig.java
@@ -129,7 +129,13 @@ public abstract class AtlasSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests().anyRequest().authenticated()
                 .and()
                 .headers()
-                .addHeaderWriter(new StaticHeadersWriter(HeadersUtil.CONTENT_SEC_POLICY_KEY, HeadersUtil.getHeaderMap(HeadersUtil.CONTENT_SEC_POLICY_KEY)))
+                .addHeaderWriter((request, response) -> {
+                    String cspNonce = HeadersUtil.getOrCreateCspNonce(request);
+                    String cspValue = HeadersUtil.getContentSecurityPolicyValue(cspNonce);
+                    if (cspValue != null) {
+                        response.setHeader(HeadersUtil.CONTENT_SEC_POLICY_KEY, cspValue);
+                    }
+                })
                 .addHeaderWriter(new StaticHeadersWriter(HeadersUtil.SERVER_KEY, HeadersUtil.getHeaderMap(HeadersUtil.SERVER_KEY)))
                 .and()
                 .servletApi()

--- a/server-common/src/test/java/org/apache/atlas/server/common/filters/HeadersUtilTest.java
+++ b/server-common/src/test/java/org/apache/atlas/server/common/filters/HeadersUtilTest.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.server.common.filters;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.servlet.ServletRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class HeadersUtilTest {
+    private Map<String, String> originalHeaders;
+
+    @BeforeMethod
+    public void setUp() {
+        originalHeaders = new HashMap<>(HeadersUtil.getAllHeaders());
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        HeadersUtil.initializeHttpResponseHeaders(convertMapToProperties(originalHeaders));
+    }
+
+    @Test
+    public void testCustomCspOverrideWithNoncePlaceholder() {
+        Properties props = new Properties();
+        props.setProperty(HeadersUtil.CONTENT_SEC_POLICY_KEY,
+                "default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'nonce-${nonce}';");
+
+        HeadersUtil.initializeHttpResponseHeaders(props);
+        String cspValue = HeadersUtil.getContentSecurityPolicyValue("customNonce");
+
+        assertNotNull(cspValue);
+        assertTrue(cspValue.contains("nonce-customNonce"));
+        assertFalse(cspValue.contains(HeadersUtil.CONTENT_SEC_POLICY_NONCE_PLACEHOLDER));
+    }
+
+    @Test
+    public void testCustomCspOverrideWithoutNoncePlaceholder() {
+        String customCsp = "default-src 'self'; script-src 'self'; style-src 'self';";
+        Properties props = new Properties();
+        props.setProperty(HeadersUtil.CONTENT_SEC_POLICY_KEY, customCsp);
+
+        HeadersUtil.initializeHttpResponseHeaders(props);
+        String cspValue = HeadersUtil.getContentSecurityPolicyValue("ignoredNonce");
+
+        assertEquals(cspValue, customCsp);
+    }
+
+    @Test
+    public void testGenerateCspNonceProducesUniqueValues() {
+        String nonceOne = HeadersUtil.generateCspNonce();
+        String nonceTwo = HeadersUtil.generateCspNonce();
+
+        assertNotNull(nonceOne);
+        assertNotNull(nonceTwo);
+        assertNotEquals(nonceOne, nonceTwo);
+        assertTrue(nonceOne.length() >= 8);
+        assertTrue(nonceTwo.length() >= 8);
+    }
+
+    @Test
+    public void testDefaultTemplateReplacesScriptAndStyleNoncePlaceholders() {
+        HeadersUtil.initializeHttpResponseHeaders(null);
+        String cspValue = HeadersUtil.getContentSecurityPolicyValue("sharedNonce");
+
+        assertEquals(countOccurrences(cspValue, "nonce-sharedNonce"), 2);
+        assertFalse(cspValue.contains(HeadersUtil.CONTENT_SEC_POLICY_NONCE_PLACEHOLDER));
+    }
+
+    @Test
+    public void testNullAndEmptyNonceFallbackBehavior() {
+        HeadersUtil.initializeHttpResponseHeaders(null);
+
+        String cspWithNullNonce = HeadersUtil.getContentSecurityPolicyValue(null);
+        String cspWithEmptyNonce = HeadersUtil.getContentSecurityPolicyValue("   ");
+
+        assertNotNull(cspWithNullNonce);
+        assertNotNull(cspWithEmptyNonce);
+        assertFalse(cspWithNullNonce.contains(HeadersUtil.CONTENT_SEC_POLICY_NONCE_PLACEHOLDER));
+        assertFalse(cspWithEmptyNonce.contains(HeadersUtil.CONTENT_SEC_POLICY_NONCE_PLACEHOLDER));
+        assertTrue(cspWithNullNonce.contains("script-src 'self' 'nonce-"));
+        assertTrue(cspWithNullNonce.contains("style-src 'self' 'nonce-"));
+        assertTrue(cspWithEmptyNonce.contains("script-src 'self' 'nonce-"));
+        assertTrue(cspWithEmptyNonce.contains("style-src 'self' 'nonce-"));
+    }
+
+    @Test
+    public void testGetOrCreateCspNonceReusesRequestScopedNonce() {
+        ServletRequest request = mock(ServletRequest.class);
+        Map<String, Object> attributes = new HashMap<>();
+
+        when(request.getAttribute(anyString())).thenAnswer(invocation -> attributes.get(invocation.getArgument(0)));
+        doAnswer(invocation -> {
+            attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(request).setAttribute(anyString(), any());
+
+        String firstNonce = HeadersUtil.getOrCreateCspNonce(request);
+        String secondNonce = HeadersUtil.getOrCreateCspNonce(request);
+
+        assertNotNull(firstNonce);
+        assertEquals(secondNonce, firstNonce);
+    }
+
+    private Properties convertMapToProperties(Map<String, String> map) {
+        Properties props = new Properties();
+        map.forEach(props::setProperty);
+        return props;
+    }
+
+    private int countOccurrences(String value, String token) {
+        int count = 0;
+        int index = 0;
+
+        while ((index = value.indexOf(token, index)) != -1) {
+            count++;
+            index += token.length();
+        }
+
+        return count;
+    }
+}

--- a/server-common/src/test/resources/atlas-application.properties
+++ b/server-common/src/test/resources/atlas-application.properties
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+atlas.rest.address=http://localhost:21000
+atlas.graphdb.backend=org.apache.atlas.repository.graphdb.janus.AtlasJanusGraphDatabase
+atlas.graph.storage.backend=berkeleyje
+atlas.graph.index.search.backend=solr
+atlas.authorizer.impl=none
+atlas.authentication.method.kerberos=false

--- a/webapp/src/main/java/org/apache/atlas/web/filters/AtlasHeaderPreAuthFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/AtlasHeaderPreAuthFilter.java
@@ -114,7 +114,7 @@ public class AtlasHeaderPreAuthFilter implements Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
         AtlasResponseRequestWrapper responseWrapper = new AtlasResponseRequestWrapper(httpResponse);
-        HeadersUtil.setSecurityHeaders(responseWrapper);
+        HeadersUtil.setSecurityHeaders(responseWrapper, servletRequest);
 
         try {
             if (headerAuthEnabled) {

--- a/webapp/src/main/java/org/apache/atlas/web/filters/CspNonceHtmlFilter.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/CspNonceHtmlFilter.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.web.filters;
+
+import org.apache.atlas.server.common.filters.HeadersUtil;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+public class CspNonceHtmlFilter implements Filter {
+    private static final String HTML_CONTENT_TYPE = "text/html";
+
+    private final CspNonceHtmlProcessor htmlProcessor = new CspNonceHtmlProcessor();
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        HttpServletRequest          httpRequest  = (HttpServletRequest) request;
+        HttpServletResponse         httpResponse = (HttpServletResponse) response;
+        BufferedHttpServletResponse wrappedResponse = new BufferedHttpServletResponse(httpResponse);
+
+        chain.doFilter(request, wrappedResponse);
+
+        byte[] responseBody = wrappedResponse.getCapturedBody();
+        if (httpResponse.isCommitted()) {
+            return;
+        }
+
+        if (responseBody.length == 0) {
+            return;
+        }
+
+        String cspNonce = HeadersUtil.getOrCreateCspNonce(httpRequest);
+        byte[] output = responseBody;
+
+        if (isHtmlResponse(httpRequest, wrappedResponse) && StringUtils.isNotBlank(cspNonce)) {
+            Charset responseCharset = resolveCharset(wrappedResponse.getCharacterEncoding());
+            String  htmlBody        = new String(responseBody, responseCharset);
+            String  updatedHtmlBody = htmlProcessor.injectNonce(htmlBody, cspNonce);
+
+            output = updatedHtmlBody.getBytes(responseCharset);
+            httpResponse.setContentLength(output.length);
+        }
+
+        ServletOutputStream responseOutputStream = httpResponse.getOutputStream();
+        responseOutputStream.write(output);
+        responseOutputStream.flush();
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    private boolean isHtmlResponse(HttpServletRequest request, HttpServletResponse response) {
+        String contentType = response.getContentType();
+        if (StringUtils.isNotBlank(contentType) && contentType.toLowerCase(Locale.ROOT).contains(HTML_CONTENT_TYPE)) {
+            return true;
+        }
+
+        String requestUri = request.getRequestURI();
+        return StringUtils.endsWithIgnoreCase(requestUri, ".html")
+                || StringUtils.endsWithIgnoreCase(requestUri, ".jsp");
+    }
+
+    private Charset resolveCharset(String charset) {
+        if (StringUtils.isBlank(charset)) {
+            return StandardCharsets.UTF_8;
+        }
+
+        try {
+            return Charset.forName(charset);
+        } catch (Exception e) {
+            return StandardCharsets.UTF_8;
+        }
+    }
+
+    private static class BufferedHttpServletResponse extends HttpServletResponseWrapper {
+        private final ByteArrayOutputStream outputStreamBuffer = new ByteArrayOutputStream();
+        private ServletOutputStream         servletOutputStream;
+        private PrintWriter                 printWriter;
+
+        BufferedHttpServletResponse(HttpServletResponse response) {
+            super(response);
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() {
+            if (printWriter != null) {
+                throw new IllegalStateException("getWriter() has already been called for this response");
+            }
+
+            if (servletOutputStream == null) {
+                servletOutputStream = new BufferedServletOutputStream(outputStreamBuffer);
+            }
+
+            return servletOutputStream;
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            if (servletOutputStream != null) {
+                throw new IllegalStateException("getOutputStream() has already been called for this response");
+            }
+
+            if (printWriter == null) {
+                Charset charset = StandardCharsets.UTF_8;
+                if (StringUtils.isNotBlank(getCharacterEncoding())) {
+                    try {
+                        charset = Charset.forName(getCharacterEncoding());
+                    } catch (Exception ignored) {
+                        charset = StandardCharsets.UTF_8;
+                    }
+                }
+
+                printWriter = new PrintWriter(new OutputStreamWriter(outputStreamBuffer, charset), true);
+            }
+
+            return printWriter;
+        }
+
+        @Override
+        public void flushBuffer() throws IOException {
+            if (printWriter != null) {
+                printWriter.flush();
+            }
+
+            if (servletOutputStream != null) {
+                servletOutputStream.flush();
+            }
+        }
+
+        byte[] getCapturedBody() throws IOException {
+            flushBuffer();
+            return outputStreamBuffer.toByteArray();
+        }
+    }
+
+    private static class BufferedServletOutputStream extends ServletOutputStream {
+        private final ByteArrayOutputStream outputStream;
+
+        BufferedServletOutputStream(ByteArrayOutputStream outputStream) {
+            this.outputStream = outputStream;
+        }
+
+        @Override
+        public void write(int b) {
+            outputStream.write(b);
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            // No-op: this wrapper does not support async I/O callbacks.
+        }
+    }
+}

--- a/webapp/src/main/java/org/apache/atlas/web/filters/CspNonceHtmlProcessor.java
+++ b/webapp/src/main/java/org/apache/atlas/web/filters/CspNonceHtmlProcessor.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.web.filters;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CspNonceHtmlProcessor {
+    private static final String CSP_NONCE_META_NAME = "csp-nonce";
+
+    private static final Pattern HEAD_OPEN_TAG_PATTERN       = Pattern.compile("<head\\b[^>]*>", Pattern.CASE_INSENSITIVE);
+    private static final Pattern CSP_NONCE_META_TAG_PATTERN  = Pattern.compile("<meta\\b[^>]*\\bname\\s*=\\s*(['\"])csp-nonce\\1[^>]*>", Pattern.CASE_INSENSITIVE);
+    private static final Pattern META_CONTENT_ATTR_PATTERN   = Pattern.compile("\\bcontent\\s*=\\s*(['\"])(.*?)\\1", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final Pattern SCRIPT_STYLE_OPEN_TAG       = Pattern.compile("<(script|style)\\b[^>]*>", Pattern.CASE_INSENSITIVE);
+    private static final Pattern NONCE_ATTR_PATTERN          = Pattern.compile("\\bnonce\\s*=\\s*(['\"]).*?\\1", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    public String injectNonce(String html, String nonce) {
+        if (StringUtils.isBlank(html) || StringUtils.isBlank(nonce)) {
+            return html;
+        }
+
+        String htmlWithMetaNonce = ensureMetaNonce(html, nonce);
+        return addNonceToScriptAndStyleTags(htmlWithMetaNonce, nonce);
+    }
+
+    private String ensureMetaNonce(String html, String nonce) {
+        Matcher metaMatcher = CSP_NONCE_META_TAG_PATTERN.matcher(html);
+
+        if (metaMatcher.find()) {
+            String metaTag      = metaMatcher.group();
+            String updatedTag   = updateMetaContentAttribute(metaTag, nonce);
+
+            return html.substring(0, metaMatcher.start()) + updatedTag + html.substring(metaMatcher.end());
+        }
+
+        Matcher headMatcher = HEAD_OPEN_TAG_PATTERN.matcher(html);
+        if (headMatcher.find()) {
+            String metaTag = "<meta name=\"" + CSP_NONCE_META_NAME + "\" content=\"" + nonce + "\" />";
+            String headTagWithMeta = headMatcher.group() + System.lineSeparator() + "    " + metaTag;
+
+            return headMatcher.replaceFirst(Matcher.quoteReplacement(headTagWithMeta));
+        }
+
+        return html;
+    }
+
+    private String updateMetaContentAttribute(String metaTag, String nonce) {
+        Matcher contentMatcher = META_CONTENT_ATTR_PATTERN.matcher(metaTag);
+
+        if (contentMatcher.find()) {
+            String replaced = contentMatcher.replaceFirst("content=\"" + Matcher.quoteReplacement(nonce) + "\"");
+            return replaced;
+        }
+
+        int insertAt = metaTag.endsWith("/>") ? metaTag.length() - 2 : metaTag.length() - 1;
+        return metaTag.substring(0, insertAt) + " content=\"" + nonce + "\"" + metaTag.substring(insertAt);
+    }
+
+    private String addNonceToScriptAndStyleTags(String html, String nonce) {
+        Matcher      tagMatcher = SCRIPT_STYLE_OPEN_TAG.matcher(html);
+        StringBuffer output     = new StringBuffer();
+
+        while (tagMatcher.find()) {
+            String tag        = tagMatcher.group();
+            String updatedTag = tag;
+
+            if (!NONCE_ATTR_PATTERN.matcher(tag).find()) {
+                int insertAt = tag.endsWith("/>") ? tag.length() - 2 : tag.length() - 1;
+                updatedTag = tag.substring(0, insertAt) + " nonce=\"" + nonce + "\"" + tag.substring(insertAt);
+            }
+
+            tagMatcher.appendReplacement(output, Matcher.quoteReplacement(updatedTag));
+        }
+
+        tagMatcher.appendTail(output);
+
+        return output.toString();
+    }
+}

--- a/webapp/src/main/java/org/apache/atlas/web/servlets/AtlasHttpServlet.java
+++ b/webapp/src/main/java/org/apache/atlas/web/servlets/AtlasHttpServlet.java
@@ -36,7 +36,7 @@ public class AtlasHttpServlet extends HttpServlet {
         try {
             response.setContentType(TEXT_HTML);
             AtlasResponseRequestWrapper responseWrapper = new AtlasResponseRequestWrapper(response);
-            HeadersUtil.setSecurityHeaders(responseWrapper);
+            HeadersUtil.setSecurityHeaders(responseWrapper, request);
 
             getServletContext()
                     .getRequestDispatcher(template)

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -97,6 +97,21 @@
         <url-pattern>/api/atlas/admin/status</url-pattern>
     </filter-mapping>
 
+    <filter>
+        <filter-name>CspNonceHtmlFilter</filter-name>
+        <filter-class>org.apache.atlas.web.filters.CspNonceHtmlFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>CspNonceHtmlFilter</filter-name>
+        <url-pattern>*.html</url-pattern>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>CspNonceHtmlFilter</filter-name>
+        <url-pattern>*.jsp</url-pattern>
+    </filter-mapping>
+
     <listener>
         <listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
     </listener>

--- a/webapp/src/test/java/org/apache/atlas/web/filters/AtlasHeaderFilterTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/filters/AtlasHeaderFilterTest.java
@@ -18,10 +18,8 @@
 package org.apache.atlas.web.filters;
 
 import org.apache.atlas.server.common.filters.AtlasHeaderFilter;
-import org.apache.atlas.server.common.filters.AtlasResponseRequestWrapper;
 import org.apache.atlas.server.common.filters.HeadersUtil;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -39,13 +37,14 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.testng.Assert.assertNotNull;
 
 public class AtlasHeaderFilterTest {
     @Mock
@@ -59,9 +58,6 @@ public class AtlasHeaderFilterTest {
 
     @Mock
     private FilterChain mockFilterChain;
-
-    @Mock
-    private AtlasResponseRequestWrapper mockResponseWrapper;
 
     private AtlasHeaderFilter atlasHeaderFilter;
     private Map<String, String> originalHeaders;
@@ -103,23 +99,9 @@ public class AtlasHeaderFilterTest {
 
     @Test
     public void testSetHeaders() throws Exception {
-        // Use MockedStatic to mock the static HeadersUtil.setSecurityHeaders method
-        try (MockedStatic<HeadersUtil> mockedHeadersUtil = mockStatic(HeadersUtil.class)) {
-            // Mock the static method
-            mockedHeadersUtil.when(() -> HeadersUtil.setSecurityHeaders(any(AtlasResponseRequestWrapper.class)))
-                    .thenAnswer(invocation -> {
-                        AtlasResponseRequestWrapper wrapper = invocation.getArgument(0);
-                        // Verify the wrapper was created with the correct response
-                        assertNotNull(wrapper);
-                        return null;
-                    });
+        atlasHeaderFilter.setHeaders(mockHttpServletResponse, "testNonce123");
 
-            // Call the method under test
-            atlasHeaderFilter.setHeaders(mockHttpServletResponse);
-
-            // Verify that HeadersUtil.setSecurityHeaders was called
-            mockedHeadersUtil.verify(() -> HeadersUtil.setSecurityHeaders(any(AtlasResponseRequestWrapper.class)));
-        }
+        verify(mockHttpServletResponse, atLeastOnce()).setHeader(eq(HeadersUtil.CONTENT_SEC_POLICY_KEY), contains("nonce-testNonce123"));
     }
 
     @Test(expectedExceptions = ClassCastException.class)

--- a/webapp/src/test/java/org/apache/atlas/web/filters/CspNonceHtmlFilterTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/filters/CspNonceHtmlFilterTest.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.web.filters;
+
+import org.apache.atlas.server.common.filters.HeadersUtil;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletResponse;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+public class CspNonceHtmlFilterTest {
+    @Test
+    public void testDoFilterInjectsNonceForHtmlResponse() throws Exception {
+        HttpServletRequest  request  = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain         chain    = Mockito.mock(FilterChain.class);
+
+        String cspNonce = "serverNonce123";
+        ByteArrayOutputStream responseBytes = new ByteArrayOutputStream();
+
+        Mockito.when(request.getRequestURI()).thenReturn("/n3/index.html");
+        Mockito.when(request.getAttribute(HeadersUtil.CONTENT_SEC_POLICY_NONCE_REQUEST_ATTRIBUTE)).thenReturn(cspNonce);
+        Mockito.when(response.getOutputStream()).thenReturn(new TestServletOutputStream(responseBytes));
+        Mockito.when(response.isCommitted()).thenReturn(false);
+        Mockito.when(response.getCharacterEncoding()).thenReturn("UTF-8");
+
+        Mockito.doAnswer(invocation -> {
+            ServletResponse wrappedResponse = invocation.getArgument(1);
+            wrappedResponse.setContentType("text/html");
+            wrappedResponse.getWriter().write("<html><head><meta name=\"csp-nonce\" content=\"\" /></head><body><script>init()</script></body></html>");
+            return null;
+        }).when(chain).doFilter(any(), any());
+
+        CspNonceHtmlFilter filter = new CspNonceHtmlFilter();
+        filter.doFilter(request, response, chain);
+
+        String output = responseBytes.toString(StandardCharsets.UTF_8.name());
+        verify(response, atLeastOnce()).setContentLength(Mockito.anyInt());
+
+        org.testng.Assert.assertTrue(output.contains("content=\"serverNonce123\""));
+        org.testng.Assert.assertTrue(output.contains("<script nonce=\"serverNonce123\">init()</script>"));
+    }
+
+    private static class TestServletOutputStream extends ServletOutputStream {
+        private final ByteArrayOutputStream outputStream;
+
+        private TestServletOutputStream(ByteArrayOutputStream outputStream) {
+            this.outputStream = outputStream;
+        }
+
+        @Override
+        public void write(int b) {
+            outputStream.write(b);
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            // No-op in unit test stream.
+        }
+    }
+}

--- a/webapp/src/test/java/org/apache/atlas/web/filters/CspNonceHtmlProcessorTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/filters/CspNonceHtmlProcessorTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.web.filters;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class CspNonceHtmlProcessorTest {
+    private final CspNonceHtmlProcessor processor = new CspNonceHtmlProcessor();
+
+    @Test
+    public void testInjectNonceUpdatesMetaAndAddsScriptStyleNonceAttributes() {
+        String html = "<html><head><meta name=\"csp-nonce\" content=\"\" /></head><body>"
+                + "<script>console.log('a');</script>"
+                + "<style>.x{color:red;}</style>"
+                + "</body></html>";
+
+        String output = processor.injectNonce(html, "nonce123");
+
+        assertTrue(output.contains("<meta name=\"csp-nonce\" content=\"nonce123\" />"));
+        assertTrue(output.contains("<script nonce=\"nonce123\">"));
+        assertTrue(output.contains("<style nonce=\"nonce123\">"));
+    }
+
+    @Test
+    public void testInjectNonceAddsMetaWhenMissing() {
+        String html = "<html><head><title>Atlas</title></head><body><script src=\"app.js\"></script></body></html>";
+
+        String output = processor.injectNonce(html, "nonce456");
+
+        assertTrue(output.contains("<meta name=\"csp-nonce\" content=\"nonce456\" />"));
+        assertTrue(output.contains("<script src=\"app.js\" nonce=\"nonce456\"></script>"));
+    }
+
+    @Test
+    public void testInjectNonceDoesNotOverrideExistingScriptNonce() {
+        String html = "<html><head></head><body><script nonce=\"existing\">x()</script></body></html>";
+
+        String output = processor.injectNonce(html, "nonce789");
+
+        assertTrue(output.contains("<script nonce=\"existing\">x()</script>"));
+        assertFalse(output.contains("nonce=\"nonce789\""));
+    }
+
+    @Test
+    public void testInjectNonceReturnsInputWhenNonceBlank() {
+        String html = "<html><head><title>Atlas</title></head><body></body></html>";
+
+        assertEquals(processor.injectNonce(html, "   "), html);
+        assertEquals(processor.injectNonce(html, null), html);
+    }
+}

--- a/webapp/src/test/java/org/apache/atlas/web/filters/HeaderUtilsTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/filters/HeaderUtilsTest.java
@@ -28,7 +28,9 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -96,6 +98,18 @@ public class HeaderUtilsTest {
         assertEquals("DENY", HeadersUtil.getHeaderMap(HeadersUtil.X_FRAME_OPTIONS_KEY));
         assertEquals("nosniff", HeadersUtil.getHeaderMap(HeadersUtil.X_CONTENT_TYPE_OPTIONS_KEY));
         assertEquals("1; mode=block", HeadersUtil.getHeaderMap(HeadersUtil.X_XSS_PROTECTION_KEY));
+    }
+
+    @Test
+    public void testContentSecurityPolicyValueUsesNonce() {
+        HeadersUtil.initializeHttpResponseHeaders(null);
+
+        String cspValue = HeadersUtil.getContentSecurityPolicyValue("testNonce123");
+
+        assertTrue(cspValue.contains("nonce-testNonce123"));
+        assertFalse(cspValue.contains(HeadersUtil.CONTENT_SEC_POLICY_NONCE_PLACEHOLDER));
+        assertFalse(cspValue.contains("'unsafe-inline'"));
+        assertFalse(cspValue.contains("'unsafe-eval'"));
     }
 
     private Properties createPropertiesWithHeaders(String... headers) {

--- a/webapp/src/test/java/org/apache/atlas/web/security/AtlasSecurityConfigTest.java
+++ b/webapp/src/test/java/org/apache/atlas/web/security/AtlasSecurityConfigTest.java
@@ -73,7 +73,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
-import org.springframework.security.web.header.writers.StaticHeadersWriter;
+import org.springframework.security.web.header.HeaderWriter;
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.testng.annotations.BeforeMethod;
@@ -511,7 +511,7 @@ public class AtlasSecurityConfigTest {
         when(mockAuthRequests.and()).thenReturn(httpSecurity);
 
         when(httpSecurity.headers()).thenReturn(mockHeadersConfigurer);
-        when(mockHeadersConfigurer.addHeaderWriter(any(StaticHeadersWriter.class))).thenReturn(mockHeadersConfigurer);
+        when(mockHeadersConfigurer.addHeaderWriter(any(HeaderWriter.class))).thenReturn(mockHeadersConfigurer);
         when(mockHeadersConfigurer.and()).thenReturn(httpSecurity);
 
         when(httpSecurity.servletApi()).thenReturn(mockServletApiConfigurer);
@@ -851,7 +851,7 @@ public class AtlasSecurityConfigTest {
         when(mockAuthRequests.and()).thenReturn(mockHttpSecurity);
 
         when(mockHttpSecurity.headers()).thenReturn(mockHeadersConfigurer);
-        when(mockHeadersConfigurer.addHeaderWriter(any(StaticHeadersWriter.class))).thenReturn(mockHeadersConfigurer);
+        when(mockHeadersConfigurer.addHeaderWriter(any(HeaderWriter.class))).thenReturn(mockHeadersConfigurer);
         when(mockHeadersConfigurer.and()).thenReturn(mockHttpSecurity);
 
         when(mockHttpSecurity.servletApi()).thenReturn(mockServletApiConfigurer);


### PR DESCRIPTION
…inline/unsafe-eval) and enabling nonce-based policy

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. ATLAS-XXXX: Fix a typo in YYY))


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)