### PR TITLE
ATLAS-5400: Fix PUT response when blocking from empty blocked list

### DIFF
--- a/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
+++ b/repository/src/main/java/org/apache/atlas/repository/graph/GraphHelper.java
@@ -679,15 +679,13 @@ public final class GraphHelper {
     }
 
     public static List<String> getBlockedClassificationIds(AtlasEdge edge) {
-        List<String> ret = null;
-
-        if (edge != null) {
-            List<String> classificationIds = AtlasGraphUtilsV2.getEncodedProperty(edge, RELATIONSHIPTYPE_BLOCKED_PROPAGATED_CLASSIFICATIONS_KEY, List.class);
-
-            ret = CollectionUtils.isNotEmpty(classificationIds) ? classificationIds : Collections.emptyList();
+        if (edge == null) {
+            return Collections.emptyList();
         }
 
-        return ret;
+        List<String> classificationIds = edge.getListProperty(RELATIONSHIPTYPE_BLOCKED_PROPAGATED_CLASSIFICATIONS_KEY);
+
+        return CollectionUtils.isNotEmpty(classificationIds) ? classificationIds : Collections.emptyList();
     }
 
     public static PropagateTags getPropagateTags(AtlasElement element) {

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v1/DeleteHandlerV1.java
@@ -1647,12 +1647,18 @@ public abstract class DeleteHandlerV1 {
     }
 
     private void setBlockedClassificationIds(AtlasEdge edge, List<String> classificationIds) {
-        if (edge != null) {
-            if (classificationIds.isEmpty()) {
-                edge.removeProperty(org.apache.atlas.repository.Constants.RELATIONSHIPTYPE_BLOCKED_PROPAGATED_CLASSIFICATIONS_KEY);
-            } else {
-                edge.setListProperty(org.apache.atlas.repository.Constants.RELATIONSHIPTYPE_BLOCKED_PROPAGATED_CLASSIFICATIONS_KEY, classificationIds);
-            }
+        if (edge == null) {
+            return;
+        }
+
+        // Copy-on-write (remove then set new list) so the PUT response can read the new blocked list immediately and
+        // readClassificationsFromEdge sees it when building the PUT response on first block.
+        String key = org.apache.atlas.repository.Constants.RELATIONSHIPTYPE_BLOCKED_PROPAGATED_CLASSIFICATIONS_KEY;
+
+        edge.removeProperty(key);
+
+        if (CollectionUtils.isNotEmpty(classificationIds)) {
+            edge.setListProperty(key, new ArrayList<>(classificationIds));
         }
     }
 }

--- a/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
+++ b/repository/src/main/java/org/apache/atlas/repository/store/graph/v2/AtlasRelationshipStoreV2.java
@@ -442,7 +442,7 @@ public class AtlasRelationshipStoreV2 implements AtlasRelationshipStore {
             }
         }
 
-        return entityRetriever.mapEdgeToAtlasRelationship(relationshipEdge);
+        return entityRetriever.mapEdgeToAtlasRelationship(graphHelper.getEdgeForGUID(relationship.getGuid()));
     }
 
     private void updateTagPropagations(AtlasEdge relationshipEdge, AtlasRelationship relationship) throws AtlasBaseException {

--- a/repository/src/test/java/org/apache/atlas/repository/tagpropagation/ClassificationPropagationWithTasksTest.java
+++ b/repository/src/test/java/org/apache/atlas/repository/tagpropagation/ClassificationPropagationWithTasksTest.java
@@ -300,6 +300,38 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
     }
 
     @Test
+    public void updateRelationship_block_putAndGetBeforeTaskCompletion() throws Exception {
+        setupRelationshipPropagationScenario();
+
+        AtlasEntity employees1 = getEntity(EMPLOYEES1_TABLE);
+
+        AtlasClassification piiTag2 = new AtlasClassification("PII");
+        piiTag2.setEntityGuid(employees1.getGuid());
+
+        AtlasRelationship relationship = getRelationship(EMPLOYEES_UNION_PROCESS, EMPLOYEES_UNION_TABLE);
+
+        assertTrue(CollectionUtils.isEmpty(relationship.getBlockedPropagatedClassifications()));
+
+        Set<AtlasClassification> blockTags = selectPropagatedClassifications(relationship, employees1.getGuid());
+
+        assertFalse(blockTags.isEmpty(), "Expected propagated PII on relationship before first block");
+
+        relationship.setBlockedPropagatedClassifications(blockTags);
+
+        AtlasRelationship putReturn = relationshipStore.update(relationship);
+
+        assertNotNull(putReturn);
+        assertFalse(putReturn.getBlockedPropagatedClassifications().isEmpty());
+        assertClassificationExistInList(putReturn.getBlockedPropagatedClassifications(), piiTag2);
+        assertFalse(classificationExistInList(putReturn.getPropagatedClassifications(), piiTag2));
+
+        AtlasRelationship getReturn = relationshipStore.getById(putReturn.getGuid());
+
+        assertClassificationExistInList(getReturn.getBlockedPropagatedClassifications(), piiTag2);
+        assertFalse(classificationExistInList(getReturn.getPropagatedClassifications(), piiTag2));
+    }
+
+    @Test
     public void updateRelationship_unblock_putAndGetBeforeTaskCompletion() throws Exception {
         setupRelationshipBlockScenario();
 
@@ -372,7 +404,7 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
         assertClassificationExistInEntity(EMPLOYEES_UNION_TABLE, piiTag3);
     }
 
