### PR TITLE
ATLAS-5398: Fix Async Imports getting Stuck

### DIFF
--- a/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
+++ b/intg/src/main/java/org/apache/atlas/AtlasErrorCode.java
@@ -233,6 +233,7 @@ public enum AtlasErrorCode {
     METRICSSTAT_ALREADY_EXISTS(409, "ATLAS-409-00-012", "Metric Statistics already collected at {0}"),
     PENDING_TASKS_ALREADY_IN_PROGRESS(409, "ATLAS-409-00-013", "There are already {0} pending tasks in queue"),
     IMPORT_ABORT_NOT_ALLOWED(409, "ATLAS-409-00-016", "Import id {0} is currently in state {1}, cannot be aborted"),
+    IMPORT_ALREADY_IN_PROGRESS(409, "ATLAS-409-00-017", "Import id {0} is already being submitted by another request, please try again later"),
 
     // All internal errors go here
     INTERNAL_ERROR(500, "ATLAS-500-00-001", "Internal server error {0}"),

--- a/notification/src/main/java/org/apache/atlas/kafka/KafkaNotification.java
+++ b/notification/src/main/java/org/apache/atlas/kafka/KafkaNotification.java
@@ -32,13 +32,17 @@ import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ConfigurationConverter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
@@ -54,6 +58,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static org.apache.atlas.security.SecurityProperties.TLS_ENABLED;
 import static org.apache.atlas.security.SecurityProperties.TRUSTSTORE_PASSWORD_KEY;
@@ -501,6 +506,65 @@ public class KafkaNotification extends AbstractNotification implements Service {
 
             return topics.isEmpty() ? null : topics;
         });
