### PR TITLE
ATLAS-5399 Add Apache Nutch metadata model and CrawlDb/HostDB import bridge

### DIFF
--- a/addons/models/7000-Nutch/7010-nutch_model.json
+++ b/addons/models/7000-Nutch/7010-nutch_model.json
@@ -1,0 +1,131 @@
+{
+    "enumDefs": [],
+    "structDefs": [],
+    "entityDefs": [
+        {
+            "name":        "nutch_crawl",
+            "superTypes":  [ "DataSet" ],
+            "serviceType": "nutch",
+            "typeVersion": "1.0",
+            "description": "A Nutch crawl identified by crawlId. Catalog owner is the CrawlDb import bridge (https://issues.apache.org/jira/browse/ATLAS-5399).",
+            "attributeDefs": [
+                { "name": "crawlId",     "typeName": "string", "cardinality": "SINGLE", "isOptional": false, "isUnique": false, "isIndexable": true },
+                { "name": "clusterName", "typeName": "string", "cardinality": "SINGLE", "isOptional": false, "isUnique": false, "isIndexable": true,  "includeInNotification": true },
+                { "name": "crawldbPath", "typeName": "string", "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": false },
+                { "name": "urlCount",    "typeName": "long",   "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": false }
+            ]
+        },
+        {
+            "name":        "nutch_seedlist",
+            "superTypes":  [ "Asset" ],
+            "serviceType": "nutch",
+            "typeVersion": "1.0",
+            "description": "Seed URL list for a single crawl (CLI inject directory). COMPOSITION 1:1 under nutch_crawl.",
+            "attributeDefs": [
+                { "name": "seedCount", "typeName": "long",   "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "seedPath",  "typeName": "string", "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false }
+            ]
+        },
+        {
+            "name":        "nutch_segment",
+            "superTypes":  [ "DataSet" ],
+            "serviceType": "nutch",
+            "typeVersion": "1.0",
+            "description": "A Nutch segment directory under {crawlId}/segments.",
+            "attributeDefs": [
+                { "name": "segmentName",   "typeName": "string", "cardinality": "SINGLE", "isOptional": false, "isUnique": false, "isIndexable": true },
+                { "name": "path",          "typeName": "string", "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": false },
+                { "name": "generatedTime", "typeName": "date",   "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": false }
+            ]
+        },
+        {
+            "name":        "nutch_domain",
+            "superTypes":  [ "Asset" ],
+            "serviceType": "nutch",
+            "typeVersion": "1.0",
+            "description": "Registrable domain / eTLD+1 (URLUtil.getDomainName / EffectiveTldFinder), not the TLD. Example: lucene.apache.org -> apache.org.",
+            "attributeDefs": [
+                { "name": "clusterName", "typeName": "string", "cardinality": "SINGLE", "isOptional": false, "isUnique": false, "isIndexable": true, "includeInNotification": true }
+            ]
+        },
+        {
+            "name":        "nutch_host",
+            "superTypes":  [ "Asset" ],
+            "serviceType": "nutch",
+            "typeVersion": "1.0",
+            "description": "Hostname (and optional protocol) unique per Atlas cluster. Fetch metrics live on nutch_crawl_hosts, not on this entity.",
+            "attributeDefs": [
+                { "name": "hostname",    "typeName": "string", "cardinality": "SINGLE", "isOptional": false, "isUnique": false, "isIndexable": true },
+                { "name": "protocol",    "typeName": "string", "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": true },
+                { "name": "clusterName", "typeName": "string", "cardinality": "SINGLE", "isOptional": false, "isUnique": false, "isIndexable": true, "includeInNotification": true }
+            ]
+        },
+        {
+            "name":        "nutch_index_process",
+            "superTypes":  [ "Process" ],
+            "serviceType": "nutch",
+            "typeVersion": "1.0",
+            "description": "One process per Nutch IndexingJob (https://issues.apache.org/jira/browse/NUTCH-3210). Inputs are nutch_crawl and/or nutch_segment; output is a generic DataSet for the search index.",
+            "attributeDefs": [
+                { "name": "operationType", "typeName": "string", "cardinality": "SINGLE", "isOptional": false, "isUnique": false, "isIndexable": true },
+                { "name": "queryText",     "typeName": "string", "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": false },
+                { "name": "clusterName",   "typeName": "string", "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": true, "includeInNotification": true },
+                { "name": "startTime",     "typeName": "date",   "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": false },
+                { "name": "endTime",       "typeName": "date",   "cardinality": "SINGLE", "isOptional": true,  "isUnique": false, "isIndexable": false }
+            ]
+        }
+    ],
+    "relationshipDefs": [
+        {
+            "name":                 "nutch_crawl_seedlist",
+            "serviceType":          "nutch",
+            "typeVersion":          "1.0",
+            "relationshipCategory": "COMPOSITION",
+            "propagateTags":        "NONE",
+            "endDef1": { "type": "nutch_crawl",    "name": "seedlist", "isContainer": true,  "cardinality": "SINGLE" },
+            "endDef2": { "type": "nutch_seedlist", "name": "crawl",    "isContainer": false, "cardinality": "SINGLE" }
+        },
+        {
+            "name":                 "nutch_crawl_segments",
+            "serviceType":          "nutch",
+            "typeVersion":          "1.0",
+            "relationshipCategory": "COMPOSITION",
+            "propagateTags":        "NONE",
+            "endDef1": { "type": "nutch_crawl",   "name": "segments", "isContainer": true,  "cardinality": "SET" },
+            "endDef2": { "type": "nutch_segment", "name": "crawl",    "isContainer": false, "cardinality": "SINGLE" }
+        },
+        {
+            "name":                 "nutch_domain_hosts",
+            "serviceType":          "nutch",
+            "typeVersion":          "1.0",
+            "relationshipCategory": "AGGREGATION",
+            "propagateTags":        "NONE",
+            "endDef1": { "type": "nutch_domain", "name": "hosts",  "isContainer": true,  "cardinality": "SET" },
+            "endDef2": { "type": "nutch_host",   "name": "domain", "isContainer": false, "cardinality": "SINGLE" }
+        },
+        {
+            "name":                 "nutch_crawl_hosts",
+            "serviceType":          "nutch",
+            "typeVersion":          "1.0",
+            "relationshipCategory": "ASSOCIATION",
+            "propagateTags":        "NONE",
+            "description":          "Many-to-many crawl to global host. Per-crawl fetch/index metrics live on the relationship.",
+            "attributeDefs": [
+                { "name": "fetchedCount",    "typeName": "long", "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "unfetchedCount",  "typeName": "long", "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "indexedCount",    "typeName": "long", "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "lastFetchTime",   "typeName": "date", "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "lastIndexedTime",   "typeName": "date",   "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "maxScore",          "typeName": "float",  "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "dnsFailures",       "typeName": "long",   "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "connectionFailures","typeName": "long",   "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "goneCount",         "typeName": "long",   "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "redirPermCount",    "typeName": "long",   "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "redirTempCount",    "typeName": "long",   "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false },
+                { "name": "homepageUrl",       "typeName": "string", "cardinality": "SINGLE", "isOptional": true, "isUnique": false, "isIndexable": false }
+            ],
+            "endDef1": { "type": "nutch_crawl", "name": "hosts",  "isContainer": false, "cardinality": "SET" },
+            "endDef2": { "type": "nutch_host",  "name": "crawls", "isContainer": false, "cardinality": "SET" }
+        }
+    ]
+}

--- a/addons/nutch-bridge/pom.xml
+++ b/addons/nutch-bridge/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing limitations under
+  ~ the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.atlas</groupId>
+        <artifactId>apache-atlas</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+
+    <artifactId>nutch-bridge</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Apache Atlas Nutch Bridge</name>
+    <description>Apache Atlas Nutch CrawlDb import bridge (https://issues.apache.org/jira/browse/ATLAS-5399)</description>
+
+    <properties>
+        <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
+        <checkstyle.skip>false</checkstyle.skip>
+        <crawler-commons.version>1.6</crawler-commons.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.crawler-commons</groupId>
+            <artifactId>crawler-commons</artifactId>
+            <version>${crawler-commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>atlas-client-v2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
+            <artifactId>atlas-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-nutch-model</id>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/models</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/../models</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>dist</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-hook</id>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/dependency/hook/nutch/atlas-nutch-plugin-impl</outputDirectory>
+                                    <overWriteIfNewer>true</overWriteIfNewer>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>${project.artifactId}</artifactId>
+                                            <version>${project.version}</version>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>copy-hook-runtime-dependencies</id>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <includeScope>runtime</includeScope>
+                                    <outputDirectory>${project.build.directory}/dependency/hook/nutch/atlas-nutch-plugin-impl</outputDirectory>
+                                    <overWriteIfNewer>true</overWriteIfNewer>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/addons/nutch-bridge/src/bin/import-nutch.sh
+++ b/addons/nutch-bridge/src/bin/import-nutch.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing limitations under
+#  the License. See accompanying LICENSE file.
+#
+
+PRG="${0}"
+
+[[ `uname -s` == *"CYGWIN"* ]] && CYGWIN=true
+
+while [ -h "${PRG}" ]; do
+  ls=`ls -ld "${PRG}"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "${PRG}"`/"$link"
+  fi
+done
+
+BASEDIR=`dirname ${PRG}`
+BASEDIR=`cd ${BASEDIR}/..;pwd`
+
+allargs=$@
+
+if test -z "${JAVA_HOME}"
+then
+    JAVA_BIN=`which java`
+    JAR_BIN=`which jar`
+else
+    JAVA_BIN="${JAVA_HOME}/bin/java"
+    JAR_BIN="${JAVA_HOME}/bin/jar"
+fi
+export JAVA_BIN
+
+if [ ! -e "${JAVA_BIN}" ] || [ ! -e "${JAR_BIN}" ]; then
+  echo "$JAVA_BIN and/or $JAR_BIN not found on the system. Please make sure java and jar commands are available."
+  exit 1
+fi
+
+for i in "${BASEDIR}/hook/nutch/atlas-nutch-plugin-impl/"*.jar; do
+  ATLASCPPATH="${ATLASCPPATH}:$i"
+done
+
+if [ -z "${ATLAS_CONF_DIR}" ] && [ -e /etc/atlas/conf ];then
+    ATLAS_CONF_DIR=/etc/atlas/conf
+fi
+ATLASCPPATH=${ATLASCPPATH}:${ATLAS_CONF_DIR}
+
+if [ -d "${ATLAS_CONF_DIR}" ] && [ -f "${ATLAS_CONF_DIR}/atlas-env.sh" ]; then
+  source ${ATLAS_CONF_DIR}/atlas-env.sh
+fi
+
+ATLAS_LOG_DIR="${ATLAS_LOG_DIR:-/var/log/atlas}"
+export ATLAS_LOG_DIR
+LOGFILE="$ATLAS_LOG_DIR/import-nutch.log"
+
+CP="${ATLASCPPATH}"
+
+if [ "${CYGWIN}" == "true" ]
+then
+   ATLAS_LOG_DIR=`cygpath -w ${ATLAS_LOG_DIR}`
+   LOGFILE=`cygpath -w ${LOGFILE}`
+   CP=`cygpath -w -p ${CP}`
+fi
+
+JAVA_PROPERTIES="$ATLAS_OPTS -Datlas.log.dir=$ATLAS_LOG_DIR -Datlas.log.file=import-nutch.log -Dlogback.configurationFile=atlas-nutch-import-logback.xml"
+
+echo "Log file for import is $LOGFILE"
+
+"${JAVA_BIN}" ${JAVA_PROPERTIES} -cp "${CP}" org.apache.atlas.nutch.bridge.NutchBridge $allargs
+
+RETVAL=$?
+[ $RETVAL -eq 0 ] && echo Nutch Data Model imported successfully!!!
+[ $RETVAL -ne 0 ] && echo Failed to import Nutch Data Model!!!
+
+exit $RETVAL

--- a/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/CrawlDbReader.java
+++ b/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/CrawlDbReader.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.MapFile;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads Nutch CrawlDb MapFiles ({@code crawldb/current}) without depending on Nutch jars.
+ * Value layout matches Nutch CrawlDatum version 7.
+ */
+public final class CrawlDbReader {
+    private CrawlDbReader() {
+    }
+
+    /**
+     * Reads every MapFile partition under {@code crawldb/current}.
+     *
+     * @param crawlDbCurrent {@code crawldb/current} or a single MapFile directory
+     * @return one record per CrawlDb URL
+     * @throws IOException if no MapFiles are found or a partition cannot be read
+     */
+    public static List<CrawlRecord> read(Path crawlDbCurrent) throws IOException {
+        Configuration conf = new Configuration();
+        FileSystem    fs   = crawlDbCurrent.getFileSystem(conf);
+        Path          dir  = crawlDbCurrent;
+
+        if (fs.isFile(dir)) {
+            dir = dir.getParent();
+        }
+
+        List<CrawlRecord> records = new ArrayList<>();
+        List<Path>        mapFiles = new ArrayList<>();
+
+        if (fs.exists(new Path(dir, "data"))) {
+            mapFiles.add(dir);
+        } else {
+            for (FileStatus status : fs.listStatus(dir)) {
+                if (status.isDirectory() && fs.exists(new Path(status.getPath(), "data"))) {
+                    mapFiles.add(status.getPath());
+                }
+            }
+        }
+
+        if (mapFiles.isEmpty()) {
+            throw new IOException("No readable CrawlDb MapFiles found under " + dir);
+        }
+
+        for (Path mapFile : mapFiles) {
+            try (MapFile.Reader reader = new MapFile.Reader(mapFile, conf)) {
+                Text            key   = new Text();
+                NutchCrawlDatum value = (NutchCrawlDatum) ReflectionUtils.newInstance(NutchCrawlDatum.class, conf);
+
+                while (reader.next(key, value)) {
+                    records.add(new CrawlRecord(key.toString(), value.status, value.score, value.fetchTime));
+                }
+            }
+        }
+
+        return records;
+    }
+
+    /**
+     * Subset of Nutch CrawlDatum Writable for v7.
+     */
+    public static class NutchCrawlDatum implements Writable {
+        byte  status;
+        long  fetchTime;
+        byte  retries;
+        int   fetchInterval;
+        float score;
+        long  modifiedTime;
+
+        /** {@inheritDoc} */
+        @Override
+        public void write(DataOutput out) throws IOException {
+            out.writeByte(7);
+            out.writeByte(status);
+            out.writeLong(fetchTime);
+            out.writeByte(retries);
+            out.writeInt(fetchInterval);
+            out.writeFloat(score);
+            out.writeLong(modifiedTime);
+            out.writeByte(0);
+            out.writeBoolean(false);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void readFields(DataInput in) throws IOException {
+            byte version = in.readByte();
+
+            status    = in.readByte();
+            fetchTime = in.readLong();
+            retries   = in.readByte();
+
+            if (version > 5) {
+                fetchInterval = in.readInt();
+            } else {
+                fetchInterval = Math.round(in.readFloat());
+            }
+
+            score = in.readFloat();
+
+            if (version > 2) {
+                modifiedTime = in.readLong();
+                int sigLen = in.readByte() & 0xff;
+                if (sigLen > 0) {
+                    in.skipBytes(sigLen);
+                }
+            }
+
+            if (version > 3) {
+                boolean hasMetadata = in.readBoolean();
+                if (hasMetadata) {
+                    if (!(in instanceof DataInputStream)) {
+                        throw new IOException("Cannot skip CrawlDatum metadata from " + in.getClass().getName());
+                    }
+
+                    in.skipBytes(((DataInputStream) in).available());
+                }
+            }
+        }
+    }
+}

--- a/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/CrawlRecord.java
+++ b/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/CrawlRecord.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+/**
+ * One CrawlDb URL record used for host rollup. Status values match Nutch CrawlDatum.
+ */
+public class CrawlRecord {
+    /** Page was not fetched yet. */
+    public static final byte STATUS_DB_UNFETCHED = 0x01;
+    /** Page was successfully fetched. */
+    public static final byte STATUS_DB_FETCHED = 0x02;
+    /** Page was successfully fetched and found not modified. */
+    public static final byte STATUS_DB_NOTMODIFIED = 0x06;
+    /** Fetching was successful. */
+    public static final byte STATUS_FETCH_SUCCESS = 0x21;
+    /** Fetching successful - page is not modified. */
+    public static final byte STATUS_FETCH_NOTMODIFIED = 0x26;
+
+    private final String url;
+    private final byte   status;
+    private final float  score;
+    private final long   fetchTime;
+
+    /**
+     * @param url       CrawlDb key (page URL)
+     * @param status    Nutch {@code CrawlDatum} status byte
+     * @param score     page score
+     * @param fetchTime fetch time in milliseconds since epoch
+     */
+    public CrawlRecord(String url, byte status, float score, long fetchTime) {
+        this.url       = url;
+        this.status    = status;
+        this.score     = score;
+        this.fetchTime = fetchTime;
+    }
+
+    /** @return page URL */
+    public String getUrl() {
+        return url;
+    }
+
+    /** @return Nutch {@code CrawlDatum} status byte */
+    public byte getStatus() {
+        return status;
+    }
+
+    /** @return page score */
+    public float getScore() {
+        return score;
+    }
+
+    /** @return fetch time in milliseconds since epoch */
+    public long getFetchTime() {
+        return fetchTime;
+    }
+
+    /**
+     * @return {@code true} for {@link #STATUS_DB_FETCHED}, {@link #STATUS_DB_NOTMODIFIED},
+     *         {@link #STATUS_FETCH_SUCCESS}, or {@link #STATUS_FETCH_NOTMODIFIED}
+     */
+    public boolean isFetched() {
+        return status == STATUS_DB_FETCHED
+                || status == STATUS_DB_NOTMODIFIED
+                || status == STATUS_FETCH_SUCCESS
+                || status == STATUS_FETCH_NOTMODIFIED;
+    }
+}

--- a/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/HostCatalogBuilder.java
+++ b/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/HostCatalogBuilder.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import crawlercommons.domains.EffectiveTldFinder;
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Rolls CrawlDb URL records up to hostname / eTLD+1. Hosts with no fetched URL are dropped.
+ */
+public final class HostCatalogBuilder {
+    private HostCatalogBuilder() {
+    }
+
+    /**
+     * Rolls CrawlDb URLs up by hostname. Drops hosts with no fetched URL.
+     *
+     * @param records CrawlDb records
+     * @return hostname to per-crawl metrics
+     */
+    public static Map<String, HostMetrics> rollup(Collection<CrawlRecord> records) {
+        if (records == null || records.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, HostMetrics> byHost = new LinkedHashMap<>();
+
+        for (CrawlRecord record : records) {
+            UrlParts parts = parseUrl(record.getUrl());
+
+            if (parts == null) {
+                continue;
+            }
+
+            HostMetrics metrics = byHost.get(parts.hostname);
+
+            if (metrics == null) {
+                metrics = new HostMetrics(parts.hostname, parts.protocol, parts.etldPlusOne);
+                byHost.put(parts.hostname, metrics);
+            }
+
+            metrics.add(record);
+        }
+
+        Map<String, HostMetrics> fetchedOnly = new LinkedHashMap<>();
+
+        for (Map.Entry<String, HostMetrics> entry : byHost.entrySet()) {
+            if (entry.getValue().hasFetchedUrl()) {
+                fetchedOnly.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return fetchedOnly;
+    }
+
+    /**
+     * Builds host metrics from HostDB. Keeps hosts with {@code fetched + notModified > 0}.
+     *
+     * @param records HostDB rows
+     * @return hostname to per-crawl metrics
+     */
+    public static Map<String, HostMetrics> fromHostDb(Collection<HostDbReader.HostDbRecord> records) {
+        if (records == null || records.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, HostMetrics> fetchedOnly = new LinkedHashMap<>();
+
+        for (HostDbReader.HostDbRecord record : records) {
+            if (record.fetched + record.notModified <= 0) {
+                continue;
+            }
+
+            UrlParts parts = parseHostname(record.hostname);
+
+            if (parts == null) {
+                continue;
+            }
+
+            HostMetrics metrics = new HostMetrics(parts.hostname, parts.protocol, parts.etldPlusOne);
+            metrics.applyHostDb(record.fetched, record.notModified, record.unfetched, record.score, record.lastCheck,
+                    record.dnsFailures, record.connectionFailures, record.gone, record.redirPerm, record.redirTemp,
+                    record.homepageUrl);
+            fetchedOnly.put(parts.hostname, metrics);
+        }
+
+        return fetchedOnly;
+    }
+
+    static UrlParts parseHostname(String hostname) {
+        if (StringUtils.isBlank(hostname)) {
+            return null;
+        }
+
+        String host = hostname.toLowerCase();
+        if (host.charAt(host.length() - 1) == '.') {
+            host = host.substring(0, host.length() - 1);
+        }
+
+        String etld = EffectiveTldFinder.getAssignedDomain(host, false, true);
+        if (StringUtils.isBlank(etld)) {
+            etld = host;
+        }
+
+        return new UrlParts(host, null, etld.toLowerCase());
+    }
+
+    static UrlParts parseUrl(String url) {
+        if (StringUtils.isBlank(url)) {
+            return null;
+        }
+
+        try {
+            URI    uri      = URI.create(url);
+            String host     = uri.getHost();
+            String protocol = uri.getScheme();
+
+            if (StringUtils.isBlank(host)) {
+                return null;
+            }
+
+            if (host.charAt(host.length() - 1) == '.') {
+                host = host.substring(0, host.length() - 1);
+            }
+
+            host = host.toLowerCase();
+
+            String etld = EffectiveTldFinder.getAssignedDomain(host, false, true);
+
+            if (StringUtils.isBlank(etld)) {
+                etld = host;
+            }
+
+            return new UrlParts(host, protocol, etld.toLowerCase());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    static final class UrlParts {
+        final String hostname;
+        final String protocol;
+        final String etldPlusOne;
+
+        UrlParts(String hostname, String protocol, String etldPlusOne) {
+            this.hostname    = hostname;
+            this.protocol    = protocol;
+            this.etldPlusOne = etldPlusOne;
+        }
+    }
+}

--- a/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/HostDbReader.java
+++ b/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/HostDbReader.java
@@ -1,0 +1,213 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.MapFile;
+import org.apache.hadoop.io.MapWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads Nutch HostDB MapFile partitions and SequenceFile {@code part-*} files
+ * without depending on Nutch jars. Value layout matches
+ * {@code org.apache.nutch.hostdb.HostDatum}.
+ */
+public final class HostDbReader {
+    private HostDbReader() {
+    }
+
+    /**
+     * Reads HostDB MapFile partitions and SequenceFile {@code part-*} files.
+     *
+     * @param hostDbCurrent {@code hostdb/current} or a HostDB partition path
+     * @return host rows with fetched / unfetched counters
+     * @throws IOException if no HostDB files are found or a partition cannot be read
+     */
+    public static List<HostDbRecord> read(Path hostDbCurrent) throws IOException {
+        Configuration conf = new Configuration();
+        FileSystem    fs   = hostDbCurrent.getFileSystem(conf);
+        Path          dir  = hostDbCurrent;
+
+        if (fs.isFile(dir)) {
+            dir = dir.getParent();
+        }
+
+        List<HostDbRecord> records = new ArrayList<>();
+        List<Path>         mapFiles = new ArrayList<>();
+        List<Path>         sequenceFiles = new ArrayList<>();
+
+        if (fs.exists(new Path(dir, "data"))) {
+            mapFiles.add(dir);
+        } else {
+            for (FileStatus status : fs.listStatus(dir)) {
+                if (status.isDirectory() && fs.exists(new Path(status.getPath(), "data"))) {
+                    mapFiles.add(status.getPath());
+                } else if (status.isFile() && status.getPath().getName().startsWith("part-")) {
+                    sequenceFiles.add(status.getPath());
+                }
+            }
+        }
+
+        if (mapFiles.isEmpty() && sequenceFiles.isEmpty()) {
+            throw new IOException("No readable HostDB files found under " + dir);
+        }
+
+        for (Path mapFile : mapFiles) {
+            try (MapFile.Reader reader = new MapFile.Reader(mapFile, conf)) {
+                Text           key   = new Text();
+                NutchHostDatum value = (NutchHostDatum) ReflectionUtils.newInstance(NutchHostDatum.class, conf);
+
+                while (reader.next(key, value)) {
+                    records.add(toRecord(key, value));
+                }
+            }
+        }
+
+        for (Path sequenceFile : sequenceFiles) {
+            try (SequenceFile.Reader reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(sequenceFile))) {
+                Text           key   = new Text();
+                NutchHostDatum value = (NutchHostDatum) ReflectionUtils.newInstance(NutchHostDatum.class, conf);
+
+                while (reader.next(key, value)) {
+                    records.add(toRecord(key, value));
+                }
+            }
+        }
+
+        return records;
+    }
+
+    private static HostDbRecord toRecord(Text key, NutchHostDatum value) {
+        return new HostDbRecord(key.toString(), value.score, value.lastCheck, value.homepageUrl,
+                value.dnsFailures, value.connectionFailures, value.unfetched, value.fetched,
+                value.notModified, value.redirTemp, value.redirPerm, value.gone);
+    }
+
+    /**
+     * One HostDB hostname row. Layout matches {@code org.apache.nutch.hostdb.HostDatum}.
+     */
+    public static class HostDbRecord {
+        final String hostname;
+        final float  score;
+        final long   lastCheck;
+        final String homepageUrl;
+        final long   dnsFailures;
+        final long   connectionFailures;
+        final long   unfetched;
+        final long   fetched;
+        final long   notModified;
+        final long   redirTemp;
+        final long   redirPerm;
+        final long   gone;
+
+        /**
+         * @param hostname           HostDB key
+         * @param score              host score
+         * @param lastCheck          last check time in milliseconds since epoch
+         * @param homepageUrl        optional homepage URL
+         * @param dnsFailures        DNS failure count
+         * @param connectionFailures connection failure count
+         * @param unfetched          unfetched URL count
+         * @param fetched            fetched URL count
+         * @param notModified        not-modified URL count
+         * @param redirTemp          temporary redirect count
+         * @param redirPerm          permanent redirect count
+         * @param gone               gone URL count
+         */
+        public HostDbRecord(String hostname, float score, long lastCheck, String homepageUrl, long dnsFailures,
+                long connectionFailures, long unfetched, long fetched, long notModified, long redirTemp,
+                long redirPerm, long gone) {
+            this.hostname = hostname;
+            this.score = score;
+            this.lastCheck = lastCheck;
+            this.homepageUrl = homepageUrl;
+            this.dnsFailures = dnsFailures;
+            this.connectionFailures = connectionFailures;
+            this.unfetched = unfetched;
+            this.fetched = fetched;
+            this.notModified = notModified;
+            this.redirTemp = redirTemp;
+            this.redirPerm = redirPerm;
+            this.gone = gone;
+        }
+    }
+
+    /**
+     * Writable subset of Nutch {@code HostDatum} used to deserialize HostDB values.
+     */
+    public static class NutchHostDatum implements Writable {
+        float  score;
+        long   lastCheck;
+        String homepageUrl = "";
+        long   dnsFailures;
+        long   connectionFailures;
+        long   unfetched;
+        long   fetched;
+        long   notModified;
+        long   redirTemp;
+        long   redirPerm;
+        long   gone;
+
+        /** {@inheritDoc} */
+        @Override
+        public void write(DataOutput out) throws IOException {
+            out.writeFloat(score);
+            out.writeLong(lastCheck);
+            Text.writeString(out, homepageUrl == null ? "" : homepageUrl);
+            out.writeLong(dnsFailures);
+            out.writeLong(connectionFailures);
+            out.writeLong(unfetched);
+            out.writeLong(fetched);
+            out.writeLong(notModified);
+            out.writeLong(redirTemp);
+            out.writeLong(redirPerm);
+            out.writeLong(gone);
+            new MapWritable().write(out);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void readFields(DataInput in) throws IOException {
+            score = in.readFloat();
+            lastCheck = in.readLong();
+            homepageUrl = Text.readString(in);
+            dnsFailures = in.readLong();
+            connectionFailures = in.readLong();
+            unfetched = in.readLong();
+            fetched = in.readLong();
+            notModified = in.readLong();
+            redirTemp = in.readLong();
+            redirPerm = in.readLong();
+            gone = in.readLong();
+            MapWritable meta = new MapWritable();
+            meta.readFields(in);
+        }
+    }
+}

--- a/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/HostMetrics.java
+++ b/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/HostMetrics.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+/**
+ * Per-host counters for a single crawl. Only hosts with fetchedCount &gt; 0 are imported.
+ */
+public class HostMetrics {
+    private final String hostname;
+    private final String protocol;
+    private final String etldPlusOne;
+    private long         fetchedCount;
+    private long         unfetchedCount;
+    private long         lastFetchTime;
+    private float        maxScore;
+    private Long         dnsFailures;
+    private Long         connectionFailures;
+    private Long         goneCount;
+    private Long         redirPermCount;
+    private Long         redirTempCount;
+    private String       homepageUrl;
+
+    /**
+     * @param hostname    host name
+     * @param protocol    URL scheme when known from CrawlDb; may be {@code null} for HostDB rows
+     * @param etldPlusOne registrable domain / eTLD+1
+     */
+    public HostMetrics(String hostname, String protocol, String etldPlusOne) {
+        this.hostname    = hostname;
+        this.protocol    = protocol;
+        this.etldPlusOne = etldPlusOne;
+    }
+
+    /**
+     * Accumulates one CrawlDb URL into fetched/unfetched counts, last fetch time, and max score.
+     *
+     * @param record CrawlDb URL record for this host
+     */
+    public void add(CrawlRecord record) {
+        if (record.isFetched()) {
+            fetchedCount++;
+            if (record.getFetchTime() > lastFetchTime) {
+                lastFetchTime = record.getFetchTime();
+            }
+        } else {
+            unfetchedCount++;
+        }
+        if (record.getScore() > maxScore) {
+            maxScore = record.getScore();
+        }
+    }
+
+    /** @return host name */
+    public String getHostname() {
+        return hostname;
+    }
+
+    /** @return URL scheme, or {@code null} when unknown */
+    public String getProtocol() {
+        return protocol;
+    }
+
+    /** @return registrable domain / eTLD+1 */
+    public String getEtldPlusOne() {
+        return etldPlusOne;
+    }
+
+    /** @return fetched URL count for this crawl */
+    public long getFetchedCount() {
+        return fetchedCount;
+    }
+
+    /** @return unfetched URL count for this crawl */
+    public long getUnfetchedCount() {
+        return unfetchedCount;
+    }
+
+    /** @return latest fetch time in milliseconds since epoch, or {@code 0} if unknown */
+    public long getLastFetchTime() {
+        return lastFetchTime;
+    }
+
+    /** @return maximum CrawlDb/HostDB score observed for this host */
+    public float getMaxScore() {
+        return maxScore;
+    }
+
+    /** @return {@code true} when at least one URL was fetched */
+    public boolean hasFetchedUrl() {
+        return fetchedCount > 0;
+    }
+
+    /**
+     * Copies HostDB counters onto this host. {@code fetchedCount} is {@code fetched + notModified}.
+     *
+     * @param fetched            fetched URL count
+     * @param notModified        not-modified URL count
+     * @param unfetched          unfetched URL count
+     * @param score              host score
+     * @param lastCheck          last check time in milliseconds since epoch
+     * @param dnsFailures        DNS failure count
+     * @param connectionFailures connection failure count
+     * @param gone               gone URL count
+     * @param redirPerm          permanent redirect count
+     * @param redirTemp          temporary redirect count
+     * @param homepageUrl        optional homepage URL
+     */
+    public void applyHostDb(long fetched, long notModified, long unfetched, float score, long lastCheck,
+            long dnsFailures, long connectionFailures, long gone, long redirPerm, long redirTemp, String homepageUrl) {
+        this.fetchedCount = fetched + notModified;
+        this.unfetchedCount = unfetched;
+        this.maxScore = score;
+        this.lastFetchTime = lastCheck;
+        this.dnsFailures = dnsFailures;
+        this.connectionFailures = connectionFailures;
+        this.goneCount = gone;
+        this.redirPermCount = redirPerm;
+        this.redirTempCount = redirTemp;
+        this.homepageUrl = homepageUrl;
+    }
+
+    /** @return DNS failure count from HostDB, or {@code null} when rolled up from CrawlDb */
+    public Long getDnsFailures() {
+        return dnsFailures;
+    }
+
+    /** @return connection failure count from HostDB, or {@code null} when rolled up from CrawlDb */
+    public Long getConnectionFailures() {
+        return connectionFailures;
+    }
+
+    /** @return gone URL count from HostDB, or {@code null} when rolled up from CrawlDb */
+    public Long getGoneCount() {
+        return goneCount;
+    }
+
+    /** @return permanent redirect count from HostDB, or {@code null} when rolled up from CrawlDb */
+    public Long getRedirPermCount() {
+        return redirPermCount;
+    }
+
+    /** @return temporary redirect count from HostDB, or {@code null} when rolled up from CrawlDb */
+    public Long getRedirTempCount() {
+        return redirTempCount;
+    }
+
+    /** @return homepage URL from HostDB, or {@code null} when unknown */
+    public String getHomepageUrl() {
+        return homepageUrl;
+    }
+}

--- a/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/NutchBridge.java
+++ b/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/NutchBridge.java
@@ -1,0 +1,459 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.atlas.ApplicationProperties;
+import org.apache.atlas.AtlasClientV2;
+import org.apache.atlas.model.instance.AtlasEntity;
+import org.apache.atlas.model.instance.AtlasEntity.AtlasEntityWithExtInfo;
+import org.apache.atlas.model.instance.AtlasEntityHeader;
+import org.apache.atlas.model.instance.AtlasObjectId;
+import org.apache.atlas.model.instance.AtlasRelatedObjectId;
+import org.apache.atlas.model.instance.AtlasStruct;
+import org.apache.atlas.model.instance.EntityMutationResponse;
+import org.apache.atlas.nutch.model.NutchDataTypes;
+import org.apache.atlas.utils.AuthenticationUtil;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.WritableName;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Batch-imports Nutch crawl catalog metadata into Atlas. Does not create nutch_index_process
+ * (<a href="https://issues.apache.org/jira/browse/NUTCH-3210">NUTCH-3210</a>).
+ */
+public class NutchBridge {
+    private static final Logger LOG = LoggerFactory.getLogger(NutchBridge.class);
+
+    private static final int    EXIT_CODE_SUCCESS    = 0;
+    private static final int    EXIT_CODE_FAILED     = 1;
+    private static final String ATLAS_ENDPOINT       = "atlas.rest.address";
+    private static final String DEFAULT_ATLAS_URL    = "http://localhost:21000/";
+    private static final String CLUSTER_NAME_KEY     = "atlas.cluster.name";
+    private static final String DEFAULT_CLUSTER_NAME = "primary";
+    static final String         QUALIFIED_NAME       = "qualifiedName";
+
+    private final AtlasClientV2 atlasClientV2;
+    private final String        clusterName;
+
+    /**
+     * CLI entry: {@code -c crawlId -d crawldb [-H hostdb] [-s seeds] [-g segments]}.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(String[] args) {
+        int           exitCode      = EXIT_CODE_FAILED;
+        AtlasClientV2 atlasClientV2 = null;
+
+        System.out.println("\n################################\n# Apache Atlas Nutch bridge #\n################################\n");
+
+        try {
+            Options options = new Options();
+            options.addOption("c", "crawlId", true, "Nutch crawlId");
+            options.addOption("d", "crawldb", true, "Path to CrawlDb (crawldb or crawldb/current)");
+            options.addOption("s", "seeds", true, "Seed directory");
+            options.addOption("g", "segments", true, "Segments directory");
+            options.addOption("H", "hostdb", true, "Path to HostDB (hostdb or hostdb/current); preferred for hosts");
+
+            CommandLine   cmd       = new DefaultParser().parse(options, args);
+            String        crawlId   = cmd.getOptionValue("c");
+            String        crawldb   = cmd.getOptionValue("d");
+            String        seeds     = cmd.getOptionValue("s");
+            String        segments  = cmd.getOptionValue("g");
+            String        hostdb    = cmd.getOptionValue("H");
+            Configuration atlasConf = ApplicationProperties.get();
+            String[]      urls      = atlasConf.getStringArray(ATLAS_ENDPOINT);
+
+            if (urls == null || urls.length == 0) {
+                urls = new String[] {DEFAULT_ATLAS_URL};
+            }
+
+            if (StringUtils.isBlank(crawlId) || StringUtils.isBlank(crawldb)) {
+                printUsage();
+                System.exit(EXIT_CODE_FAILED);
+            }
+
+            if (!AuthenticationUtil.isKerberosAuthenticationEnabled()) {
+                String[] basicAuthUsernamePassword = AuthenticationUtil.getBasicAuthenticationInput();
+
+                atlasClientV2 = new AtlasClientV2(urls, basicAuthUsernamePassword);
+            } else {
+                UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+
+                atlasClientV2 = new AtlasClientV2(ugi, ugi.getShortUserName(), urls);
+            }
+
+            NutchBridge bridge = new NutchBridge(atlasConf, atlasClientV2);
+
+            registerCrawlDatumAlias();
+            registerHostDatumAlias();
+            bridge.importCrawl(crawlId, crawldb, seeds, segments, hostdb);
+
+            exitCode = EXIT_CODE_SUCCESS;
+        } catch (Exception e) {
+            System.out.println("ImportNutchEntities failed. Please check the log file for the detailed error message");
+            e.printStackTrace();
+            LOG.error("ImportNutchEntities failed", e);
+        } finally {
+            if (atlasClientV2 != null) {
+                atlasClientV2.close();
+            }
+        }
+
+        System.exit(exitCode);
+    }
+
+    static void registerCrawlDatumAlias() {
+        WritableName.addName(CrawlDbReader.NutchCrawlDatum.class, "org.apache.nutch.crawl.CrawlDatum");
+    }
+
+    static void registerHostDatumAlias() {
+        WritableName.addName(HostDbReader.NutchHostDatum.class, "org.apache.nutch.hostdb.HostDatum");
+    }
+
+    /**
+     * @param atlasConf     Atlas application properties ({@code atlas.cluster.name})
+     * @param atlasClientV2 REST client used to create and update entities
+     */
+    public NutchBridge(Configuration atlasConf, AtlasClientV2 atlasClientV2) {
+        this.atlasClientV2 = atlasClientV2;
+        this.clusterName   = atlasConf.getString(CLUSTER_NAME_KEY, DEFAULT_CLUSTER_NAME);
+    }
+
+    /**
+     * Imports crawl, seedlist, segments, domains, hosts, and crawl-host metrics.
+     * Hosts come from HostDB when present; otherwise CrawlDb rollup.
+     *
+     * @param crawlId     Nutch crawl id
+     * @param crawldbPath CrawlDb directory ({@code crawldb} or {@code crawldb/current})
+     * @param seedDir     optional inject seed directory
+     * @param segmentsDir optional segments directory
+     * @throws Exception if CrawlDb/HostDB cannot be read or Atlas REST calls fail
+     */
+    public void importCrawl(String crawlId, String crawldbPath, String seedDir, String segmentsDir) throws Exception {
+        importCrawl(crawlId, crawldbPath, seedDir, segmentsDir, null);
+    }
+
+    /**
+     * Same as {@link #importCrawl(String, String, String, String)} with an explicit HostDB path.
+     *
+     * @param crawlId     Nutch crawl id
+     * @param crawldbPath CrawlDb directory ({@code crawldb} or {@code crawldb/current})
+     * @param seedDir     optional inject seed directory
+     * @param segmentsDir optional segments directory
+     * @param hostDbPath  HostDB directory, or {@code null} to discover {@code ../hostdb/current}
+     * @throws Exception if CrawlDb/HostDB cannot be read or Atlas REST calls fail
+     */
+    public void importCrawl(String crawlId, String crawldbPath, String seedDir, String segmentsDir, String hostDbPath) throws Exception {
+        Path crawldb = resolveCurrentDir(crawldbPath);
+        List<CrawlRecord> records = CrawlDbReader.read(crawldb);
+        Map<String, HostMetrics> hosts = resolveHosts(crawldbPath, hostDbPath, records);
+        List<String> segmentNames = listSegmentNames(segmentsDir);
+        long seedCount = countSeedLines(seedDir);
+
+        LOG.info("Importing Nutch crawl {} ({} URLs, {} fetched hosts, {} segments)", crawlId, records.size(), hosts.size(), segmentNames.size());
+
+        AtlasEntityWithExtInfo crawl = createOrUpdateCrawl(crawlId, crawldbPath, records.size());
+        createOrUpdateSeedlist(crawlId, seedDir, seedCount, crawl.getEntity());
+        for (String segmentName : segmentNames) {
+            createOrUpdateSegment(crawlId, segmentsDir, segmentName, crawl.getEntity());
+        }
+        for (HostMetrics metrics : hosts.values()) {
+            createOrUpdateHostAndDomain(crawl.getEntity(), metrics);
+        }
+    }
+
+    @VisibleForTesting
+    AtlasEntityWithExtInfo createOrUpdateCrawl(String crawlId, String crawldbPath, long urlCount) throws Exception {
+        String                 qn     = NutchQualifiedNames.crawl(crawlId, clusterName);
+        AtlasEntityWithExtInfo existing = findEntity(NutchDataTypes.NUTCH_CRAWL.getName(), qn);
+        AtlasEntity            entity   = existing != null ? existing.getEntity() : new AtlasEntity(NutchDataTypes.NUTCH_CRAWL.getName());
+
+        entity.setAttribute(QUALIFIED_NAME, qn);
+        entity.setAttribute("name", crawlId);
+        entity.setAttribute("crawlId", crawlId);
+        entity.setAttribute("clusterName", clusterName);
+        entity.setAttribute("crawldbPath", crawldbPath);
+        entity.setAttribute("urlCount", urlCount);
+
+        return save(entity, existing);
+    }
+
+    @VisibleForTesting
+    AtlasEntityWithExtInfo createOrUpdateSeedlist(String crawlId, String seedPath, long seedCount, AtlasEntity crawl) throws Exception {
+        String                 qn       = NutchQualifiedNames.seedlist(crawlId, clusterName);
+        AtlasEntityWithExtInfo existing = findEntity(NutchDataTypes.NUTCH_SEEDLIST.getName(), qn);
+        AtlasEntity            entity   = existing != null ? existing.getEntity() : new AtlasEntity(NutchDataTypes.NUTCH_SEEDLIST.getName());
+
+        entity.setAttribute(QUALIFIED_NAME, qn);
+        entity.setAttribute("name", crawlId + "-seeds");
+        entity.setAttribute("seedPath", seedPath);
+        entity.setAttribute("seedCount", seedCount);
+        entity.setRelationshipAttribute("crawl", objectId(crawl));
+
+        return save(entity, existing);
+    }
+
+    @VisibleForTesting
+    AtlasEntityWithExtInfo createOrUpdateSegment(String crawlId, String segmentsDir, String segmentName, AtlasEntity crawl) throws Exception {
+        String                 qn       = NutchQualifiedNames.segment(crawlId, segmentName, clusterName);
+        AtlasEntityWithExtInfo existing = findEntity(NutchDataTypes.NUTCH_SEGMENT.getName(), qn);
+        AtlasEntity            entity   = existing != null ? existing.getEntity() : new AtlasEntity(NutchDataTypes.NUTCH_SEGMENT.getName());
+        String                 path     = segmentsDir == null ? segmentName : segmentsDir + "/" + segmentName;
+
+        entity.setAttribute(QUALIFIED_NAME, qn);
+        entity.setAttribute("name", segmentName);
+        entity.setAttribute("segmentName", segmentName);
+        entity.setAttribute("path", path);
+        entity.setRelationshipAttribute("crawl", objectId(crawl));
+
+        return save(entity, existing);
+    }
+
+    @VisibleForTesting
+    void createOrUpdateHostAndDomain(AtlasEntity crawl, HostMetrics metrics) throws Exception {
+        String domainQn = NutchQualifiedNames.domain(metrics.getEtldPlusOne(), clusterName);
+        String hostQn   = NutchQualifiedNames.host(metrics.getHostname(), clusterName);
+
+        AtlasEntityWithExtInfo domainExisting = findEntity(NutchDataTypes.NUTCH_DOMAIN.getName(), domainQn);
+        AtlasEntity            domain         = domainExisting != null ? domainExisting.getEntity() : new AtlasEntity(NutchDataTypes.NUTCH_DOMAIN.getName());
+
+        domain.setAttribute(QUALIFIED_NAME, domainQn);
+        domain.setAttribute("name", metrics.getEtldPlusOne());
+        domain.setAttribute("clusterName", clusterName);
+        AtlasEntityWithExtInfo savedDomain = save(domain, domainExisting);
+
+        AtlasEntityWithExtInfo hostExisting = findEntity(NutchDataTypes.NUTCH_HOST.getName(), hostQn);
+        AtlasEntity            host         = hostExisting != null ? hostExisting.getEntity() : new AtlasEntity(NutchDataTypes.NUTCH_HOST.getName());
+
+        host.setAttribute(QUALIFIED_NAME, hostQn);
+        host.setAttribute("name", metrics.getHostname());
+        host.setAttribute("hostname", metrics.getHostname());
+        host.setAttribute("protocol", metrics.getProtocol());
+        host.setAttribute("clusterName", clusterName);
+        host.setRelationshipAttribute("domain", objectId(savedDomain.getEntity()));
+
+        AtlasStruct relAttrs = new AtlasStruct();
+        relAttrs.setAttribute("fetchedCount", metrics.getFetchedCount());
+        relAttrs.setAttribute("unfetchedCount", metrics.getUnfetchedCount());
+        relAttrs.setAttribute("maxScore", metrics.getMaxScore());
+        if (metrics.getLastFetchTime() > 0) {
+            relAttrs.setAttribute("lastFetchTime", new Date(metrics.getLastFetchTime()));
+        }
+        if (metrics.getDnsFailures() != null) {
+            relAttrs.setAttribute("dnsFailures", metrics.getDnsFailures());
+        }
+        if (metrics.getConnectionFailures() != null) {
+            relAttrs.setAttribute("connectionFailures", metrics.getConnectionFailures());
+        }
+        if (metrics.getGoneCount() != null) {
+            relAttrs.setAttribute("goneCount", metrics.getGoneCount());
+        }
+        if (metrics.getRedirPermCount() != null) {
+            relAttrs.setAttribute("redirPermCount", metrics.getRedirPermCount());
+        }
+        if (metrics.getRedirTempCount() != null) {
+            relAttrs.setAttribute("redirTempCount", metrics.getRedirTempCount());
+        }
+        if (StringUtils.isNotBlank(metrics.getHomepageUrl())) {
+            relAttrs.setAttribute("homepageUrl", metrics.getHomepageUrl());
+        }
+
+        AtlasRelatedObjectId crawlRel = new AtlasRelatedObjectId();
+        crawlRel.setTypeName(NutchDataTypes.NUTCH_CRAWL.getName());
+        crawlRel.setGuid(crawl.getGuid());
+        crawlRel.setRelationshipType("nutch_crawl_hosts");
+        crawlRel.setRelationshipAttributes(relAttrs);
+
+        List<AtlasRelatedObjectId> crawls = new ArrayList<>();
+        crawls.add(crawlRel);
+        host.setRelationshipAttribute("crawls", crawls);
+
+        save(host, hostExisting);
+    }
+
+    @VisibleForTesting
+    String qualifiedName(String crawlId) {
+        return NutchQualifiedNames.crawl(crawlId, clusterName);
+    }
+
+    private AtlasEntityWithExtInfo save(AtlasEntity entity, AtlasEntityWithExtInfo existing) throws Exception {
+        AtlasEntityWithExtInfo payload = new AtlasEntityWithExtInfo(entity);
+
+        if (existing == null) {
+            return createEntityInAtlas(payload);
+        }
+
+        return updateEntityInAtlas(payload);
+    }
+
+    private AtlasObjectId objectId(AtlasEntity entity) {
+        if (entity.getGuid() != null) {
+            return new AtlasObjectId(entity.getGuid(), entity.getTypeName());
+        }
+
+        return new AtlasObjectId(entity.getTypeName(), QUALIFIED_NAME, entity.getAttribute(QUALIFIED_NAME));
+    }
+
+    AtlasEntityWithExtInfo findEntity(String typeName, String qualifiedName) {
+        try {
+            return atlasClientV2.getEntityByAttribute(typeName, Collections.singletonMap(QUALIFIED_NAME, qualifiedName));
+        } catch (Exception e) {
+            LOG.debug("Entity not found: {} {}", typeName, qualifiedName);
+            return null;
+        }
+    }
+
+    AtlasEntityWithExtInfo createEntityInAtlas(AtlasEntityWithExtInfo entity) throws Exception {
+        EntityMutationResponse  response = atlasClientV2.createEntity(entity);
+        List<AtlasEntityHeader> created  = response.getCreatedEntities();
+
+        if (CollectionUtils.isNotEmpty(created)) {
+            return atlasClientV2.getEntityByGuid(created.get(0).getGuid());
+        }
+
+        return entity;
+    }
+
+    AtlasEntityWithExtInfo updateEntityInAtlas(AtlasEntityWithExtInfo entity) throws Exception {
+        atlasClientV2.updateEntity(entity);
+        return entity;
+    }
+
+    @VisibleForTesting
+    Map<String, HostMetrics> resolveHosts(String crawldbPath, String hostDbPath, List<CrawlRecord> crawlRecords) throws Exception {
+        Path hostDb = resolveHostDbPath(crawldbPath, hostDbPath);
+
+        if (hostDb != null) {
+            try {
+                Map<String, HostMetrics> hosts = HostCatalogBuilder.fromHostDb(HostDbReader.read(hostDb));
+                LOG.info("hostSource=hostdb path={}", hostDb);
+                return hosts;
+            } catch (IOException e) {
+                if (StringUtils.isNotBlank(hostDbPath)) {
+                    throw e;
+                }
+                LOG.warn("Unable to read discovered HostDB {}; falling back to CrawlDb host rollup", hostDb, e);
+            }
+        }
+
+        LOG.info("hostSource=crawldb");
+        return HostCatalogBuilder.rollup(crawlRecords);
+    }
+
+    private static Path resolveHostDbPath(String crawldbPath, String hostDbPath) throws IOException {
+        org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
+
+        if (StringUtils.isNotBlank(hostDbPath)) {
+            Path explicit = resolveCurrentDir(hostDbPath);
+            if (explicit.getFileSystem(conf).exists(explicit)) {
+                return explicit;
+            }
+            throw new IOException("HostDB path does not exist: " + hostDbPath);
+        }
+
+        Path crawlCurrent = resolveCurrentDir(crawldbPath);
+        Path sibling = new Path(crawlCurrent.getParent().getParent(), "hostdb/current");
+        if (sibling.getFileSystem(conf).exists(sibling)) {
+            return sibling;
+        }
+
+        return null;
+    }
+
+    private static Path resolveCurrentDir(String pathStr) {
+        Path path = new Path(pathStr);
+        if (!pathStr.endsWith("current")) {
+            path = new Path(path, "current");
+        }
+        return path;
+    }
+
+    private static List<String> listSegmentNames(String segmentsDir) throws Exception {
+        if (StringUtils.isBlank(segmentsDir)) {
+            return Collections.emptyList();
+        }
+
+        org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
+        Path                                 dir  = new Path(segmentsDir);
+        FileSystem                           fs   = dir.getFileSystem(conf);
+
+        if (!fs.exists(dir)) {
+            return Collections.emptyList();
+        }
+
+        List<String> names = new ArrayList<>();
+        for (FileStatus status : fs.listStatus(dir)) {
+            if (status.isDirectory()) {
+                names.add(status.getPath().getName());
+            }
+        }
+        return names;
+    }
+
+    private static long countSeedLines(String seedDir) throws Exception {
+        if (StringUtils.isBlank(seedDir)) {
+            return 0;
+        }
+
+        org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
+        Path                                 dir  = new Path(seedDir);
+        FileSystem                           fs   = dir.getFileSystem(conf);
+
+        if (!fs.exists(dir)) {
+            return 0;
+        }
+
+        long count = 0;
+        FileStatus[] files = fs.isDirectory(dir) ? fs.listStatus(dir) : new FileStatus[] {fs.getFileStatus(dir)};
+        for (FileStatus file : files) {
+            if (file.isFile()) {
+                try (java.io.BufferedReader reader = new java.io.BufferedReader(new java.io.InputStreamReader(fs.open(file.getPath()), java.nio.charset.StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        if (StringUtils.isNotBlank(line) && !line.startsWith("#")) {
+                            count++;
+                        }
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    private static void printUsage() {
+        System.out.println("Usage: import-nutch.sh -c <crawlId> -d <crawldb> [-H <hostdb>] [-s <seedDir>] [-g <segmentsDir>]");
+    }
+}

--- a/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/NutchQualifiedNames.java
+++ b/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/bridge/NutchQualifiedNames.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+/**
+ * Hive-style qualifiedName helpers for Nutch types.
+ */
+public final class NutchQualifiedNames {
+    private NutchQualifiedNames() {
+    }
+
+    /**
+     * @param crawlId     Nutch crawl id
+     * @param clusterName Atlas cluster name
+     * @return {@code {crawlId}@{clusterName}}
+     */
+    public static String crawl(String crawlId, String clusterName) {
+        return crawlId + "@" + clusterName;
+    }
+
+    /**
+     * @param crawlId     Nutch crawl id
+     * @param clusterName Atlas cluster name
+     * @return {@code {crawlId}.seeds@{clusterName}}
+     */
+    public static String seedlist(String crawlId, String clusterName) {
+        return crawlId + ".seeds@" + clusterName;
+    }
+
+    /**
+     * @param crawlId     Nutch crawl id
+     * @param segmentName Nutch segment directory name
+     * @param clusterName Atlas cluster name
+     * @return {@code {crawlId}.{segmentName}@{clusterName}}
+     */
+    public static String segment(String crawlId, String segmentName, String clusterName) {
+        return crawlId + "." + segmentName + "@" + clusterName;
+    }
+
+    /**
+     * @param etldPlusOne registrable domain / eTLD+1
+     * @param clusterName Atlas cluster name
+     * @return {@code {etldPlusOne}@{clusterName}}
+     */
+    public static String domain(String etldPlusOne, String clusterName) {
+        return etldPlusOne + "@" + clusterName;
+    }
+
+    /**
+     * @param hostname    host name
+     * @param clusterName Atlas cluster name
+     * @return {@code {hostname}@{clusterName}}
+     */
+    public static String host(String hostname, String clusterName) {
+        return hostname + "@" + clusterName;
+    }
+}

--- a/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/model/NutchDataTypes.java
+++ b/addons/nutch-bridge/src/main/java/org/apache/atlas/nutch/model/NutchDataTypes.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.model;
+
+/**
+ * Nutch entity type names for the <a href="https://issues.apache.org/jira/browse/ATLAS-5399">ATLAS-5399</a> model.
+ */
+public enum NutchDataTypes {
+    /** CrawlDb crawl ({@code nutch_crawl}). */
+    NUTCH_CRAWL,
+    /** Seed directory for a crawl ({@code nutch_seedlist}). */
+    NUTCH_SEEDLIST,
+    /** Segment directory ({@code nutch_segment}). */
+    NUTCH_SEGMENT,
+    /** Registrable domain / eTLD+1 ({@code nutch_domain}). */
+    NUTCH_DOMAIN,
+    /** Hostname unique per Atlas cluster ({@code nutch_host}). */
+    NUTCH_HOST,
+    /** IndexingJob process created by Nutch ({@code nutch_index_process}). */
+    NUTCH_INDEX_PROCESS;
+
+    /**
+     * @return Atlas type name ({@code nutch_crawl}, {@code nutch_seedlist}, ...)
+     */
+    public String getName() {
+        return name().toLowerCase();
+    }
+}

--- a/addons/nutch-bridge/src/main/resources/atlas-nutch-import-logback.xml
+++ b/addons/nutch-bridge/src/main/resources/atlas-nutch-import-logback.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing limitations under
+  ~ the License.
+  -->
+
+<configuration>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <param name="Target" value="System.out"/>
+    <encoder>
+      <pattern>%date [%thread] %level{5} [%file:%line] %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${atlas.log.dir}/${atlas.log.file}</file>
+    <append>true</append>
+    <encoder>
+      <pattern>%date [%thread] %level{5} [%file:%line] %msg%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${atlas.log.dir}/${atlas.log.file}-%d</fileNamePattern>
+      <maxHistory>15</maxHistory>
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+    </rollingPolicy>
+  </appender>
+
+  <logger name="org.apache.atlas" additivity="false" level="info">
+    <appender-ref ref="FILE"/>
+  </logger>
+
+   <root level="warn">
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>

--- a/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/CrawlDbReaderTest.java
+++ b/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/CrawlDbReaderTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.MapFile;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class CrawlDbReaderTest {
+    @Test
+    public void readsPartitionedMapFile() throws Exception {
+        File tmp = File.createTempFile("crawldb", "");
+        tmp.delete();
+        tmp.mkdirs();
+        Path current = new Path(new File(tmp, "current").getAbsolutePath());
+        Path part = new Path(current, "part-r-00000");
+        Configuration conf = new Configuration();
+
+        CrawlDbReader.NutchCrawlDatum value = new CrawlDbReader.NutchCrawlDatum();
+        value.status = CrawlRecord.STATUS_DB_FETCHED;
+        value.fetchTime = 42L;
+        value.score = 2.5f;
+
+        try (MapFile.Writer writer = new MapFile.Writer(conf, part,
+                MapFile.Writer.keyClass(Text.class),
+                MapFile.Writer.valueClass(CrawlDbReader.NutchCrawlDatum.class),
+                MapFile.Writer.compression(SequenceFile.CompressionType.NONE))) {
+            writer.append(new Text("https://nutch.apache.org/"), value);
+        }
+
+        List<CrawlRecord> records = CrawlDbReader.read(current);
+
+        assertEquals(records.size(), 1);
+        assertEquals(records.get(0).getUrl(), "https://nutch.apache.org/");
+        assertEquals(records.get(0).getStatus(), CrawlRecord.STATUS_DB_FETCHED);
+        assertEquals(records.get(0).getFetchTime(), 42L);
+        assertEquals(records.get(0).getScore(), 2.5f, 0.001);
+    }
+}

--- a/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/HostCatalogBuilderTest.java
+++ b/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/HostCatalogBuilderTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class HostCatalogBuilderTest {
+    @Test
+    public void skipsHostsWithOnlyUnfetchedUrls() {
+        CrawlRecord unfetched = new CrawlRecord("https://only.example.com/page", CrawlRecord.STATUS_DB_UNFETCHED, 1.0f, 1L);
+
+        Map<String, HostMetrics> hosts = HostCatalogBuilder.rollup(Collections.singletonList(unfetched));
+
+        assertTrue(hosts.isEmpty());
+    }
+
+    @Test
+    public void importsFetchedHostsAndDerivesEtldPlusOne() {
+        CrawlRecord fetched = new CrawlRecord("https://lucene.apache.org/core/", CrawlRecord.STATUS_DB_FETCHED, 2.5f, 100L);
+        CrawlRecord extra   = new CrawlRecord("https://lucene.apache.org/other", CrawlRecord.STATUS_DB_UNFETCHED, 0.1f, 50L);
+
+        Map<String, HostMetrics> hosts = HostCatalogBuilder.rollup(Arrays.asList(fetched, extra));
+
+        assertEquals(hosts.size(), 1);
+        HostMetrics metrics = hosts.get("lucene.apache.org");
+        assertEquals(metrics.getEtldPlusOne(), "apache.org");
+        assertEquals(metrics.getProtocol(), "https");
+        assertEquals(metrics.getFetchedCount(), 1);
+        assertEquals(metrics.getUnfetchedCount(), 1);
+        assertEquals(metrics.getMaxScore(), 2.5f, 0.001);
+        assertEquals(metrics.getLastFetchTime(), 100L);
+        assertTrue(metrics.hasFetchedUrl());
+    }
+
+    @Test
+    public void treatsUkPublicSuffixAsEtldPlusOne() {
+        CrawlRecord fetched = new CrawlRecord("https://www.example.co.uk/a", CrawlRecord.STATUS_FETCH_SUCCESS, 1.0f, 9L);
+
+        Map<String, HostMetrics> hosts = HostCatalogBuilder.rollup(Collections.singletonList(fetched));
+
+        assertEquals(hosts.get("www.example.co.uk").getEtldPlusOne(), "example.co.uk");
+        assertFalse("uk".equals(hosts.get("www.example.co.uk").getEtldPlusOne()));
+    }
+
+    @Test
+    public void fromHostDbImportsFetchedPlusNotModifiedAndSkipsUnfetchedOnly() {
+        HostDbReader.HostDbRecord fetched = new HostDbReader.HostDbRecord("lucene.apache.org", 2.5f, 100L,
+                "https://lucene.apache.org/", 1L, 2L, 3L, 4L, 1L, 5L, 6L, 7L);
+        HostDbReader.HostDbRecord unfetched = new HostDbReader.HostDbRecord("only.example.com", 1.0f, 1L, null, 0, 0, 9, 0, 0, 0, 0, 0);
+
+        Map<String, HostMetrics> hosts = HostCatalogBuilder.fromHostDb(Arrays.asList(fetched, unfetched));
+
+        assertEquals(hosts.size(), 1);
+        HostMetrics metrics = hosts.get("lucene.apache.org");
+        assertEquals(metrics.getEtldPlusOne(), "apache.org");
+        assertEquals(metrics.getFetchedCount(), 5);
+        assertEquals(metrics.getUnfetchedCount(), 3);
+        assertEquals(metrics.getMaxScore(), 2.5f, 0.001);
+        assertEquals(metrics.getLastFetchTime(), 100L);
+        assertEquals(metrics.getDnsFailures().longValue(), 1L);
+        assertEquals(metrics.getConnectionFailures().longValue(), 2L);
+        assertEquals(metrics.getGoneCount().longValue(), 7L);
+        assertEquals(metrics.getRedirTempCount().longValue(), 5L);
+        assertEquals(metrics.getRedirPermCount().longValue(), 6L);
+        assertEquals(metrics.getHomepageUrl(), "https://lucene.apache.org/");
+    }
+}

--- a/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/HostDbReaderTest.java
+++ b/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/HostDbReaderTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.MapFile;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class HostDbReaderTest {
+    @Test
+    public void writableRoundTripMatchesHostDatumLayout() throws Exception {
+        HostDbReader.NutchHostDatum written = new HostDbReader.NutchHostDatum();
+        written.score = 1.5f;
+        written.lastCheck = 42L;
+        written.homepageUrl = "https://example.com/";
+        written.dnsFailures = 1;
+        written.connectionFailures = 2;
+        written.unfetched = 3;
+        written.fetched = 4;
+        written.notModified = 5;
+        written.redirTemp = 6;
+        written.redirPerm = 7;
+        written.gone = 8;
+
+        DataOutputBuffer out = new DataOutputBuffer();
+        written.write(out);
+
+        HostDbReader.NutchHostDatum read = new HostDbReader.NutchHostDatum();
+        DataInputBuffer in = new DataInputBuffer();
+        in.reset(out.getData(), 0, out.getLength());
+        read.readFields(in);
+
+        assertEquals(read.score, 1.5f, 0.001);
+        assertEquals(read.lastCheck, 42L);
+        assertEquals(read.homepageUrl, "https://example.com/");
+        assertEquals(read.dnsFailures, 1);
+        assertEquals(read.fetched, 4);
+        assertEquals(read.notModified, 5);
+        assertEquals(read.gone, 8);
+    }
+
+    @Test
+    public void mapFileRoundTrip() throws Exception {
+        File tmp = File.createTempFile("hostdb", "");
+        tmp.delete();
+        tmp.mkdirs();
+        Path current = new Path(new File(tmp, "current").getAbsolutePath());
+        Path dir = new Path(current, "part-r-00000");
+        Configuration conf = new Configuration();
+
+        HostDbReader.NutchHostDatum value = new HostDbReader.NutchHostDatum();
+        value.fetched = 2;
+        value.notModified = 1;
+        value.score = 9.0f;
+        value.lastCheck = 99L;
+
+        try (MapFile.Writer writer = new MapFile.Writer(conf, dir,
+                MapFile.Writer.keyClass(Text.class),
+                MapFile.Writer.valueClass(HostDbReader.NutchHostDatum.class),
+                MapFile.Writer.compression(SequenceFile.CompressionType.NONE))) {
+            writer.append(new Text("lucene.apache.org"), value);
+        }
+
+        List<HostDbReader.HostDbRecord> records = HostDbReader.read(current);
+        assertEquals(records.size(), 1);
+        assertEquals(records.get(0).hostname, "lucene.apache.org");
+        assertEquals(records.get(0).fetched, 2);
+        assertEquals(records.get(0).notModified, 1);
+        assertEquals(records.get(0).score, 9.0f, 0.001);
+        assertEquals(records.get(0).lastCheck, 99L);
+    }
+
+    @Test
+    public void sequenceFileRoundTrip() throws Exception {
+        File tmp = File.createTempFile("hostdb", "");
+        tmp.delete();
+        tmp.mkdirs();
+        Path current = new Path(new File(tmp, "current").getAbsolutePath());
+        Path part = new Path(current, "part-r-00000");
+        Configuration conf = new Configuration();
+
+        HostDbReader.NutchHostDatum value = new HostDbReader.NutchHostDatum();
+        value.fetched = 1;
+        value.score = 3.0f;
+
+        try (SequenceFile.Writer writer = SequenceFile.createWriter(conf,
+                SequenceFile.Writer.file(part),
+                SequenceFile.Writer.keyClass(Text.class),
+                SequenceFile.Writer.valueClass(HostDbReader.NutchHostDatum.class))) {
+            writer.append(new Text("nutch.apache.org"), value);
+        }
+
+        List<HostDbReader.HostDbRecord> records = HostDbReader.read(current);
+
+        assertEquals(records.size(), 1);
+        assertEquals(records.get(0).hostname, "nutch.apache.org");
+        assertEquals(records.get(0).fetched, 1);
+        assertEquals(records.get(0).score, 3.0f, 0.001);
+    }
+}

--- a/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/NutchModelJsonTest.java
+++ b/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/NutchModelJsonTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.testng.Assert.assertTrue;
+
+public class NutchModelJsonTest {
+    @Test
+    public void modelDefinesCatalogAndIndexProcessTypes() throws Exception {
+        File model = new File("target/models/7000-Nutch/7010-nutch_model.json");
+        if (!model.isFile()) {
+            model = new File("../models/7000-Nutch/7010-nutch_model.json");
+        }
+
+        JsonNode root = new ObjectMapper().readTree(model);
+        Set<String> entityNames = new HashSet<>();
+        for (JsonNode def : root.get("entityDefs")) {
+            entityNames.add(def.get("name").asText());
+        }
+
+        assertTrue(entityNames.contains("nutch_crawl"));
+        assertTrue(entityNames.contains("nutch_seedlist"));
+        assertTrue(entityNames.contains("nutch_segment"));
+        assertTrue(entityNames.contains("nutch_domain"));
+        assertTrue(entityNames.contains("nutch_host"));
+        assertTrue(entityNames.contains("nutch_index_process"));
+
+        Set<String> relNames = new HashSet<>();
+        for (JsonNode def : root.get("relationshipDefs")) {
+            relNames.add(def.get("name").asText());
+        }
+        assertTrue(relNames.contains("nutch_crawl_hosts"));
+        assertTrue(relNames.contains("nutch_domain_hosts"));
+
+        Set<String> crawlHostAttrs = new HashSet<>();
+        for (JsonNode def : root.get("relationshipDefs")) {
+            if ("nutch_crawl_hosts".equals(def.get("name").asText())) {
+                for (JsonNode attr : def.get("attributeDefs")) {
+                    crawlHostAttrs.add(attr.get("name").asText());
+                }
+            }
+        }
+        assertTrue(crawlHostAttrs.contains("dnsFailures"));
+        assertTrue(crawlHostAttrs.contains("connectionFailures"));
+        assertTrue(crawlHostAttrs.contains("goneCount"));
+        assertTrue(crawlHostAttrs.contains("redirPermCount"));
+        assertTrue(crawlHostAttrs.contains("redirTempCount"));
+        assertTrue(crawlHostAttrs.contains("homepageUrl"));
+    }
+}

--- a/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/NutchQualifiedNamesTest.java
+++ b/addons/nutch-bridge/src/test/java/org/apache/atlas/nutch/bridge/NutchQualifiedNamesTest.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing limitations under
+ * the License.
+ */
+package org.apache.atlas.nutch.bridge;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class NutchQualifiedNamesTest {
+    @Test
+    public void usesHiveStyleClusterSuffix() {
+        assertEquals(NutchQualifiedNames.crawl("mycrawl", "dev"), "mycrawl@dev");
+        assertEquals(NutchQualifiedNames.seedlist("mycrawl", "dev"), "mycrawl.seeds@dev");
+        assertEquals(NutchQualifiedNames.segment("mycrawl", "20260101", "dev"), "mycrawl.20260101@dev");
+        assertEquals(NutchQualifiedNames.domain("apache.org", "dev"), "apache.org@dev");
+        assertEquals(NutchQualifiedNames.host("atlas.apache.org", "dev"), "atlas.apache.org@dev");
+    }
+}

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -157,6 +157,13 @@ atlas.graph.storage.hbase.regions-per-server=1
 
         <dependency>
             <groupId>org.apache.atlas</groupId>
+            <artifactId>nutch-bridge</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.atlas</groupId>
             <artifactId>rest-notification-webapp</artifactId>
             <version>${project.version}</version>
             <type>war</type>
@@ -284,6 +291,7 @@ atlas.graph.storage.hbase.regions-per-server=1
                                         <descriptor>src/main/assemblies/atlas-sqoop-hook-package.xml</descriptor>
                                         <descriptor>src/main/assemblies/atlas-storm-hook-package.xml</descriptor>
                                         <descriptor>src/main/assemblies/atlas-kafka-hook-package.xml</descriptor>
+                                        <descriptor>src/main/assemblies/atlas-nutch-hook-package.xml</descriptor>
                                         <descriptor>src/main/assemblies/atlas-couchbase-hook-package.xml</descriptor>
                                         <descriptor>src/main/assemblies/atlas-server-package.xml</descriptor>
                                         <descriptor>src/main/assemblies/rest-server-package.xml</descriptor>

--- a/distro/src/main/assemblies/atlas-nutch-hook-package.xml
+++ b/distro/src/main/assemblies/atlas-nutch-hook-package.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing limitations under
+  ~ the License.
+  -->
+<assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <id>nutch-hook</id>
+    <baseDirectory>apache-atlas-nutch-hook-${project.version}</baseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>../addons/nutch-bridge/src/bin</directory>
+            <outputDirectory>hook-bin</outputDirectory>
+            <fileMode>0755</fileMode>
+            <directoryMode>0755</directoryMode>
+        </fileSet>
+        <fileSet>
+            <directory>../addons/nutch-bridge/target/dependency/hook</directory>
+            <outputDirectory>hook</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/distro/src/main/assemblies/standalone-package.xml
+++ b/distro/src/main/assemblies/standalone-package.xml
@@ -193,6 +193,12 @@
             <fileMode>0755</fileMode>
             <directoryMode>0755</directoryMode>
         </fileSet>
+        <fileSet>
+            <directory>../addons/nutch-bridge/src/bin</directory>
+            <outputDirectory>hook-bin</outputDirectory>
+            <fileMode>0755</fileMode>
+            <directoryMode>0755</directoryMode>
+        </fileSet>
 
         <!-- for migration setup -->
         <fileSet>

--- a/docs/src/documents/HighLevelArchitecture.md
+++ b/docs/src/documents/HighLevelArchitecture.md
@@ -60,6 +60,7 @@ as well. Currently, Atlas supports ingesting and managing metadata from the foll
    *  [Sqoop](#/HookSqoop)
    *  [Storm](#/HookStorm)
    *  [Kafka](#/HookKafka)
+   *  [Nutch](#/HookNutch)
 
 The integration implies two things:
 There are metadata models that Atlas defines natively to represent objects of these components.

--- a/docs/src/documents/Hook/HookNutch.md
+++ b/docs/src/documents/Hook/HookNutch.md
@@ -1,0 +1,54 @@
+---
+name: Nutch
+route: /HookNutch
+menu: Documentation
+submenu: Hooks
+---
+import  * as theme  from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+
+# Apache Atlas integration for Apache Nutch
+
+Atlas catalogs Nutch crawls ([ATLAS-5399](https://issues.apache.org/jira/browse/ATLAS-5399)). Index-job lineage is emitted by the Nutch Atlas IndexWriter ([NUTCH-3210](https://issues.apache.org/jira/browse/NUTCH-3210)).
+
+## Model
+
+Entity types (`serviceType`: nutch), loaded from `addons/models/7000-Nutch/7010-nutch_model.json`:
+
+* `nutch_crawl` (DataSet) — `{crawlId}@{clusterName}`
+* `nutch_seedlist` (Asset) — `{crawlId}.seeds@{clusterName}` (COMPOSITION 1:1 under crawl)
+* `nutch_segment` (DataSet) — `{crawlId}.{segmentName}@{clusterName}`
+* `nutch_domain` (Asset) — eTLD+1 / assigned domain, not TLD. Example: `lucene.apache.org` → `apache.org`. `{etldPlusOne}@{clusterName}`
+* `nutch_host` (Asset) — global hostname `{hostname}@{clusterName}`
+* `nutch_index_process` (Process) — created by Nutch IndexingJob, not this bridge
+* Index sink — generic `DataSet` `{collectionOrIndexName}@{clusterName}`
+
+`nutch_crawl_hosts` is an ASSOCIATION with relationship attributes: fetchedCount, unfetchedCount, indexedCount, lastFetchTime, lastIndexedTime, maxScore. When hosts come from Nutch HostDB, optional attributes are also set: dnsFailures, connectionFailures, goneCount, redirPermCount, redirTempCount, homepageUrl.
+
+## Dual-writer rules
+
+* This bridge may create/update crawl, seedlist, segment, domain, host, and crawl–host metrics.
+* The Nutch IndexWriter may create `nutch_index_process` and the index `DataSet`, and may update indexedCount / lastIndexedTime on an existing crawl–host relationship. It must not create crawl/host/domain entities.
+
+## Cardinality
+
+Do not model crawled URLs as Atlas entities. The bridge imports hosts that have at least one FETCHED URL (CrawlDb) or `fetched + notModified > 0` (HostDB).
+
+## Importing CrawlDb / HostDB metadata
+
+Hosts are preferred from Nutch HostDB (`{crawlId}/hostdb/current`, written by `UpdateHostDb`) when that directory exists. HostDB is optional in Nutch; if it is absent, hosts are rolled up from CrawlDb URLs (`hostSource=crawldb`). Crawl `urlCount`, seedlist, and segments still come from CrawlDb, the seed directory, and the segments directory.
+
+Pass `-H` / `--hostdb` to force a HostDB path. Otherwise the bridge looks for `{parent(crawldb)}/hostdb/current`.
+
+<SyntaxHighlighter wrapLines={true} language="shell" style={theme.dark}>
+{`Usage: <atlas package>/hook-bin/import-nutch.sh -c <crawlId> -d <crawldb> [-H <hostdb>] [-s <seedDir>] [-g <segmentsDir>]`}
+</SyntaxHighlighter>
+
+Configure `atlas.rest.address` and `atlas.cluster.name`. Authenticate with username/password or a token the same way as other Atlas bridges.
+
+## Out of scope (v1)
+
+* URL/page entity types or URL sample lists
+* Nutch REST admin / JobManager types (removed in [NUTCH-3165](https://issues.apache.org/jira/browse/NUTCH-3165))
+* Consuming `indexer-kafka` JSON on `ATLAS_HOOK`
+* Inject/fetch/parse Process types

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>addons/impala-bridge-shim</module>
         <module>addons/impala-hook-api</module>
         <module>addons/kafka-bridge</module>
+        <module>addons/nutch-bridge</module>
         <module>addons/sqoop-bridge</module>
         <module>addons/sqoop-bridge-shim</module>
         <module>addons/storm-bridge</module>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Catalog Apache Nutch crawls in Atlas without creating one entity per URL ([ATLAS-5399](https://issues.apache.org/jira/browse/ATLAS-5399)).

Adds a Nutch metadata model (`addons/models/7000-Nutch/`) and a CrawlDb/HostDB import bridge (`addons/nutch-bridge`). The bridge creates crawl, seedlist, segment, domain, and host entities, plus per-crawl host metrics on `nutch_crawl_hosts`. Hosts are preferred from Nutch HostDB when `{crawl}/hostdb/current` exists; otherwise they are rolled up from CrawlDb. There is no `nutch_url` type.

Indexing lineage is **not** emitted here. The model includes `nutch_index_process`; the Nutch Atlas IndexWriter creates that process and a generic index `DataSet` ([NUTCH-3210](https://issues.apache.org/jira/browse/NUTCH-3210)). The two sides share `atlas.cluster.name` and `crawlId`.

Import CLI:
```
hook-bin/import-nutch.sh -c -d [-H ] [-s ] [-g ]
```

The distro `nutch-hook` package ships the bridge and its runtime dependencies so import does not need Nutch on the classpath. Docs: `docs/src/documents/Hook/HookNutch.md`.

**Out of scope**: URL/page entities, Nutch REST/JobManager types (NUTCH-3165), `indexer-kafka` / `ATLAS_HOOK`, inject/fetch/parse process types.

## How was this patch tested?

- `mvn -pl addons/nutch-bridge test` (CrawlDb MapFile partitions, HostDB SequenceFile, qualified names, host rollup, model JSON)
- Live `dev-support/atlas-docker` (postgres) with seed `https://nutch.apache.org/`: import created crawl, seedlist, segment, `apache.org`, `nutch.apache.org`, and crawl-host metrics; Nutch IndexingJob then created the index `DataSet` and `nutch_index_process`
- Lineage in the Atlas UI: crawl + segment to `nutch_index_process` to index

See attached screenshot of the lineage tab for the demo indexing process.
<img width="1677" height="1981" alt="atlas-nutch-lineage" src="https://github.com/user-attachments/assets/e3f4596d-ddc9-4aba-8f4f-f3eee968687e" />