-    private void setupRelationshipBlockScenario() throws AtlasBaseException {
+    private void setupRelationshipPropagationScenario() throws AtlasBaseException {
         AtlasEntity hdfsPath   = getEntity(HDFS_PATH_EMPLOYEES);
         AtlasEntity employees1 = getEntity(EMPLOYEES1_TABLE);
         AtlasEntity employees2 = getEntity(EMPLOYEES2_TABLE);
@@ -399,12 +431,45 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
         addClassificationIfMissing(employees1, piiTag2);
         addClassificationIfMissing(employees2, piiTag3);
 
+        resetRelationshipForPropagation();
+
         propagateClassificationIfPresent(hdfsPath.getGuid(), piiTag1.getTypeName());
         propagateClassificationIfPresent(employees1.getGuid(), piiTag2.getTypeName());
         propagateClassificationIfPresent(employees2.getGuid(), piiTag3.getTypeName());
 
         assertClassificationExistInEntity(EMPLOYEES_UNION_TABLE, piiTag2);
         assertClassificationExistInEntity(EMPLOYEES_UNION_TABLE, piiTag3);
+    }
+
+    private void resetRelationshipForPropagation() throws AtlasBaseException {
+        AtlasRelationship relationship = getRelationship(EMPLOYEES_UNION_PROCESS, EMPLOYEES_UNION_TABLE);
+        PropagateTags       oldPropagateTags = relationship.getPropagateTags();
+        List<String>        oldBlockedIds    = GraphHelper.getBlockedClassificationIds(
+                new GraphHelper(graph).getEdgeForGUID(relationship.getGuid()));
+
+        if (oldPropagateTags != ONE_TO_TWO || CollectionUtils.isNotEmpty(relationship.getBlockedPropagatedClassifications())) {
+            relationship.setPropagateTags(ONE_TO_TWO);
+            relationship.setBlockedPropagatedClassifications(Collections.emptySet());
+
+            AtlasRelationship resetReturn = relationshipStore.update(relationship);
+
+            if (resetReturn.getPendingTasks() != null && !resetReturn.getPendingTasks().isEmpty()) {
+                applyRelationshipTaskIfPending(resetReturn, oldPropagateTags, oldBlockedIds);
+            }
+        }
+    }
+
+    private void setupRelationshipBlockScenario() throws AtlasBaseException {
+        setupRelationshipPropagationScenario();
+
+        AtlasEntity employees1 = getEntity(EMPLOYEES1_TABLE);
+        AtlasEntity employees2 = getEntity(EMPLOYEES2_TABLE);
+
+        AtlasClassification piiTag2 = new AtlasClassification("PII");
+        piiTag2.setEntityGuid(employees1.getGuid());
+
+        AtlasClassification piiTag3 = new AtlasClassification("PII");
+        piiTag3.setEntityGuid(employees2.getGuid());
 
         AtlasRelationship relationship   = getRelationship(EMPLOYEES_UNION_PROCESS, EMPLOYEES_UNION_TABLE);
         PropagateTags       oldPropagateTags = relationship.getPropagateTags();
@@ -509,18 +574,24 @@ public class ClassificationPropagationWithTasksTest extends AtlasTestBase {
     }
 
     private void assertClassificationExistInList(Set<AtlasClassification> classifications, AtlasClassification expected) {
+        if (!classificationExistInList(classifications, expected)) {
+            fail("Classification not found in relationship response");
+        }
+    }
+
+    private boolean classificationExistInList(Set<AtlasClassification> classifications, AtlasClassification expected) {
         if (classifications == null) {
-            fail("Propagated classifications list is null");
+            return false;
         }
 
         for (AtlasClassification classification : classifications) {
             if (classification.getTypeName().equals(expected.getTypeName())
                     && classification.getEntityGuid().equals(expected.getEntityGuid())) {
-                return;
+                return true;
             }
         }
 
-        fail("Propagated classification not found in relationship response");
+        return false;
     }
 
     private void loadModelFilesAndImportTestData() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up to ATLAS-5375 ([#729](https://github.com/apache/atlas/pull/729)).
If the blocked list on a relationship was **empty** and a client blocked a tag, the graph was updated correctly — but the **PUT response** could still show the old edge (tag propagated, nothing blocked). **GET** right after PUT showed the right state.

This patch fixes that PUT response for **empty → blocked** (first block and block after unblock):
- Write the blocked list with remove-then-set (copy-on-write)
- Read it back with getListProperty, matching how it is written
- Reload the relationship edge before building the PUT body

Entity tag updates still run in the background; no API change.

## How was this patch tested?

- Tested the scenario manually on running Atlas server
- Additionally, added a test which checks that blocking from an empty list updates PUT and GET before the background task finishes. Existing unblock tests still pass.
`mvn -pl repository -Dtest=ClassificationPropagationWithTasksTest,ClassificationPropagationTasksTest,ClassificationTaskTest,ClassificationPropagateTaskFactoryTest test`