+    }
+
+    @VisibleForTesting
+    AdminClient createAdminClient() {
+        return AdminClient.create(this.properties);
+    }
+
+    @Override
+    public boolean isTopicFullyConsumed(NotificationType notificationType, String topicName) {
+        String groupId = getConsumerProperties(notificationType).getProperty(ConsumerConfig.GROUP_ID_CONFIG);
+
+        try (AdminClient adminClient = createAdminClient()) {
+            if (!adminClient.listTopics().names().get().contains(topicName)) {
+                // a deleted topic can no longer deliver anything, so there is nothing left to consume
+                LOG.info("isTopicFullyConsumed(topic={}): topic does not exist", topicName);
+
+                return true;
+            }
+
+            List<TopicPartition> partitions = adminClient.describeTopics(Collections.singleton(topicName)).allTopicNames().get()
+                    .get(topicName).partitions().stream()
+                    .map(partition -> new TopicPartition(topicName, partition.partition()))
+                    .collect(Collectors.toList());
+
+            if (partitions.isEmpty()) {
+                return true;
+            }
+
+            Map<TopicPartition, OffsetAndMetadata> committedOffsets = adminClient.listConsumerGroupOffsets(groupId).partitionsToOffsetAndMetadata().get();
+            Map<TopicPartition, OffsetSpec>        endOffsetRequest = partitions.stream().collect(Collectors.toMap(partition -> partition, partition -> OffsetSpec.latest()));
+            Map<TopicPartition, ListOffsetsResultInfo> endOffsets   = adminClient.listOffsets(endOffsetRequest).all().get();
+
+            for (TopicPartition partition : partitions) {
+                OffsetAndMetadata     committed = committedOffsets.get(partition);
+                ListOffsetsResultInfo end       = endOffsets.get(partition);
+
+                long committedOffset = committed != null ? committed.offset() : 0L;
+                long endOffset       = end != null ? end.offset() : 0L;
+
+                if (committedOffset < endOffset) {
+                    LOG.info("isTopicFullyConsumed(topic={}): partition={} has committedOffset={} behind endOffset={}", topicName, partition.partition(), committedOffset, endOffset);
+
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            LOG.warn("isTopicFullyConsumed(topic={}): interrupted, assuming messages remain", topicName, e);
+
+            return false;
+        } catch (Exception e) {
+            // an unreadable topic must not be treated as consumed, or an import would be resolved early
+            LOG.warn("isTopicFullyConsumed(topic={}): failed to read offsets, assuming messages remain", topicName, e);
+
+            return false;
+        }
     }
 
     // kafka-client doesn't have method to check if consumer is open, hence checking list topics and catching exception

--- a/notification/src/main/java/org/apache/atlas/notification/NotificationInterface.java
+++ b/notification/src/main/java/org/apache/atlas/notification/NotificationInterface.java
@@ -146,6 +146,21 @@ public interface NotificationInterface {
     default void closeConsumer(NotificationType notificationType, String topic) {}
 
     /**
+     * Reports whether every message on the topic has already been consumed and committed by the
+     * notification type's consumer group, meaning a consumer started now would receive nothing.
+     * <p>
+     * Implementations that cannot determine this must return {@code false}, so callers fall back to
+     * starting a consumer rather than assuming there is no work left.
+     *
+     * @param notificationType The type of notification the topic belongs to.
+     * @param topicName The name of the topic to inspect.
+     * @return true only if the topic is known to be fully consumed, or no longer exists.
+     */
+    default boolean isTopicFullyConsumed(NotificationType notificationType, String topicName) {
+        return false;
+    }
+
+    /**
      * Atlas notification types.
      */
     enum NotificationType {

--- a/notification/src/test/java/org/apache/atlas/kafka/KafkaNotificationMockTest.java
+++ b/notification/src/test/java/org/apache/atlas/kafka/KafkaNotificationMockTest.java
@@ -20,10 +20,22 @@ package org.apache.atlas.kafka;
 import org.apache.atlas.notification.NotificationConsumer;
 import org.apache.atlas.notification.NotificationException;
 import org.apache.atlas.notification.NotificationInterface;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -32,18 +44,25 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class KafkaNotificationMockTest {
+    private static final String TOPIC = "ATLAS_IMPORT_test-import";
+
     @Test
     public void testCreateConsumers() {
         Properties properties = mock(Properties.class);
@@ -151,6 +170,88 @@ public class KafkaNotificationMockTest {
             assertEquals(e.getFailedMessages().get(0), "This is a test message1");
             assertEquals(e.getFailedMessages().get(1), "This is a test message2");
         }
+    }
+
+    @Test
+    public void testIsTopicFullyConsumedWhenCommittedIsAtEnd() {
+        KafkaNotification kafkaNotification = kafkaNotificationBackedBy(adminClientFor(TOPIC, 10L, 10L));
+
+        assertTrue(kafkaNotification.isTopicFullyConsumed(NotificationInterface.NotificationType.ASYNC_IMPORT, TOPIC));
+    }
+
+    @Test
+    public void testIsTopicFullyConsumedWhenMessagesRemain() {
+        KafkaNotification kafkaNotification = kafkaNotificationBackedBy(adminClientFor(TOPIC, 4L, 10L));
+
+        assertFalse(kafkaNotification.isTopicFullyConsumed(NotificationInterface.NotificationType.ASYNC_IMPORT, TOPIC));
+    }
+
+    @Test
+    public void testIsTopicFullyConsumedWhenNothingWasEverCommitted() {
+        AdminClient adminClient = adminClientFor(TOPIC, 0L, 10L);
+
+        ListConsumerGroupOffsetsResult noOffsets = mock(ListConsumerGroupOffsetsResult.class);
+        when(noOffsets.partitionsToOffsetAndMetadata()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
+        when(adminClient.listConsumerGroupOffsets(anyString())).thenReturn(noOffsets);
+
+        assertFalse(kafkaNotificationBackedBy(adminClient).isTopicFullyConsumed(NotificationInterface.NotificationType.ASYNC_IMPORT, TOPIC));
+    }
+
+    @Test
+    public void testIsTopicFullyConsumedWhenTopicNoLongerExists() {
+        AdminClient adminClient = adminClientFor(TOPIC, 10L, 10L);
+
+        ListTopicsResult noTopics = mock(ListTopicsResult.class);
+        when(noTopics.names()).thenReturn(KafkaFuture.completedFuture(Collections.emptySet()));
+        when(adminClient.listTopics()).thenReturn(noTopics);
+
+        // a deleted topic cannot deliver anything, so the import must not be left holding the queue
+        assertTrue(kafkaNotificationBackedBy(adminClient).isTopicFullyConsumed(NotificationInterface.NotificationType.ASYNC_IMPORT, TOPIC));
+    }
+
+    @Test
+    public void testIsTopicFullyConsumedWhenOffsetLookupFails() {
+        AdminClient adminClient = adminClientFor(TOPIC, 10L, 10L);
+
+        when(adminClient.listTopics()).thenThrow(new RuntimeException("broker unreachable"));
+
+        // an unreadable topic must not be reported as consumed, or an import would be resolved early
+        assertFalse(kafkaNotificationBackedBy(adminClient).isTopicFullyConsumed(NotificationInterface.NotificationType.ASYNC_IMPORT, TOPIC));
+    }
+
+    private KafkaNotification kafkaNotificationBackedBy(AdminClient adminClient) {
+        KafkaNotification kafkaNotification = Mockito.spy(new KafkaNotification(new Properties()));
+
+        Mockito.doReturn(adminClient).when(kafkaNotification).createAdminClient();
+
+        return kafkaNotification;
+    }
+
+    private AdminClient adminClientFor(String topic, long committedOffset, long endOffset) {
+        AdminClient    adminClient = mock(AdminClient.class);
+        TopicPartition partition   = new TopicPartition(topic, 0);
+        Node           node        = new Node(0, "localhost", 9092);
+
+        ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
+        when(listTopicsResult.names()).thenReturn(KafkaFuture.completedFuture(Collections.singleton(topic)));
+        when(adminClient.listTopics()).thenReturn(listTopicsResult);
+
+        TopicDescription topicDescription = new TopicDescription(topic, false,
+                Collections.singletonList(new TopicPartitionInfo(0, node, Collections.singletonList(node), Collections.singletonList(node))));
+
+        DescribeTopicsResult describeTopicsResult = mock(DescribeTopicsResult.class);
+        when(describeTopicsResult.allTopicNames()).thenReturn(KafkaFuture.completedFuture(Collections.singletonMap(topic, topicDescription)));
+        when(adminClient.describeTopics(anyCollection())).thenReturn(describeTopicsResult);
+
+        ListConsumerGroupOffsetsResult committedResult = mock(ListConsumerGroupOffsetsResult.class);
+        when(committedResult.partitionsToOffsetAndMetadata()).thenReturn(KafkaFuture.completedFuture(Collections.singletonMap(partition, new OffsetAndMetadata(committedOffset))));
+        when(adminClient.listConsumerGroupOffsets(anyString())).thenReturn(committedResult);
+
+        ListOffsetsResult listOffsetsResult = mock(ListOffsetsResult.class);
+        when(listOffsetsResult.all()).thenReturn(KafkaFuture.completedFuture(Collections.singletonMap(partition, new ListOffsetsResultInfo(endOffset, 0L, Optional.empty()))));
+        when(adminClient.listOffsets(anyMap())).thenReturn(listOffsetsResult);
+
+        return adminClient;
     }
 
     static class TestKafkaNotification<T> extends KafkaNotification {

--- a/repository/src/main/java/org/apache/atlas/repository/impexp/AsyncImportService.java
+++ b/repository/src/main/java/org/apache/atlas/repository/impexp/AsyncImportService.java
@@ -18,7 +18,10 @@
 
 package org.apache.atlas.repository.impexp;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.AtlasException;
 import org.apache.atlas.SortOrder;
 import org.apache.atlas.annotation.GraphTransaction;
 import org.apache.atlas.exception.AtlasBaseException;
@@ -26,10 +29,14 @@ import org.apache.atlas.model.PList;
 import org.apache.atlas.model.SearchFilter.SortType;
 import org.apache.atlas.model.impexp.AsyncImportStatus;
 import org.apache.atlas.model.impexp.AtlasAsyncImportRequest;
+import org.apache.atlas.model.impexp.AtlasImportResult;
+import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.ogm.DataAccess;
 import org.apache.atlas.repository.store.graph.v2.AtlasGraphUtilsV2;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -42,21 +49,45 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.apache.atlas.model.impexp.AtlasAsyncImportRequest.ImportStatus;
+import static org.apache.atlas.model.impexp.AtlasImportResult.OperationStatus.FAIL;
+import static org.apache.atlas.model.impexp.AtlasImportResult.OperationStatus.PARTIAL_SUCCESS;
+import static org.apache.atlas.model.impexp.AtlasImportResult.OperationStatus.SUCCESS;
 import static org.apache.atlas.repository.Constants.PROPERTY_KEY_ASYNC_IMPORT_ID;
 import static org.apache.atlas.repository.Constants.PROPERTY_KEY_ASYNC_IMPORT_STATUS;
 import static org.apache.atlas.repository.ogm.impexp.AtlasAsyncImportRequestDTO.ASYNC_IMPORT_TYPE_NAME;
 
 @Service
 public class AsyncImportService {
-    private static final Logger LOG = LoggerFactory.getLogger(AsyncImportService.class);
+    private static final Logger LOG                                              = LoggerFactory.getLogger(AsyncImportService.class);
+    private static final int    DEFAULT_MAX_ATTEMPTS                             = 3;
+    private static final long   DEFAULT_RETRY_DELAY_MS                           = 1000;
+    private static final String EXCEPTION_CLASS_NAME_PERMANENT_LOCKING_EXCEPTION = "PermanentLockingException";
 
     private final DataAccess                                          dataAccess;
     private final ImportCacheManager<String, AtlasAsyncImportRequest> importCache;
 
+    /** Graph storage retry settings, shared with the rest of the repository layer. */
+    @VisibleForTesting
+    int maxAttempts;
+
+    @VisibleForTesting
+    long retryDelayMs;
+
     @Inject
     public AsyncImportService(DataAccess dataAccess) {
         this.dataAccess  = dataAccess;
-        this.importCache = new ImportCacheManager<>();
+        this.importCache = new ImportCacheManager<>(AsyncImportService::isTerminal);
+        this.maxAttempts  = DEFAULT_MAX_ATTEMPTS;
+        this.retryDelayMs = DEFAULT_RETRY_DELAY_MS;
+
+        try {
+            Configuration configuration = ApplicationProperties.get();
+
+            this.maxAttempts  = configuration.getInt(GraphHelper.RETRY_COUNT, DEFAULT_MAX_ATTEMPTS);
+            this.retryDelayMs = configuration.getLong(GraphHelper.RETRY_DELAY, DEFAULT_RETRY_DELAY_MS);
+        } catch (AtlasException e) {
+            LOG.error("Could not load configuration, using defaults for {} and {}", GraphHelper.RETRY_COUNT, GraphHelper.RETRY_DELAY, e);
+        }
     }
 
     public void populateCache(AtlasAsyncImportRequest importRequest) {
@@ -67,28 +98,80 @@ public class AsyncImportService {
 
     public AtlasAsyncImportRequest fetchImportRequestByImportId(String importId) {
         try {
-            AtlasAsyncImportRequest cachedRequest = importCache.get(importId);
-
-            if (cachedRequest != null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Cache hit for importId: {}", importId);
-                }
-                return cachedRequest;
-            }
-            AtlasAsyncImportRequest request = new AtlasAsyncImportRequest();
-
-            request.setImportId(importId);
-
-            request = dataAccess.load(request);
-
-            populateCache(request);
-
-            return request;
+            return loadImportRequest(importId);
         } catch (Exception e) {
             LOG.error("Error fetching request with importId: {}", importId, e);
 
             return null;
         }
+    }
+
+    /**
+     * Reads a request, retrying transient failures before giving up. Callers that have already
+     * removed the importId from the request queue use this, because a null from a one-shot read is
+     * indistinguishable from "no such request" and would silently drop a queued import.
+     * <p>
+     * A request that genuinely does not exist is reported immediately: retrying a definitive answer
+     * only delays the caller.
+     */
+    public AtlasAsyncImportRequest fetchImportRequestByImportIdWithRetry(String importId) {
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return loadImportRequest(importId);
+            } catch (Exception e) {
+                if (isRequestNotFound(e)) {
+                    LOG.warn("No import request exists with importId: {}", importId);
+
+                    return null;
+                }
+
+                if (attempt == maxAttempts) {
+                    LOG.error("Error fetching request with importId: {}, giving up after {} attempts", importId, maxAttempts, e);
+
+                    return null;
+                }
+
+                LOG.warn("Error fetching request with importId: {} on attempt {} of {}, retrying in {} ms", importId, attempt, maxAttempts, retryDelayMs, e);
+
+                if (!sleepBeforeRetry()) {
+                    return null;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private AtlasAsyncImportRequest loadImportRequest(String importId) throws AtlasBaseException {
+        AtlasAsyncImportRequest cachedRequest = importCache.get(importId);
+
+        if (cachedRequest != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cache hit for importId: {}", importId);
+            }
+            return cachedRequest;
+        }
+
+        AtlasAsyncImportRequest request = new AtlasAsyncImportRequest();
+
+        request.setImportId(importId);
+
+        request = dataAccess.load(request);
+
+        populateCache(request);
+
+        return request;
+    }
+
+    private boolean isRequestNotFound(Exception e) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+            if (cause instanceof AtlasBaseException
+                    && ((AtlasBaseException) cause).getAtlasErrorCode() == AtlasErrorCode.INSTANCE_BY_UNIQUE_ATTRIBUTE_NOT_FOUND) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void saveImport(String importId) {
@@ -98,21 +181,39 @@ public class AsyncImportService {
                 saveImportRequest(importRequest);
                 importCache.invalidate(importId);
             }
-        } catch (AtlasBaseException e) {
+        } catch (Throwable e) {
             LOG.error("Error saving import request from cache for importId: {}", importId, e);
         }
     }
 
     public void saveImportRequest(AtlasAsyncImportRequest importRequest) throws AtlasBaseException {
-        try {
-            dataAccess.saveNoLoad(importRequest);
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                dataAccess.saveNoLoad(importRequest);
+                LOG.debug("Save request ID: {} request: {}", importRequest.getImportId(), importRequest);
+                return;
+            } catch (Throwable e) {
+                List<Throwable> throwableList = ExceptionUtils.getThrowableList(e);
 
-            LOG.debug("Save request ID: {} request: {}", importRequest.getImportId(), importRequest);
-        } catch (AtlasBaseException e) {
-            LOG.error("Failed to save import: {} with request: {}", importRequest.getImportId(), importRequest, e);
+                // only a lock conflict is worth retrying: any other failure means the backend itself is
+                // unhealthy, and retrying just delays surfacing that
+                if (!throwableList.isEmpty()
+                        && containsException(throwableList, EXCEPTION_CLASS_NAME_PERMANENT_LOCKING_EXCEPTION)
+                        && (attempt < maxAttempts - 1)) {
+                    LOG.error("Caught {} , Retrying the transaction, attempt count is:{}",
+                            EXCEPTION_CLASS_NAME_PERMANENT_LOCKING_EXCEPTION, attempt);
+                    continue;
+                }
 
-            throw e;
+                LOG.error("Failed to save import: {} with request: {}", importRequest.getImportId(), importRequest, e);
+                if (e instanceof AtlasBaseException) {
+                    throw (AtlasBaseException) e;
+                }
+
+                throw new AtlasBaseException(AtlasErrorCode.IMPORT_FAILED, e);
+            }
         }
+        throw new AtlasBaseException(AtlasErrorCode.IMPORT_FAILED, "Failed to save import request after retries");
     }
 
     public void updateImportRequest(AtlasAsyncImportRequest importRequest) {
@@ -121,6 +222,62 @@ public class AsyncImportService {
         } catch (AtlasBaseException abe) {
             LOG.error("Failed to update import: {} with request: {}", importRequest.getImportId(), importRequest, abe);
         }
+    }
+
+    public AtlasAsyncImportRequest resolveRequestStatus(String importId) throws AtlasBaseException {
+        // the cached request is the only record of progress while an import is PROCESSING: entity
+        // counters are updated in the cache and are not written to the graph until the import
+        // completes. Evicting here would reload stale counters and the import could never satisfy
+        // its completion check.
+        AtlasAsyncImportRequest importRequest = fetchImportRequestByImportId(importId);
+        if (importRequest == null
+                || importRequest.getStatus() != ImportStatus.PROCESSING
+                || !isProcessingComplete(importRequest)) {
+            return importRequest;
+        }
+
+        ImportStatus resolvedStatus = resolveToTerminalStatus(importRequest);
+
+        LOG.info("Resolved completed PROCESSING request importId={} to status={}", importId, resolvedStatus);
+
+        return importRequest;
+    }
+
+    /**
+     * Resolves a request that can no longer make progress, regardless of how far its counters got.
+     * Used when an import is found PROCESSING but its topic has already been fully consumed, which
+     * leaves nothing to deliver and no way for the normal completion path to ever run.
+     */
+    public AtlasAsyncImportRequest resolveAbandonedRequest(String importId) throws AtlasBaseException {
+        AtlasAsyncImportRequest importRequest = fetchImportRequestByImportId(importId);
+
+        if (importRequest == null || importRequest.getStatus() != ImportStatus.PROCESSING) {
+            return importRequest;
+        }
+
+        ImportStatus resolvedStatus = resolveToTerminalStatus(importRequest);
+
+        LOG.warn("Resolved abandoned PROCESSING request importId={} to status={}, its topic had no messages left to consume", importId, resolvedStatus);
+
+        return importRequest;
+    }
+
+    private ImportStatus resolveToTerminalStatus(AtlasAsyncImportRequest importRequest) throws AtlasBaseException {
+        ImportStatus resolvedStatus = resolveCompletedStatus(importRequest);
+
+        importRequest.setStatus(resolvedStatus);
+        importRequest.setCompletedTime(System.currentTimeMillis());
+
+        AtlasImportResult importResult = importRequest.getImportResult();
+        if (importResult != null) {
+            importResult.setOperationStatus(resolveOperationStatus(resolvedStatus));
+            importRequest.setImportResult(importResult);
+        }
+
+        saveImportRequest(importRequest);
+        populateCache(importRequest);
+
+        return resolvedStatus;
     }
 
     public List<String> fetchInProgressImportIds() {
@@ -223,5 +380,65 @@ public class AsyncImportService {
         } finally {
             LOG.debug("<== AsyncImportService.getImportStatusById(importId={})", importId);
         }
+    }
+
+    /**
+     * An import that has not reached a terminal state keeps progress only in the cache, so those
+     * entries must survive size and TTL pressure. Terminal requests are already durable.
+     */
+    @VisibleForTesting
+    static boolean isTerminal(AtlasAsyncImportRequest importRequest) {
+        ImportStatus status = importRequest == null ? null : importRequest.getStatus();
+
+        return status != ImportStatus.STAGING && status != ImportStatus.WAITING && status != ImportStatus.PROCESSING;
+    }
+
+    private boolean containsException(final List<Throwable> exceptions, final String exceptionName) {
+        return exceptions.stream().anyMatch(o -> o.getClass().getSimpleName().equals(exceptionName));
+    }
+
+    /** Returns false if the wait was interrupted, in which case the caller must stop retrying. */
+    private boolean sleepBeforeRetry() {
+        try {
+            Thread.sleep(retryDelayMs);
+
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            return false;
+        }
+    }
+
+    private boolean isProcessingComplete(AtlasAsyncImportRequest importRequest) {
+        AtlasAsyncImportRequest.ImportDetails details = importRequest.getImportDetails();
+
+        if (details == null || details.getTotalEntitiesCount() <= 0) {
+            return false;
+        }
+
+        int processedEntities = details.getImportedEntitiesCount() + details.getFailedEntitiesCount();
+        return processedEntities >= details.getTotalEntitiesCount();
+    }
+
+    private ImportStatus resolveCompletedStatus(AtlasAsyncImportRequest importRequest) {
+        AtlasAsyncImportRequest.ImportDetails details = importRequest.getImportDetails();
+        if (details.getTotalEntitiesCount() == details.getImportedEntitiesCount()) {
+            return ImportStatus.SUCCESSFUL;
+        } else if (details.getImportedEntitiesCount() > 0) {
+            return ImportStatus.PARTIAL_SUCCESS;
+        }
+
+        return ImportStatus.FAILED;
+    }
+
+    private AtlasImportResult.OperationStatus resolveOperationStatus(ImportStatus status) {
+        if (status == ImportStatus.SUCCESSFUL) {
+            return SUCCESS;
+        } else if (status == ImportStatus.PARTIAL_SUCCESS) {
+            return PARTIAL_SUCCESS;
+        }
+
+        return FAIL;
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/impexp/ImportCacheManager.java
+++ b/repository/src/main/java/org/apache/atlas/repository/impexp/ImportCacheManager.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 /**
  * Lightweight in-memory cache for import operations.
@@ -35,9 +36,21 @@ public class ImportCacheManager<K, V> {
     private static final long TTL_MINUTES = 30;         // Expire after 30 minutes
     private static final long TTL_MILLIS = TimeUnit.MINUTES.toMillis(TTL_MINUTES);
 
+    /**
+     * Entries rejected by this predicate are never dropped by size or TTL pressure. Callers whose
+     * cached value is the only copy of in-flight state use it to pin that state until it is durable.
+     * Explicit {@link #invalidate(Object)} and {@link #clear()} still remove pinned entries.
+     */
+    private final Predicate<V> evictable;
+
     private final ConcurrentHashMap<K, CacheEntry<V>> cache = new ConcurrentHashMap<>();
 
     public ImportCacheManager() {
+        this(null);
+    }
+
+    public ImportCacheManager(Predicate<V> evictable) {
+        this.evictable = evictable != null ? evictable : value -> true;
         startCleanupThread();
     }
 
@@ -76,7 +89,7 @@ public class ImportCacheManager<K, V> {
             return null;
         }
 
-        if (entry.isExpired(TTL_MILLIS)) {
+        if (entry.isExpired(TTL_MILLIS) && evictable.test(entry.value)) {
             cache.remove(key);
             return null;
         }
@@ -99,13 +112,13 @@ public class ImportCacheManager<K, V> {
         return cache.size();
     }
 
-    /** Evicts the oldest entry based on timestamp */
+    /** Evicts the oldest evictable entry based on timestamp */
     private void evictOldest() {
         K oldestKey = null;
         long oldestTime = Long.MAX_VALUE;
 
         for (Map.Entry<K, CacheEntry<V>> e : cache.entrySet()) {
-            if (e.getValue().timestamp < oldestTime) {
+            if (e.getValue().timestamp < oldestTime && evictable.test(e.getValue().value)) {
                 oldestKey = e.getKey();
                 oldestTime = e.getValue().timestamp;
             }
@@ -127,6 +140,6 @@ public class ImportCacheManager<K, V> {
 
     private void cleanup() {
         long now = System.currentTimeMillis();
-        cache.entrySet().removeIf(e -> (now - e.getValue().timestamp) > TTL_MILLIS);
+        cache.entrySet().removeIf(e -> (now - e.getValue().timestamp) > TTL_MILLIS && evictable.test(e.getValue().value));
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AsyncImportTaskExecutor.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AsyncImportTaskExecutor.java
@@ -19,7 +19,9 @@
 package org.apache.atlas.repository.store.graph.v2;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.atlas.ApplicationProperties;
 import org.apache.atlas.AtlasErrorCode;
+import org.apache.atlas.AtlasException;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.kafka.NotificationProvider;
 import org.apache.atlas.model.impexp.AtlasAsyncImportRequest;
@@ -33,8 +35,10 @@ import org.apache.atlas.model.notification.MessageSource;
 import org.apache.atlas.model.typedef.AtlasTypesDef;
 import org.apache.atlas.notification.NotificationException;
 import org.apache.atlas.notification.NotificationInterface;
+import org.apache.atlas.repository.graph.GraphHelper;
 import org.apache.atlas.repository.impexp.AsyncImportService;
 import org.apache.atlas.repository.store.graph.v2.asyncimport.ImportTaskListener;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +48,9 @@ import javax.inject.Inject;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.atlas.notification.NotificationInterface.NotificationType.ASYNC_IMPORT;
 
@@ -52,14 +58,25 @@ import static org.apache.atlas.notification.NotificationInterface.NotificationTy
 public class AsyncImportTaskExecutor {
     private static final Logger LOG = LoggerFactory.getLogger(AsyncImportTaskExecutor.class);
 
-    private static final String MESSAGE_SOURCE = AsyncImportTaskExecutor.class.getSimpleName();
-    private static final int MAX_RETRIES       = 3;
-    private static final int BASE_BACKOFF_MS   = 500;
+    private static final String MESSAGE_SOURCE         = AsyncImportTaskExecutor.class.getSimpleName();
+    private static final int    DEFAULT_MAX_ATTEMPTS   = 3;
+    private static final long   DEFAULT_RETRY_DELAY_MS = 1000;
+
+    // importIds this instance is currently registering/publishing. Import submissions are always routed
+    // to the active instance, so an in-process guard is enough to keep a single publisher per importId.
+    private final Set<String> registrationsInFlight = ConcurrentHashMap.newKeySet();
 
     private final AsyncImportService    importService;
     private final NotificationInterface notificationInterface;
     private final ImportTaskListener    importTaskListener;
     private final MessageSource         messageSource;
+
+    /** Graph storage retry settings, shared with the rest of the repository layer. */
+    @VisibleForTesting
+    int maxAttempts;
+
+    @VisibleForTesting
+    long retryDelayMs;
 
     @Inject
     public AsyncImportTaskExecutor(AsyncImportService importService, ImportTaskListener importTaskListener) {
@@ -67,11 +84,31 @@ public class AsyncImportTaskExecutor {
         this.notificationInterface = NotificationProvider.get();
         this.importTaskListener    = importTaskListener;
         this.messageSource         = new MessageSource(MESSAGE_SOURCE);
+        this.maxAttempts           = DEFAULT_MAX_ATTEMPTS;
+        this.retryDelayMs          = DEFAULT_RETRY_DELAY_MS;
+
+        try {
+            Configuration configuration = ApplicationProperties.get();
+
+            this.maxAttempts  = configuration.getInt(GraphHelper.RETRY_COUNT, DEFAULT_MAX_ATTEMPTS);
+            this.retryDelayMs = configuration.getLong(GraphHelper.RETRY_DELAY, DEFAULT_RETRY_DELAY_MS);
+        } catch (AtlasException e) {
+            LOG.error("Could not load configuration, using defaults for {} and {}", GraphHelper.RETRY_COUNT, GraphHelper.RETRY_DELAY, e);
+        }
     }
 
     public AtlasAsyncImportRequest run(AtlasImportResult result, EntityImportStream entityImportStream) throws AtlasBaseException {
+        String  importId = entityImportStream.getMd5Hash();
+        boolean claimed  = registrationsInFlight.add(importId);
+
         try {
-            String                  importId      = entityImportStream.getMd5Hash();
+            // registering and publishing are a single critical section per importId: without it two
+            // concurrent submissions of the same archive both resolve to STAGING and each publishes
+            // the full entity set to the same topic
+            if (!claimed) {
+                return awaitInFlightRequest(importId);
+            }
+
             AtlasAsyncImportRequest importRequest = registerRequest(result, importId, entityImportStream.size(), entityImportStream.getCreationOrder());
 
             if (ObjectUtils.equals(importRequest.getStatus(), ImportStatus.WAITING) || ObjectUtils.equals(importRequest.getStatus(), ImportStatus.PROCESSING)) {
@@ -87,10 +124,47 @@ public class AsyncImportTaskExecutor {
 
             return importRequest;
         } catch (AtlasBaseException abe) {
+            if (abe.getAtlasErrorCode() == AtlasErrorCode.IMPORT_ALREADY_IN_PROGRESS) {
+                throw abe;
+            }
+
             throw new AtlasBaseException(AtlasErrorCode.IMPORT_FAILED, abe);
         } finally {
+            if (claimed) {
+                registrationsInFlight.remove(importId);
+            }
+
             entityImportStream.close();
         }
+    }
+
+    /**
+     * Returns the request being submitted concurrently for the same importId, without publishing.
+     * The winning thread may not have committed the request vertex yet, so the lookup is retried
+     * briefly before giving up.
+     */
+    private AtlasAsyncImportRequest awaitInFlightRequest(String importId) throws AtlasBaseException {
+        LOG.warn("AsyncImportTaskExecutor.run(): import request with id={} is already being submitted by another request, skipping publish", importId);
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            AtlasAsyncImportRequest inFlightRequest = importService.fetchImportRequestByImportId(importId);
+
+            if (inFlightRequest != null) {
+                return inFlightRequest;
+            }
+
+            if (attempt < maxAttempts) {
+                try {
+                    Thread.sleep(retryDelayMs);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+
+                    break;
+                }
+            }
+        }
+
+        throw new AtlasBaseException(AtlasErrorCode.IMPORT_ALREADY_IN_PROGRESS, importId);
     }
 
     public void publishTypeDefNotification(AtlasAsyncImportRequest importRequest, AtlasTypesDef atlasTypesDef) throws AtlasBaseException {
@@ -144,10 +218,27 @@ public class AsyncImportTaskExecutor {
             importService.populateCache(importRequest);
 
             importTaskListener.onReceiveImportRequest(importRequest);
+        } catch (AtlasBaseException | RuntimeException e) {
+            persistPublishProgress(importRequest);
+
+            throw e;
         } finally {
             notificationInterface.closeProducer(ASYNC_IMPORT, importRequest.getTopicName());
 
             LOG.info("<== publishImportRequest(importId={})", importRequest.getImportId());
+        }
+    }
+
+    /**
+     * The published position and counters are only kept in the cache while publishing, and reach the
+     * graph when the request is handed to the listener. If publishing fails before that, persist them
+     * once so a resubmit resumes where publishing stopped instead of republishing from the start.
+     */
+    private void persistPublishProgress(AtlasAsyncImportRequest importRequest) {
+        try {
+            importService.saveImportRequest(importRequest);
+        } catch (Exception e) {
+            LOG.warn("AsyncImport(id={}): failed to persist publish progress, a resubmit may republish entities", importRequest.getImportId(), e);
         }
     }
 
@@ -217,7 +308,7 @@ public class AsyncImportTaskExecutor {
         LOG.info("==> registerRequest(importId={})", importId);
 
         try {
-            AtlasAsyncImportRequest existingImportRequest = importService.fetchImportRequestByImportId(importId);
+            AtlasAsyncImportRequest existingImportRequest = importService.resolveRequestStatus(importId);
 
             // handle new , successful and failed request from scratch
             if (existingImportRequest == null
@@ -233,19 +324,24 @@ public class AsyncImportTaskExecutor {
                 newImportRequest.setReceivedTime(System.currentTimeMillis());
                 newImportRequest.getImportDetails().setTotalEntitiesCount(totalEntities);
                 newImportRequest.getImportDetails().setCreationOrder(creationOrder);
+                newImportRequest.getImportDetails().setPublishedEntityCount(0);
+
                 return withRetry(() -> {
                     importService.saveImportRequest(newImportRequest);
                     LOG.info("registerRequest(importId={}): registered new request", importId);
-                    return importService.fetchImportRequestByImportId(newImportRequest.getImportId()); }, importId);
+                    return importService.fetchImportRequestByImportId(newImportRequest.getImportId());
+                }, importId);
             } else if (ObjectUtils.equals(existingImportRequest.getStatus(), ImportStatus.STAGING)) {
                 // if we are resuming staging, we need to update the latest request received at
                 existingImportRequest.setReceivedTime(System.currentTimeMillis());
 
-                return withRetry(() -> {
-                    importService.updateImportRequest(existingImportRequest);
-                    LOG.info("registerRequest(importId={}): resumed {}", importId, existingImportRequest);
-                    return existingImportRequest;
-                }, importId);
+                // updateImportRequest retries internally and logs rather than throwing, so wrapping it
+                // in withRetry() only ever ran the body once
+                importService.updateImportRequest(existingImportRequest);
+
+                LOG.info("registerRequest(importId={}): resumed {}", importId, existingImportRequest);
+
+                return existingImportRequest;
             }
 
             // handle request in / WAITING / PROCESSING status as resume
@@ -279,11 +375,11 @@ public class AsyncImportTaskExecutor {
                     }
                 }
 
-                boolean canRetry = lockingConflict && attempt < (MAX_RETRIES - 1);
+                boolean canRetry = lockingConflict && attempt < (maxAttempts - 1);
                 if (canRetry) {
-                    long backoff = (long) BASE_BACKOFF_MS * (attempt + 1);
+                    long backoff = retryDelayMs * (attempt + 1);
                     LOG.warn("Lock conflict for importId={} on attempt {}/{}, backing off {} ms",
-                            importId, attempt + 1, MAX_RETRIES, backoff);
+                            importId, attempt + 1, maxAttempts, backoff);
                     try {
                         Thread.sleep(backoff);
                     } catch (InterruptedException ignored) {
@@ -293,7 +389,7 @@ public class AsyncImportTaskExecutor {
                 }
 
                 // Non-retryable OR last attempt failed
-                LOG.error("Failed to process importId={} on attempt {}/{}", importId, attempt + 1, MAX_RETRIES, e);
+                LOG.error("Failed to process importId={} on attempt {}/{}", importId, attempt + 1, maxAttempts, e);
                 if (e instanceof AtlasBaseException) {
                     throw (AtlasBaseException) e;
                 }

--- a/repository/src/test/java/org/apache/atlas/repository/impexp/AsyncImportServiceTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/impexp/AsyncImportServiceTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 public class AsyncImportServiceTest {
@@ -72,6 +73,10 @@ public class AsyncImportServiceTest {
 
         dataAccess         = mock(DataAccess.class);
         asyncImportService = new AsyncImportService(dataAccess);
+
+        // keep retry-backed reads from sleeping through the configured graph storage delay
+        asyncImportService.retryDelayMs = 1;
+        asyncImportService.maxAttempts  = 3;
     }
 
     @Test
@@ -100,6 +105,60 @@ public class AsyncImportServiceTest {
 
         assertNull(result);
         verify(dataAccess, times(1)).load(any(AtlasAsyncImportRequest.class));
+    }
+
+    @Test
+    public void testFetchImportRequestWithRetrySucceedsAfterTransientFailure() throws AtlasBaseException {
+        String                  importId    = "import-transient";
+        AtlasAsyncImportRequest mockRequest = new AtlasAsyncImportRequest();
+
+        mockRequest.setImportId(importId);
+
+        doThrow(new RuntimeException("backend unavailable"))
+                .doThrow(new RuntimeException("backend unavailable"))
+                .doReturn(mockRequest)
+                .when(dataAccess).load(any(AtlasAsyncImportRequest.class));
+
+        AtlasAsyncImportRequest result = asyncImportService.fetchImportRequestByImportIdWithRetry(importId);
+
+        assertNotNull(result);
+        assertEquals(result.getImportId(), importId);
+        verify(dataAccess, times(3)).load(any(AtlasAsyncImportRequest.class));
+    }
+
+    @Test
+    public void testFetchImportRequestWithRetryGivesUpAfterMaxAttempts() throws AtlasBaseException {
+        when(dataAccess.load(any(AtlasAsyncImportRequest.class))).thenThrow(new RuntimeException("backend unavailable"));
+
+        assertNull(asyncImportService.fetchImportRequestByImportIdWithRetry("import-unreadable"));
+
+        verify(dataAccess, times(3)).load(any(AtlasAsyncImportRequest.class));
+    }
+
+    @Test
+    public void testFetchImportRequestWithRetryDoesNotRetryMissingRequest() throws AtlasBaseException {
+        when(dataAccess.load(any(AtlasAsyncImportRequest.class)))
+                .thenThrow(new AtlasBaseException(org.apache.atlas.AtlasErrorCode.INSTANCE_BY_UNIQUE_ATTRIBUTE_NOT_FOUND, "type", "attrs"));
+
+        assertNull(asyncImportService.fetchImportRequestByImportIdWithRetry("import-missing"));
+
+        // a request that does not exist is a definitive answer, retrying it only delays the caller
+        verify(dataAccess, times(1)).load(any(AtlasAsyncImportRequest.class));
+    }
+
+    @Test
+    public void testFetchImportRequestWithRetryServesCachedRequestWithoutLoading() throws AtlasBaseException {
+        AtlasAsyncImportRequest cached = new AtlasAsyncImportRequest(new AtlasImportResult());
+
+        cached.setImportId("import-cached");
+        cached.setGuid("guid-cached");
+        cached.setStatus(PROCESSING);
+
+        asyncImportService.populateCache(cached);
+
+        assertSame(asyncImportService.fetchImportRequestByImportIdWithRetry("import-cached"), cached);
+
+        verify(dataAccess, times(0)).load(any(AtlasAsyncImportRequest.class));
     }
 
     @Test
@@ -239,6 +298,130 @@ public class AsyncImportServiceTest {
         assertNotNull(result);
         assertEquals(result.getImportId(), importId);
         verify(dataAccess, times(1)).load(any(AtlasAsyncImportRequest.class));
+    }
+
+    @Test
+    public void testResolveAbandonedRequestResolvesIncompleteProcessingRequest() throws AtlasBaseException {
+        String importId = "import-abandoned";
+
+        AtlasAsyncImportRequest request = new AtlasAsyncImportRequest(new AtlasImportResult());
+        request.setImportId(importId);
+        request.setStatus(PROCESSING);
+        request.getImportDetails().setTotalEntitiesCount(5);
+        request.getImportDetails().setImportedEntitiesCount(2);
+
+        when(dataAccess.load(any(AtlasAsyncImportRequest.class))).thenReturn(request);
+
+        // the topic is drained, so the request must be resolved even though its counters are short
+        AtlasAsyncImportRequest resolved = asyncImportService.resolveAbandonedRequest(importId);
+
+        assertEquals(resolved.getStatus(), AtlasAsyncImportRequest.ImportStatus.PARTIAL_SUCCESS);
+        assertTrue(resolved.getCompletedTime() > 0);
+        verify(dataAccess, times(1)).saveNoLoad(request);
+    }
+
+    @Test
+    public void testResolveAbandonedRequestResolvesRequestThatImportedNothing() throws AtlasBaseException {
+        String importId = "import-abandoned-empty";
+
+        AtlasAsyncImportRequest request = new AtlasAsyncImportRequest(new AtlasImportResult());
+        request.setImportId(importId);
+        request.setStatus(PROCESSING);
+        request.getImportDetails().setTotalEntitiesCount(5);
+
+        when(dataAccess.load(any(AtlasAsyncImportRequest.class))).thenReturn(request);
+
+        AtlasAsyncImportRequest resolved = asyncImportService.resolveAbandonedRequest(importId);
+
+        assertEquals(resolved.getStatus(), AtlasAsyncImportRequest.ImportStatus.FAILED);
+        verify(dataAccess, times(1)).saveNoLoad(request);
+    }
+
+    @Test
+    public void testResolveAbandonedRequestLeavesNonProcessingRequestUntouched() throws AtlasBaseException {
+        String importId = "import-waiting";
+
+        AtlasAsyncImportRequest request = new AtlasAsyncImportRequest(new AtlasImportResult());
+        request.setImportId(importId);
+        request.setStatus(WAITING);
+
+        when(dataAccess.load(any(AtlasAsyncImportRequest.class))).thenReturn(request);
+
+        AtlasAsyncImportRequest resolved = asyncImportService.resolveAbandonedRequest(importId);
+
+        assertEquals(resolved.getStatus(), WAITING);
+        verify(dataAccess, times(0)).saveNoLoad(request);
+    }
+
+    @Test
+    public void testResolveRequestStatusKeepsInFlightProgressCached() throws AtlasBaseException {
+        String importId = "import-in-flight";
+
+        AtlasAsyncImportRequest inFlight = new AtlasAsyncImportRequest(new AtlasImportResult());
+        inFlight.setImportId(importId);
+        inFlight.setGuid("guid-in-flight");
+        inFlight.setStatus(PROCESSING);
+        inFlight.getImportDetails().setTotalEntitiesCount(5);
+        inFlight.getImportDetails().setImportedEntitiesCount(4);
+
+        asyncImportService.populateCache(inFlight);
+
+        // the persisted copy is stale: progress is not written to the graph until the import completes
+        AtlasAsyncImportRequest persisted = new AtlasAsyncImportRequest(new AtlasImportResult());
+        persisted.setImportId(importId);
+        persisted.setStatus(PROCESSING);
+        persisted.getImportDetails().setTotalEntitiesCount(5);
+
+        when(dataAccess.load(any(AtlasAsyncImportRequest.class))).thenReturn(persisted);
+
+        AtlasAsyncImportRequest resolved = asyncImportService.resolveRequestStatus(importId);
+
+        assertSame(resolved, inFlight);
+        assertEquals(resolved.getImportDetails().getImportedEntitiesCount(), 4);
+        verify(dataAccess, times(0)).load(any(AtlasAsyncImportRequest.class));
+
+        // the entry must still be cached, otherwise the running import loses its progress
+        assertSame(asyncImportService.fetchImportRequestByImportId(importId), inFlight);
+    }
+
+    @Test
+    public void testCacheDoesNotEvictInFlightRequestUnderSizePressure() throws InterruptedException {
+        AtlasAsyncImportRequest inFlight = new AtlasAsyncImportRequest(new AtlasImportResult());
+        inFlight.setImportId("import-processing");
+        inFlight.setGuid("guid-processing");
+        inFlight.setStatus(PROCESSING);
+        inFlight.getImportDetails().setImportedEntitiesCount(7);
+
+        asyncImportService.populateCache(inFlight);
+
+        // eviction targets the oldest entry, so make the in-flight request the unambiguous candidate
+        Thread.sleep(5);
+
+        for (int i = 0; i < 25; i++) {
+            AtlasAsyncImportRequest terminal = new AtlasAsyncImportRequest(new AtlasImportResult());
+            terminal.setImportId("import-done-" + i);
+            terminal.setGuid("guid-done-" + i);
+            terminal.setStatus(SUCCESSFUL);
+
+            asyncImportService.populateCache(terminal);
+        }
+
+        assertSame(asyncImportService.fetchImportRequestByImportId("import-processing"), inFlight);
+    }
+
+    @Test
+    public void testIsTerminalPinsOnlyInFlightRequests() {
+        AtlasAsyncImportRequest request = new AtlasAsyncImportRequest(new AtlasImportResult());
+
+        for (AtlasAsyncImportRequest.ImportStatus status : AtlasAsyncImportRequest.ImportStatus.values()) {
+            request.setStatus(status);
+
+            boolean inFlight = status == AtlasAsyncImportRequest.ImportStatus.STAGING
+                    || status == WAITING
+                    || status == PROCESSING;
+
+            assertEquals(AsyncImportService.isTerminal(request), !inFlight, "unexpected pinning for status " + status);
+        }
     }
 
     @AfterMethod

--- a/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AsyncImportTaskExecutorTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/store/graph/v2/AsyncImportTaskExecutorTest.java
@@ -40,10 +40,17 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -56,6 +63,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 public class AsyncImportTaskExecutorTest {
@@ -84,6 +92,10 @@ public class AsyncImportTaskExecutorTest {
 
             asyncImportTaskExecutor = new AsyncImportTaskExecutor(importService, importTaskListener);
         }
+
+        // keep retry-backed paths from sleeping through the configured graph storage delay
+        asyncImportTaskExecutor.retryDelayMs = 1;
+        asyncImportTaskExecutor.maxAttempts  = 3;
     }
 
     @Test
@@ -100,7 +112,8 @@ public class AsyncImportTaskExecutorTest {
         when(mockEntityImportStream.getCreationOrder()).thenReturn(Collections.emptyList());
         when(mockEntityImportStream.hasNext()).thenReturn(false);
 
-        when(importService.fetchImportRequestByImportId("import-md5-hash")).thenReturn(null).thenReturn(savedRequest);
+        when(importService.resolveRequestStatus("import-md5-hash")).thenReturn(null);
+        when(importService.fetchImportRequestByImportId("import-md5-hash")).thenReturn(savedRequest);
         doNothing().when(importService).saveImportRequest(any(AtlasAsyncImportRequest.class));
 
         AtlasAsyncImportRequest result = asyncImportTaskExecutor.run(mockResult, mockEntityImportStream);
@@ -109,6 +122,149 @@ public class AsyncImportTaskExecutorTest {
         assertSame(result.getStatus(), AtlasAsyncImportRequest.ImportStatus.STAGING);
         verify(mockEntityImportStream).close();
         verify(importService).saveImportRequest(any(AtlasAsyncImportRequest.class));
+    }
+
+    @Test
+    void testConcurrentRunPublishesOnce() throws Exception {
+        AtlasImportResult       mockResult = mock(AtlasImportResult.class);
+        AtlasAsyncImportRequest staged     = new AtlasAsyncImportRequest(mockResult);
+
+        staged.setImportId("import-md5");
+        staged.setStatus(AtlasAsyncImportRequest.ImportStatus.STAGING);
+
+        when(importService.resolveRequestStatus("import-md5")).thenReturn(null);
+        when(importService.fetchImportRequestByImportId("import-md5")).thenReturn(staged);
+
+        AsyncImportTaskExecutor executor       = spy(asyncImportTaskExecutor);
+        CountDownLatch          publishStarted = new CountDownLatch(1);
+        CountDownLatch          releasePublish = new CountDownLatch(1);
+
+        // hold the winning thread inside the critical section while the duplicate is submitted
+        doAnswer(invocation -> {
+            publishStarted.countDown();
+            releasePublish.await(10, TimeUnit.SECONDS);
+
+            return null;
+        }).when(executor).publishImportRequest(any(), any());
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<AtlasAsyncImportRequest> winner = pool.submit(() -> executor.run(mockResult, entityImportStream("import-md5")));
+
+            assertTrue(publishStarted.await(10, TimeUnit.SECONDS), "first request never reached publish");
+
+            AtlasAsyncImportRequest duplicate = pool.submit(() -> executor.run(mockResult, entityImportStream("import-md5"))).get(10, TimeUnit.SECONDS);
+
+            releasePublish.countDown();
+
+            assertNotNull(winner.get(10, TimeUnit.SECONDS));
+            assertSame(duplicate, staged);
+
+            verify(executor, times(1)).publishImportRequest(any(), any());
+            verify(importService, times(1)).saveImportRequest(any(AtlasAsyncImportRequest.class));
+        } finally {
+            releasePublish.countDown();
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void testConcurrentRunRejectsDuplicateWhenInFlightRequestNotYetVisible() throws Exception {
+        AtlasImportResult       mockResult = mock(AtlasImportResult.class);
+        AtlasAsyncImportRequest staged     = new AtlasAsyncImportRequest(mockResult);
+
+        staged.setImportId("import-md5");
+        staged.setStatus(AtlasAsyncImportRequest.ImportStatus.STAGING);
+
+        when(importService.resolveRequestStatus("import-md5")).thenReturn(null);
+
+        // the winner reads its own request, the duplicate cannot see it yet
+        when(importService.fetchImportRequestByImportId("import-md5")).thenReturn(staged, (AtlasAsyncImportRequest) null);
+
+        AsyncImportTaskExecutor executor       = spy(asyncImportTaskExecutor);
+        CountDownLatch          publishStarted = new CountDownLatch(1);
+        CountDownLatch          releasePublish = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            publishStarted.countDown();
+            releasePublish.await(10, TimeUnit.SECONDS);
+
+            return null;
+        }).when(executor).publishImportRequest(any(), any());
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<AtlasAsyncImportRequest> winner = pool.submit(() -> executor.run(mockResult, entityImportStream("import-md5")));
+
+            assertTrue(publishStarted.await(10, TimeUnit.SECONDS), "first request never reached publish");
+
+            Future<AtlasAsyncImportRequest> duplicate = pool.submit(() -> executor.run(mockResult, entityImportStream("import-md5")));
+            ExecutionException              failure   = expectThrows(ExecutionException.class, () -> duplicate.get(10, TimeUnit.SECONDS));
+
+            releasePublish.countDown();
+
+            assertNotNull(winner.get(10, TimeUnit.SECONDS));
+            assertEquals(((AtlasBaseException) failure.getCause()).getAtlasErrorCode(), AtlasErrorCode.IMPORT_ALREADY_IN_PROGRESS);
+
+            verify(executor, times(1)).publishImportRequest(any(), any());
+        } finally {
+            releasePublish.countDown();
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void testRunAfterPublishCompletedAllowsResubmission() throws AtlasBaseException {
+        AtlasImportResult       mockResult = mock(AtlasImportResult.class);
+        AtlasAsyncImportRequest staged     = new AtlasAsyncImportRequest(mockResult);
+
+        staged.setImportId("import-md5");
+        staged.setStatus(AtlasAsyncImportRequest.ImportStatus.STAGING);
+
+        when(importService.resolveRequestStatus("import-md5")).thenReturn(null);
+        when(importService.fetchImportRequestByImportId("import-md5")).thenReturn(staged);
+
+        AsyncImportTaskExecutor executor = spy(asyncImportTaskExecutor);
+
+        doNothing().when(executor).publishImportRequest(any(), any());
+
+        // the claim is per-submission, so a later resubmission is not blocked by a stale claim
+        executor.run(mockResult, entityImportStream("import-md5"));
+        executor.run(mockResult, entityImportStream("import-md5"));
+
+        verify(executor, times(2)).publishImportRequest(any(), any());
+    }
+
+    @Test
+    void testPublishFailurePersistsProgress() throws AtlasBaseException {
+        AtlasImportResult       mockResult    = mock(AtlasImportResult.class);
+        AtlasAsyncImportRequest importRequest = new AtlasAsyncImportRequest(mockResult);
+
+        importRequest.setImportId("import-md5");
+        importRequest.getImportTrackingInfo().setStartEntityPosition(42);
+
+        AsyncImportTaskExecutor executor = spy(asyncImportTaskExecutor);
+
+        doThrow(new RuntimeException("publish interrupted")).when(executor).publishEntityNotification(any(), any());
+
+        expectThrows(RuntimeException.class, () -> executor.publishImportRequest(importRequest, mock(EntityImportStream.class)));
+
+        // without this the graph keeps the stale position and a resubmit republishes from the start
+        verify(importService, times(1)).saveImportRequest(importRequest);
+        verify(importTaskListener, never()).onReceiveImportRequest(any());
+    }
+
+    private EntityImportStream entityImportStream(String md5Hash) {
+        EntityImportStream entityImportStream = mock(EntityImportStream.class);
+
+        when(entityImportStream.getMd5Hash()).thenReturn(md5Hash);
+        when(entityImportStream.size()).thenReturn(5);
+        when(entityImportStream.getCreationOrder()).thenReturn(Collections.emptyList());
+        when(entityImportStream.hasNext()).thenReturn(false);
+
+        return entityImportStream;
     }
 
     @Test
@@ -122,7 +278,7 @@ public class AsyncImportTaskExecutorTest {
 
         AtlasAsyncImportRequest mockRequest = mock(AtlasAsyncImportRequest.class);
         when(mockRequest.getStatus()).thenReturn(AtlasAsyncImportRequest.ImportStatus.WAITING);
-        when(importService.fetchImportRequestByImportId("import-md5")).thenReturn(mockRequest);
+        when(importService.resolveRequestStatus("import-md5")).thenReturn(mockRequest);
 
         doNothing().when(mockEntityImportStream).close();
 
@@ -156,7 +312,7 @@ public class AsyncImportTaskExecutorTest {
         AtlasAsyncImportRequest mockRequest = mock(AtlasAsyncImportRequest.class);
 
         when(mockRequest.getStatus()).thenReturn(AtlasAsyncImportRequest.ImportStatus.PROCESSING);
-        when(importService.fetchImportRequestByImportId("import-md5")).thenReturn(mockRequest);
+        when(importService.resolveRequestStatus("import-md5")).thenReturn(mockRequest);
 
         doNothing().when(mockEntityImportStream).close();
 
@@ -426,7 +582,8 @@ public class AsyncImportTaskExecutorTest {
             when(existingRequest.getImportDetails()).thenReturn(new AtlasAsyncImportRequest.ImportDetails());
         }
 
-        when(importService.fetchImportRequestByImportId("import-id")).thenReturn(existingRequest).thenReturn(savedRequest);
+        when(importService.resolveRequestStatus("import-id")).thenReturn(existingRequest);
+        when(importService.fetchImportRequestByImportId("import-id")).thenReturn(savedRequest);
 
         AtlasAsyncImportRequest result = asyncImportTaskExecutor.registerRequest(mockResult, "import-id", 10, Collections.emptyList());
 
@@ -450,7 +607,7 @@ public class AsyncImportTaskExecutorTest {
 
         when(mockImportRequest.getStatus()).thenReturn(AtlasAsyncImportRequest.ImportStatus.SUCCESSFUL);
         when(mockImportRequest.getImportDetails()).thenReturn(new AtlasAsyncImportRequest.ImportDetails());
-        when(importService.fetchImportRequestByImportId("import-id")).thenReturn(mockImportRequest);
+        when(importService.resolveRequestStatus("import-id")).thenReturn(mockImportRequest);
         doThrow(new AtlasBaseException("Some error while saving")).when(importService).saveImportRequest(any(AtlasAsyncImportRequest.class));
 
         AtlasBaseException exception = expectThrows(AtlasBaseException.class, () -> asyncImportTaskExecutor.registerRequest(mockResult, "import-id", 10, Collections.emptyList()));
@@ -468,7 +625,8 @@ public class AsyncImportTaskExecutorTest {
                 .doNothing()
                 .when(importService).saveImportRequest(any(AtlasAsyncImportRequest.class));
 
-        when(importService.fetchImportRequestByImportId("import-id")).thenReturn(null).thenReturn(savedRequest);
+        when(importService.resolveRequestStatus("import-id")).thenReturn(null);
+        when(importService.fetchImportRequestByImportId("import-id")).thenReturn(savedRequest);
 
         AtlasAsyncImportRequest response =
                 asyncImportTaskExecutor.registerRequest(result, "import-id", 5, Collections.emptyList());
@@ -485,7 +643,7 @@ public class AsyncImportTaskExecutorTest {
         doThrow(new RuntimeException(new PermanentLockingException("lock conflict")))
                 .when(importService).saveImportRequest(any(AtlasAsyncImportRequest.class));
 
-        when(importService.fetchImportRequestByImportId("import-id")).thenReturn(null);
+        when(importService.resolveRequestStatus("import-id")).thenReturn(null);
 
         AtlasBaseException ex = expectThrows(
                 AtlasBaseException.class,
@@ -503,7 +661,7 @@ public class AsyncImportTaskExecutorTest {
         doThrow(new RuntimeException("Unexpected error"))
                 .when(importService).saveImportRequest(any(AtlasAsyncImportRequest.class));
 
-        when(importService.fetchImportRequestByImportId("import-id")).thenReturn(null);
+        when(importService.resolveRequestStatus("import-id")).thenReturn(null);
 
         AtlasBaseException ex = expectThrows(
                 AtlasBaseException.class,

--- a/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/ImportTaskListenerImpl.java
@@ -41,6 +41,7 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -198,16 +199,16 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
 
     @VisibleForTesting
     void startInternal() {
-        populateRequestQueue();
-
-        if (!requestQueue.isEmpty()) {
-            CompletableFuture.runAsync(this::startNextImportInQueue)
-                    .exceptionally(ex -> {
-                        LOG.error("Failed to start next import in queue", ex);
-
-                        return null;
-                    });
-        }
+        // populating the queue reads the graph, queries kafka and can resolve abandoned imports: doing that
+        // on the service startup thread holds up every service started after this one, including the audit
+        // repository that those very writes depend on
+        CompletableFuture.runAsync(() -> {
+            populateRequestQueue();
+            startNextImportInQueue();
+        }).exceptionally(ex -> {
+            LOG.error("Failed to start next import in queue", ex);
+            return null;
+        });
     }
 
     @VisibleForTesting
@@ -249,6 +250,7 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
                 exec.submit(() -> startImportConsumer(nextImport));
             } else {
                 LOG.warn("No executor available to process import task (instance is passive).");
+                releaseAsyncImportSemaphore();
             }
         } catch (Exception e) {
             LOG.error("Error while starting the next import, releasing the lock if held", e);
@@ -283,7 +285,9 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
                 // Reset retry count because we got a valid importId (even if it's invalid later)
                 retryCount = 0;
 
-                nextImport = asyncImportService.fetchImportRequestByImportId(importId);
+                // poll() already removed the id, so a transient read failure here would drop the
+                // import for the lifetime of this process while the graph still reports it WAITING
+                nextImport = asyncImportService.fetchImportRequestByImportIdWithRetry(importId);
 
                 if (isNotValidImportRequest(nextImport)) {
                     LOG.info("Import request {}, is not in a valid status to start import, hence skipping..", nextImport);
@@ -339,15 +343,44 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
         List<String> queuedImports     = asyncImportService.fetchQueuedImportRequests();
         List<String> inProgressImports = asyncImportService.fetchInProgressImportIds();
 
+        if (queuedImports == null) {
+            queuedImports = Collections.emptyList();
+        }
+
+        if (inProgressImports == null) {
+            inProgressImports = Collections.emptyList();
+        }
+
         if (queuedImports.isEmpty() && inProgressImports.isEmpty()) {
             LOG.info("populateRequestQueue(): no queued asynchronous import requests found.");
         } else {
             LOG.info("populateRequestQueue(): loaded {} asynchronous import requests (in-progress={}, queued={})", (inProgressImports.size() + queuedImports.size()), inProgressImports.size(), queuedImports.size());
 
-            Stream.concat(inProgressImports.stream(), queuedImports.stream()).forEach(this::enqueueImportId);
+            Stream.concat(inProgressImports.stream().filter(this::isResumable), queuedImports.stream())
+                    .forEach(this::enqueueImportId);
         }
 
         LOG.info("<== populateRequestQueue()");
+    }
+
+    /**
+     * An import found PROCESSING at startup can only continue if its topic still has messages to
+     * deliver. If the topic was already drained before the previous shutdown, starting a consumer
+     * would hold the single import permit forever, since nothing would ever trigger completion.
+     */
+    @VisibleForTesting
+    boolean isResumable(String importId) {
+        if (!notificationHookConsumer.isImportTopicFullyConsumed(ASYNC_IMPORT_TOPIC_PREFIX.getString() + importId)) {
+            return true;
+        }
+
+        try {
+            asyncImportService.resolveAbandonedRequest(importId);
+        } catch (Exception e) {
+            LOG.error("Failed to resolve abandoned import {}, skipping it to keep the import queue moving", importId, e);
+        }
+
+        return false;
     }
 
     private void startImportConsumer(AtlasAsyncImportRequest importRequest) {
@@ -367,9 +400,14 @@ public class ImportTaskListenerImpl implements Service, ActiveStateChangeHandler
             LOG.error("Failed to start consumer for import: {}, marking import as failed", importRequest, e);
         } finally {
             if (ObjectUtils.equals(importRequest.getStatus(), ImportStatus.FAILED)) {
-                asyncImportService.saveImport(importRequest.getImportId());
-
-                onCompleteImportRequest(importRequest.getImportId());
+                try {
+                    asyncImportService.saveImport(importRequest.getImportId());
+                } catch (Throwable t) {
+                    // Failing to persist FAILED status must not block queue progress.
+                    LOG.error("Failed to persist FAILED state for importId={}", importRequest.getImportId(), t);
+                } finally {
+                    onCompleteImportRequest(importRequest.getImportId());
+                }
             }
 
             LOG.info("<== startImportConsumer(importId={})", importRequest.getImportId());

--- a/webapp/src/main/java/org/apache/atlas/notification/NotificationHookConsumer.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/NotificationHookConsumer.java
@@ -257,6 +257,10 @@ public class NotificationHookConsumer implements Service, ActiveStateChangeHandl
         return HandlerOrder.NOTIFICATION_HOOK_CONSUMER.getOrder();
     }
 
+    public boolean isImportTopicFullyConsumed(String topic) {
+        return notificationInterface.isTopicFullyConsumed(ASYNC_IMPORT, topic);
+    }
+
     public void closeImportConsumer(String importId, String topic) {
         try {
             LOG.info("==> closeImportConsumer(importId={}, topic={})", importId, topic);

--- a/webapp/src/main/java/org/apache/atlas/notification/SerialEntityProcessor.java
+++ b/webapp/src/main/java/org/apache/atlas/notification/SerialEntityProcessor.java
@@ -412,6 +412,7 @@ public class SerialEntityProcessor implements NotificationEntityProcessor {
         AtlasMetricsUtil.NotificationStat   stats                 = new AtlasMetricsUtil.NotificationStat();
         AuditFilter.AuditLog                auditLog              = null;
         boolean                             importRequestComplete = false;
+        String                              completedImportId     = null;
 
         if (authorizeUsingMessageUser) {
             setCurrentUser(messageUser);
@@ -639,6 +640,7 @@ public class SerialEntityProcessor implements NotificationEntityProcessor {
 
                                 asyncImporter.onImportComplete(importId);
                                 importRequestComplete = true;
+                                completedImportId     = importId;
                             }
                         }
                         break;
@@ -648,6 +650,8 @@ public class SerialEntityProcessor implements NotificationEntityProcessor {
                             final String                                           importId                 = entityImportNotification.getImportId();
                             final AtlasEntity.AtlasEntityWithExtInfo               entityWithExtInfo        = entityImportNotification.getEntity();
                             final int                                              position                 = entityImportNotification.getPosition();
+
+                            completedImportId = null;
 
                             LOG.info("==> IMPORT_ENTITY:processing entity: {} at position: {}", importId, position);
 
@@ -659,6 +663,10 @@ public class SerialEntityProcessor implements NotificationEntityProcessor {
                                 LOG.error("IMPORT_ENTITY: {} failed to import entity: {}", importId, entityImportNotification);
                             } finally {
                                 if (importRequestComplete) {
+                                    // set before onImportComplete() so the import queue is released
+                                    // even if completion bookkeeping fails
+                                    completedImportId = importId;
+
                                     asyncImporter.onImportComplete(importId);
                                 }
                                 LOG.info("<== IMPORT_ENTITY:processing entity: {} at position: {}", importId, position);
@@ -775,8 +783,8 @@ public class SerialEntityProcessor implements NotificationEntityProcessor {
                 nextStatsLogTime = AtlasMetricsCounter.getNextHourStartTime(now);
             }
 
-            if (importRequestComplete) {
-                asyncImporter.onCompleteImportRequest(((AtlasEntityImportNotification) message).getImportId());
+            if (importRequestComplete && StringUtils.isNotEmpty(completedImportId)) {
+                asyncImporter.onCompleteImportRequest(completedImportId);
             }
         }
     }

--- a/webapp/src/test/java/org/apache/atlas/notification/ImportTaskListenerImplTest.java
+++ b/webapp/src/test/java/org/apache/atlas/notification/ImportTaskListenerImplTest.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.CountDownLatch;
@@ -97,6 +98,7 @@ public class ImportTaskListenerImplTest {
         asyncImportService = mock(AsyncImportService.class);
 
         when(asyncImportService.fetchImportRequestByImportId("import123")).thenReturn(importRequest);
+        when(asyncImportService.fetchImportRequestByImportIdWithRetry("import123")).thenReturn(importRequest);
 
         notificationHookConsumer = mock(NotificationHookConsumer.class);
         importTaskListener       = new ImportTaskListenerImpl(asyncImportService, notificationHookConsumer, requestQueue);
@@ -108,6 +110,7 @@ public class ImportTaskListenerImplTest {
 
         importRequest = createImportRequestMock("import123", "topic1");
         when(asyncImportService.fetchImportRequestByImportId(any(String.class))).thenReturn(importRequest);
+        when(asyncImportService.fetchImportRequestByImportIdWithRetry(any(String.class))).thenReturn(importRequest);
 
         importTaskListener = new ImportTaskListenerImpl(asyncImportService, notificationHookConsumer, requestQueue);
     }
@@ -179,6 +182,62 @@ public class ImportTaskListenerImplTest {
         verify(requestQueue, times(1)).offer("import2", 5, TimeUnit.SECONDS);
         verify(requestQueue, times(1)).offer("import3", 5, TimeUnit.SECONDS);
         verify(asyncImportService, times(1)).fetchQueuedImportRequests();
+    }
+
+    @Test
+    public void testPopulateRequestQueueSkipsAndResolvesDrainedInProgressImport() throws Exception {
+        try {
+            when(asyncImportService.fetchQueuedImportRequests()).thenReturn(Collections.emptyList());
+            when(asyncImportService.fetchInProgressImportIds()).thenReturn(Collections.singletonList("drained-import"));
+            when(notificationHookConsumer.isImportTopicFullyConsumed(anyString())).thenReturn(true);
+
+            importTaskListener.populateRequestQueue();
+
+            // enqueueing it would start a consumer on an empty topic and hold the import permit forever
+            verify(requestQueue, never()).offer(eq("drained-import"), anyLong(), any(TimeUnit.class));
+            verify(asyncImportService, times(1)).resolveAbandonedRequest("drained-import");
+        } finally {
+            restoreQueueStubs();
+        }
+    }
+
+    @Test
+    public void testPopulateRequestQueueResumesInProgressImportWithPendingMessages() throws Exception {
+        try {
+            when(asyncImportService.fetchQueuedImportRequests()).thenReturn(Collections.emptyList());
+            when(asyncImportService.fetchInProgressImportIds()).thenReturn(Collections.singletonList("resumable-import"));
+            when(notificationHookConsumer.isImportTopicFullyConsumed(anyString())).thenReturn(false);
+
+            importTaskListener.populateRequestQueue();
+
+            verify(requestQueue, times(1)).offer("resumable-import", 5, TimeUnit.SECONDS);
+            verify(asyncImportService, never()).resolveAbandonedRequest("resumable-import");
+        } finally {
+            restoreQueueStubs();
+        }
+    }
+
+    @Test
+    public void testPopulateRequestQueueEnqueuesDrainedImportWhenResolutionFails() throws Exception {
+        try {
+            when(asyncImportService.fetchQueuedImportRequests()).thenReturn(Collections.emptyList());
+            when(asyncImportService.fetchInProgressImportIds()).thenReturn(Collections.singletonList("unresolvable-import"));
+            when(notificationHookConsumer.isImportTopicFullyConsumed(anyString())).thenReturn(true);
+            doThrow(new AtlasBaseException("resolution failed")).when(asyncImportService).resolveAbandonedRequest("unresolvable-import");
+
+            importTaskListener.populateRequestQueue();
+
+            // a failed resolution must still keep the drained import out of the queue
+            verify(requestQueue, never()).offer(eq("unresolvable-import"), anyLong(), any(TimeUnit.class));
+        } finally {
+            restoreQueueStubs();
+        }
+    }
+
+    private void restoreQueueStubs() {
+        when(asyncImportService.fetchQueuedImportRequests()).thenReturn(Collections.emptyList());
+        when(asyncImportService.fetchInProgressImportIds()).thenReturn(Collections.emptyList());
+        when(notificationHookConsumer.isImportTopicFullyConsumed(anyString())).thenReturn(false);
     }
 
     @Test
@@ -293,6 +352,7 @@ public class ImportTaskListenerImplTest {
 
         when(request.getStatus()).thenReturn(WAITING);
         when(asyncImportService.fetchImportRequestByImportId("import123")).thenReturn(request);
+        when(asyncImportService.fetchImportRequestByImportIdWithRetry("import123")).thenReturn(request);
         when(requestQueue.poll(anyLong(), any(TimeUnit.class))).thenReturn("import123");
 
         CountDownLatch consumerStarted = new CountDownLatch(1);
@@ -317,6 +377,7 @@ public class ImportTaskListenerImplTest {
 
         when(request.getStatus()).thenReturn(WAITING);
         when(asyncImportService.fetchImportRequestByImportId("import123")).thenReturn(request);
+        when(asyncImportService.fetchImportRequestByImportIdWithRetry("import123")).thenReturn(request);
         when(requestQueue.poll(anyLong(), any(TimeUnit.class))).thenReturn("import123").thenReturn(null);
 
         CountDownLatch consumerClosed = new CountDownLatch(1);
@@ -342,6 +403,43 @@ public class ImportTaskListenerImplTest {
         verify(notificationHookConsumer, times(1)).closeImportConsumer("import123", "ATLAS_IMPORT_import123");
     }
 
+    @Test
+    public void testStartImportConsumer_FailureStillCompletesWhenSaveImportThrowsRuntime() throws Exception {
+        AtlasAsyncImportRequest request = createImportRequestMock("import123", "topic1");
+
+        when(request.getStatus()).thenReturn(WAITING);
+        when(asyncImportService.fetchImportRequestByImportId("import123")).thenReturn(request);
+        when(asyncImportService.fetchImportRequestByImportIdWithRetry("import123")).thenReturn(request);
+        when(requestQueue.poll(anyLong(), any(TimeUnit.class))).thenReturn("import123").thenReturn(null);
+
+        CountDownLatch consumerClosed = new CountDownLatch(1);
+
+        doThrow(new RuntimeException("Consumer failed")).when(notificationHookConsumer)
+                .startAsyncImportConsumer(NotificationInterface.NotificationType.ASYNC_IMPORT, "import123", "topic1");
+
+        doAnswer(invocation -> {
+            when(request.getStatus()).thenReturn(invocation.getArgument(0));
+            return null;
+        }).when(request).setStatus(any());
+
+        doNothing()
+                .doThrow(new RuntimeException("Graph commit failure"))
+                .when(asyncImportService).saveImport("import123");
+
+        doAnswer(invocation -> {
+            consumerClosed.countDown();
+            return null;
+        }).when(notificationHookConsumer).closeImportConsumer(anyString(), anyString());
+
+        setExecutorService(importTaskListener, synchronousExecutor());
+
+        importTaskListener.onReceiveImportRequest(request);
+
+        assertTrue(consumerClosed.await(5, TimeUnit.SECONDS), "closeImportConsumer was not invoked");
+
+        verify(notificationHookConsumer, times(1)).closeImportConsumer("import123", "ATLAS_IMPORT_import123");
+    }
+
     @Test(dataProvider = "importQueueScenarios")
     public void testGetImportIdFromQueue(String[] pollResults, AtlasAsyncImportRequest[] fetchResults, String expectedImportId, int expectedPollCount) throws InterruptedException {
         //configure mock queue behaviour
@@ -351,7 +449,7 @@ public class ImportTaskListenerImplTest {
 
         // Configure fetch service behavior
         for (AtlasAsyncImportRequest fetchResult : fetchResults) {
-            when(asyncImportService.fetchImportRequestByImportId(fetchResult.getImportId())).thenReturn(fetchResult);
+            when(asyncImportService.fetchImportRequestByImportIdWithRetry(fetchResult.getImportId())).thenReturn(fetchResult);
         }
 
         // Execute the method
@@ -468,7 +566,7 @@ public class ImportTaskListenerImplTest {
 
         when(asyncImportSemaphore.tryAcquire()).thenReturn(true);
         when(requestQueue.poll(anyLong(), any())).thenReturn(VALID_IMPORT_ID);
-        when(asyncImportService.fetchImportRequestByImportId(VALID_IMPORT_ID)).thenReturn(validRequest);
+        when(asyncImportService.fetchImportRequestByImportIdWithRetry(VALID_IMPORT_ID)).thenReturn(validRequest);
 
         sut.startAsyncImportIfAvailable(null);
 
@@ -491,7 +589,7 @@ public class ImportTaskListenerImplTest {
         invalidRequest.setStatus(ABORTED);
 
         when(requestQueue.poll(anyLong(), any())).thenReturn(INVALID_IMPORT_ID).thenReturn(null);
-        when(asyncImportService.fetchImportRequestByImportId(INVALID_IMPORT_ID)).thenReturn(invalidRequest);
+        when(asyncImportService.fetchImportRequestByImportIdWithRetry(INVALID_IMPORT_ID)).thenReturn(invalidRequest);
 
         when(asyncImportSemaphore.tryAcquire()).thenReturn(true);
 

--- a/webapp/src/test/java/org/apache/atlas/notification/SerialEntityProcessorTest.java
+++ b/webapp/src/test/java/org/apache/atlas/notification/SerialEntityProcessorTest.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.notification;
+
+import org.apache.atlas.RequestContext;
+import org.apache.atlas.kafka.AtlasKafkaMessage;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntity.AtlasEntitiesWithExtInfo;
+import org.apache.atlas.model.notification.HookNotification;
+import org.apache.atlas.model.notification.ImportNotification;
+import org.apache.atlas.model.typedef.AtlasTypesDef;
+import org.apache.atlas.notification.pc.Ticket;
+import org.apache.atlas.repository.converters.AtlasInstanceConverter;
+import org.apache.atlas.repository.impexp.AsyncImporter;
+import org.apache.atlas.repository.store.graph.AtlasEntityStore;
+import org.apache.atlas.type.AtlasEntityType;
+import org.apache.atlas.type.AtlasTypeRegistry;
+import org.apache.atlas.util.AtlasMetricsUtil;
+import org.apache.commons.configuration2.Configuration;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.springframework.security.core.Authentication;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class SerialEntityProcessorTest {
+    private AtlasEntityStore entityStore;
+
+    private SerialEntityProcessor sep;
+
+    @BeforeMethod
+    public void build() {
+        Configuration cfg = mockConfiguration();
+
+        entityStore = Mockito.mock(AtlasEntityStore.class);
+        AtlasMetricsUtil metricsUtil = Mockito.mock(AtlasMetricsUtil.class);
+        doNothing().when(metricsUtil).onNotificationProcessingComplete(anyString(), anyInt(), anyLong(), any());
+        Map<String, Authentication> principals = Collections.emptyMap();
+        AtlasTypeRegistry registry = Mockito.mock(AtlasTypeRegistry.class);
+        Mockito.when(registry.getEntityTypeByName(Mockito.anyString())).thenAnswer(inv -> Mockito.mock(AtlasEntityType.class));
+
+        sep = new SerialEntityProcessor(cfg, metricsUtil, principals, entityStore, Mockito.mock(AtlasInstanceConverter.class),
+                Mockito.mock(EntityCorrelationManager.class), registry,
+                Mockito.mock(Logger.class), Mockito.mock(Logger.class), Mockito.mock(AsyncImporter.class));
+    }
+
+    @AfterMethod
+    public void resetCtx() {
+        RequestContext.clear();
+    }
+
+    private AtlasKafkaMessage<HookNotification> kafka(HookNotification hn) {
+        return new AtlasKafkaMessage<>(hn, 4L, "hook-topic", 0);
+    }
+
+    private Configuration mockConfiguration() {
+        Configuration cfg = Mockito.mock(Configuration.class);
+        Mockito.when(cfg.getInt(anyString(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
+        Mockito.when(cfg.getBoolean(anyString(), anyBoolean())).thenAnswer(inv -> inv.getArgument(1));
+        Mockito.when(cfg.getStringArray(Mockito.anyString())).thenReturn(null);
+
+        return cfg;
+    }
+
+    private SerialEntityProcessor processorWith(AsyncImporter asyncImporter) {
+        return new SerialEntityProcessor(mockConfiguration(), Mockito.mock(AtlasMetricsUtil.class), Collections.emptyMap(),
+                entityStore, Mockito.mock(AtlasInstanceConverter.class),
+                Mockito.mock(EntityCorrelationManager.class),
+                Mockito.mock(AtlasTypeRegistry.class), Mockito.mock(Logger.class), Mockito.mock(Logger.class), asyncImporter);
+    }
+
+    private HookNotification importEntityNotification(String importId, int position) {
+        AtlasEntity entity = new AtlasEntity("hive_table");
+
+        entity.setGuid("guid-" + position);
+        entity.setAttribute("qualifiedName", "default.t" + position + "@cl1");
+
+        return new ImportNotification.AtlasEntityImportNotification(importId, "svc", new AtlasEntity.AtlasEntityWithExtInfo(entity), position);
+    }
+
+    @Test
+    public void lifecycle_noopMethodsAndTicketWrapper() {
+        assertNull(sep.collectResults());
+        sep.shutdown();
+        AtlasEntitiesWithExtInfo empty = new AtlasEntitiesWithExtInfo();
+        empty.setEntities(Collections.emptyList());
+        Ticket tk = Mockito.mock(Ticket.class);
+        Mockito.when(tk.getMessage()).thenReturn(kafka(new HookNotification.EntityCreateRequestV2("svc", empty)));
+        Mockito.when(tk.getQualifiedNamesSet()).thenReturn(Collections.emptySet());
+        assertNotNull(sep.handleMessage(tk));
+    }
+
+    @Test
+    public void importTypesDefFailure_completesImportRequestWithoutClassCast() throws Exception {
+        AsyncImporter asyncImporter = Mockito.mock(AsyncImporter.class);
+
+        doThrow(Mockito.mock(org.apache.atlas.exception.AtlasBaseException.class))
+                .when(asyncImporter).onImportTypeDef(any(AtlasTypesDef.class), anyString());
+
+        SerialEntityProcessor processor = processorWith(asyncImporter);
+
+        HookNotification message = new ImportNotification.AtlasTypesDefImportNotification("import-123", "svc", new AtlasTypesDef());
+        assertNotNull(processor.handleMessage(kafka(message)));
+
+        verify(asyncImporter, times(1)).onImportComplete("import-123");
+        verify(asyncImporter, times(1)).onCompleteImportRequest("import-123");
+    }
+
+    @Test
+    public void lastImportEntity_releasesImportQueue() throws Exception {
+        AsyncImporter asyncImporter = Mockito.mock(AsyncImporter.class);
+
+        Mockito.when(asyncImporter.onImportEntity(any(), anyString(), anyInt())).thenReturn(true);
+
+        SerialEntityProcessor processor = processorWith(asyncImporter);
+
+        assertNotNull(processor.handleMessage(kafka(importEntityNotification("import-123", 9))));
+
+        verify(asyncImporter, times(1)).onImportComplete("import-123");
+        verify(asyncImporter, times(1)).onCompleteImportRequest("import-123");
+    }
+
+    @Test
+    public void inFlightImportEntity_keepsImportQueueHeld() throws Exception {
+        AsyncImporter asyncImporter = Mockito.mock(AsyncImporter.class);
+
+        Mockito.when(asyncImporter.onImportEntity(any(), anyString(), anyInt())).thenReturn(false);
+
+        SerialEntityProcessor processor = processorWith(asyncImporter);
+
+        assertNotNull(processor.handleMessage(kafka(importEntityNotification("import-123", 1))));
+
+        verify(asyncImporter, never()).onImportComplete(anyString());
+        verify(asyncImporter, never()).onCompleteImportRequest(anyString());
+    }
+
+    @Test
+    public void failedImportEntity_releasesImportQueue() throws Exception {
+        AsyncImporter asyncImporter = Mockito.mock(AsyncImporter.class);
+
+        doThrow(Mockito.mock(org.apache.atlas.exception.AtlasBaseException.class))
+                .when(asyncImporter).onImportEntity(any(), anyString(), anyInt());
+
+        SerialEntityProcessor processor = processorWith(asyncImporter);
+
+        assertNotNull(processor.handleMessage(kafka(importEntityNotification("import-123", 9))));
+
+        verify(asyncImporter, times(1)).onImportComplete("import-123");
+        verify(asyncImporter, times(1)).onCompleteImportRequest("import-123");
+    }
+
+    @Test
+    public void importCompletionBookkeepingFailure_stillReleasesImportQueue() throws Exception {
+        AsyncImporter asyncImporter = Mockito.mock(AsyncImporter.class);
+
+        Mockito.when(asyncImporter.onImportEntity(any(), anyString(), anyInt())).thenReturn(true);
+        doThrow(new org.apache.atlas.exception.AtlasBaseException("import completion failed"))
+                .when(asyncImporter).onImportComplete(anyString());
+
+        SerialEntityProcessor processor = processorWith(asyncImporter);
+
+        processor.handleMessage(kafka(importEntityNotification("import-123", 9)));
+
+        verify(asyncImporter, atLeastOnce()).onImportComplete("import-123");
+        verify(asyncImporter, times(1)).onCompleteImportRequest("import-123");
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed concurrent duplicate request handling.


## How was this patch tested?

Manually deployed to cluster and tested against the failing scenarios