### PR TITLE
ATLAS-5388: Add topic-scoped authorization for REST notification POST.

### DIFF
--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizationUtils.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizationUtils.java
@@ -78,6 +78,14 @@ public class AtlasAuthorizationUtils {
         }
     }
 
+    public static void verifyAccess(AtlasNotificationRequest request, Object... errorMsgParams) throws AtlasBaseException {
+        if (!isAccessAllowed(request)) {
+            String message = (errorMsgParams != null && errorMsgParams.length > 0) ? StringUtils.join(errorMsgParams) : "";
+
+            throw new AtlasBaseException(AtlasErrorCode.UNAUTHORIZED_ACCESS, request.getUser(), message);
+        }
+    }
+
     public static void scrubSearchResults(AtlasSearchResultScrubRequest request) {
         String userName = getCurrentUserName();
 
@@ -192,6 +200,34 @@ public class AtlasAuthorizationUtils {
                 AtlasAuthorizer authorizer = AtlasAuthorizerFactory.getAtlasAuthorizer();
 
                 request.setUser(getCurrentUserName(), getCurrentUserGroups());
+                request.setClientIPAddress(RequestContext.get().getClientIPAddress());
+                request.setForwardedAddresses(RequestContext.get().getForwardedAddresses());
+                request.setRemoteIPAddress(RequestContext.get().getClientIPAddress());
+
+                ret = authorizer.isAccessAllowed(request);
+            } catch (AtlasAuthorizationException e) {
+                LOG.error("Unable to obtain AtlasAuthorizer", e);
+            }
+        } else {
+            ret = true;
+        }
+
+        RequestContext.get().endMetricRecord(metric);
+
+        return ret;
+    }
+
+    public static boolean isAccessAllowed(AtlasNotificationRequest request) {
+        MetricRecorder metric = RequestContext.get().startMetricRecord("isAccessAllowed");
+
+        boolean ret      = false;
+        String  userName = getCurrentUserName();
+
+        if (StringUtils.isNotEmpty(userName)) {
+            try {
+                AtlasAuthorizer authorizer = AtlasAuthorizerFactory.getAtlasAuthorizer();
+
+                request.setUser(userName, getCurrentUserGroups());
                 request.setClientIPAddress(RequestContext.get().getClientIPAddress());
                 request.setForwardedAddresses(RequestContext.get().getForwardedAddresses());
                 request.setRemoteIPAddress(RequestContext.get().getClientIPAddress());

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizeConstants.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizeConstants.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorize;
+
+public final class AtlasAuthorizeConstants {
+    public static final String NOTIFICATION_TOPIC_RESOURCE_TYPE = "notification-topic";
+
+    private AtlasAuthorizeConstants() {
+    }
+}

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizer.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizer.java
@@ -65,6 +65,10 @@ public interface AtlasAuthorizer {
         return true;
     }
 
+    default boolean isAccessAllowed(AtlasNotificationRequest request) throws AtlasAuthorizationException {
+        return false;
+    }
+
     /**
      * scrub search-results to handle entities for which the user doesn't have access
      * @param request

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasNoneAuthorizer.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasNoneAuthorizer.java
@@ -50,6 +50,11 @@ public class AtlasNoneAuthorizer implements AtlasAuthorizer {
     }
 
     @Override
+    public boolean isAccessAllowed(AtlasNotificationRequest request) {
+        return true;
+    }
+
+    @Override
     public void scrubSearchResults(AtlasSearchResultScrubRequest request) {
     }
 }

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasNotificationRequest.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasNotificationRequest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.atlas.authorize;
+
+
+public class AtlasNotificationRequest extends AtlasAccessRequest {
+    private final String topicName;
+
+    public AtlasNotificationRequest(AtlasPrivilege action, String topicName) {
+        super(action);
+
+        this.topicName = topicName;
+    }
+
+    public String getTopicName() {
+        return topicName;
+    }
+
+    public String getResourceType() {
+        return AtlasAuthorizeConstants.NOTIFICATION_TOPIC_RESOURCE_TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return "AtlasNotificationRequest[action=" + getAction() + ", topicName=" + topicName + ", resourceType=" + getResourceType() +
+                ", accessTime=" + getAccessTime() + ", user=" + getUser() + ", userGroups=" + getUserGroups() +
+                ", clientIPAddress=" + getClientIPAddress() + ", forwardedAddresses=" + getForwardedAddresses() +
+                ", remoteIPAddress=" + getRemoteIPAddress() + "]";
+    }
+}

--- a/authorization/src/main/java/org/apache/atlas/authorize/AtlasPrivilege.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/AtlasPrivilege.java
@@ -48,7 +48,7 @@ public enum AtlasPrivilege {
 
     ADMIN_AUDITS("admin-audits"),
 
-    SERVICE_NOTIFICATION_POST("service-notification-post");
+    POST_NOTIFICATION("post-notification");
 
     private final String type;
 

--- a/authorization/src/main/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthorizer.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthorizer.java
@@ -24,6 +24,7 @@ import org.apache.atlas.authorize.AtlasAccessRequest;
 import org.apache.atlas.authorize.AtlasAdminAccessRequest;
 import org.apache.atlas.authorize.AtlasAuthorizer;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest;
+import org.apache.atlas.authorize.AtlasNotificationRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.authorize.AtlasRelationshipAccessRequest;
 import org.apache.atlas.authorize.AtlasSearchResultScrubRequest;
@@ -32,6 +33,7 @@ import org.apache.atlas.authorize.AtlasTypesDefFilterRequest;
 import org.apache.atlas.authorize.simple.AtlasSimpleAuthzPolicy.AtlasAdminPermission;
 import org.apache.atlas.authorize.simple.AtlasSimpleAuthzPolicy.AtlasAuthzRole;
 import org.apache.atlas.authorize.simple.AtlasSimpleAuthzPolicy.AtlasEntityPermission;
+import org.apache.atlas.authorize.simple.AtlasSimpleAuthzPolicy.AtlasNotificationPermission;
 import org.apache.atlas.authorize.simple.AtlasSimpleAuthzPolicy.AtlasRelationshipPermission;
 import org.apache.atlas.authorize.simple.AtlasSimpleAuthzPolicy.AtlasTypePermission;
 import org.apache.atlas.model.discovery.AtlasSearchResult;
@@ -254,6 +256,39 @@ public final class AtlasSimpleAuthorizer implements AtlasAuthorizer {
     }
 
     @Override
+    public boolean isAccessAllowed(AtlasNotificationRequest request) {
+        LOG.debug("==> SimpleAtlasAuthorizer.isAccessAllowed({})", request);
+
+        boolean     ret   = false;
+        Set<String> roles = getRoles(request.getUser(), request.getUserGroups());
+
+        for (String role : roles) {
+            List<AtlasNotificationPermission> permissions = getNotificationPermissionsForRole(role);
+
+            if (permissions != null) {
+                final String action    = request.getAction() != null ? request.getAction().getType() : null;
+                final String topicName = request.getTopicName();
+
+                for (AtlasNotificationPermission permission : permissions) {
+                    if (isMatch(action, permission.getPrivileges()) && isMatch(topicName, permission.getTopicNames())) {
+                        ret = true;
+
+                        break;
+                    }
+                }
+            }
+
+            if (ret) {
+                break;
+            }
+        }
+
+        LOG.debug("<== SimpleAtlasAuthorizer.isAccessAllowed({}): {}", request, ret);
+
+        return ret;
+    }
+
+    @Override
     public void scrubSearchResults(AtlasSearchResultScrubRequest request) {
         LOG.debug("==> SimpleAtlasAuthorizer.scrubSearchResults({})", request);
 
@@ -365,6 +400,18 @@ public final class AtlasSimpleAuthorizer implements AtlasAuthorizer {
             AtlasAuthzRole role = authzPolicy.getRoles().get(roleName);
 
             ret = role != null ? role.getRelationshipPermissions() : null;
+        }
+
+        return ret;
+    }
+
+    private List<AtlasNotificationPermission> getNotificationPermissionsForRole(String roleName) {
+        List<AtlasNotificationPermission> ret = null;
+
+        if (authzPolicy != null && roleName != null) {
+            AtlasAuthzRole role = authzPolicy.getRoles().get(roleName);
+
+            ret = role != null ? role.getNotificationPermissions() : null;
         }
 
         return ret;

--- a/authorization/src/main/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthzPolicy.java
+++ b/authorization/src/main/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthzPolicy.java
@@ -76,19 +76,25 @@ public class AtlasSimpleAuthzPolicy implements Serializable {
     public static class AtlasAuthzRole implements Serializable {
         private static final long serialVersionUID = 1L;
 
-        private List<AtlasAdminPermission>        adminPermissions;
-        private List<AtlasTypePermission>         typePermissions;
-        private List<AtlasEntityPermission>       entityPermissions;
-        private List<AtlasRelationshipPermission> relationshipPermissions;
+        private List<AtlasAdminPermission>         adminPermissions;
+        private List<AtlasTypePermission>          typePermissions;
+        private List<AtlasEntityPermission>        entityPermissions;
+        private List<AtlasRelationshipPermission>  relationshipPermissions;
+        private List<AtlasNotificationPermission>  notificationPermissions;
 
         public AtlasAuthzRole() {
         }
 
         public AtlasAuthzRole(List<AtlasAdminPermission> adminPermissions, List<AtlasTypePermission> typePermissions, List<AtlasEntityPermission> entityPermissions, List<AtlasRelationshipPermission> relationshipPermissions) {
-            this.adminPermissions        = adminPermissions;
-            this.typePermissions         = typePermissions;
-            this.entityPermissions       = entityPermissions;
-            this.relationshipPermissions = relationshipPermissions;
+            this(adminPermissions, typePermissions, entityPermissions, relationshipPermissions, null);
+        }
+
+        public AtlasAuthzRole(List<AtlasAdminPermission> adminPermissions, List<AtlasTypePermission> typePermissions, List<AtlasEntityPermission> entityPermissions, List<AtlasRelationshipPermission> relationshipPermissions, List<AtlasNotificationPermission> notificationPermissions) {
+            this.adminPermissions         = adminPermissions;
+            this.typePermissions          = typePermissions;
+            this.entityPermissions        = entityPermissions;
+            this.relationshipPermissions  = relationshipPermissions;
+            this.notificationPermissions  = notificationPermissions;
         }
 
         public List<AtlasAdminPermission> getAdminPermissions() {
@@ -121,6 +127,14 @@ public class AtlasSimpleAuthzPolicy implements Serializable {
 
         public void setRelationshipPermissions(List<AtlasRelationshipPermission> relationshipPermissions) {
             this.relationshipPermissions = relationshipPermissions;
+        }
+
+        public List<AtlasNotificationPermission> getNotificationPermissions() {
+            return notificationPermissions;
+        }
+
+        public void setNotificationPermissions(List<AtlasNotificationPermission> notificationPermissions) {
+            this.notificationPermissions = notificationPermissions;
         }
     }
 
@@ -389,6 +403,42 @@ public class AtlasSimpleAuthzPolicy implements Serializable {
 
         public void setEnd2EntityClassification(List<String> end2EntityClassification) {
             this.end2EntityClassification = end2EntityClassification;
+        }
+    }
+
+    @JsonAutoDetect(getterVisibility = PUBLIC_ONLY, setterVisibility = PUBLIC_ONLY, fieldVisibility = NONE)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @XmlRootElement
+    @XmlAccessorType(XmlAccessType.PROPERTY)
+    public static class AtlasNotificationPermission implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private List<String> privileges;
+        private List<String> topicNames;
+
+        public AtlasNotificationPermission() {
+        }
+
+        public AtlasNotificationPermission(List<String> privileges, List<String> topicNames) {
+            this.privileges  = privileges;
+            this.topicNames  = topicNames;
+        }
+
+        public List<String> getPrivileges() {
+            return privileges;
+        }
+
+        public void setPrivileges(List<String> privileges) {
+            this.privileges = privileges;
+        }
+
+        public List<String> getTopicNames() {
+            return topicNames;
+        }
+
+        public void setTopicNames(List<String> topicNames) {
+            this.topicNames = topicNames;
         }
     }
 }

--- a/authorization/src/main/resources/atlas-simple-authz-policy.json
+++ b/authorization/src/main/resources/atlas-simple-authz-policy.json
@@ -36,6 +36,21 @@
           "end2EntityId":             [ ".*" ],
           "end2EntityClassification": [ ".*" ]
         }
+      ],
+      "notificationPermissions": [
+        {
+          "privileges":  [ ".*" ],
+          "topicNames":  [ ".*" ]
+        }
+      ]
+    },
+
+    "HIVE_HOOK_SERVICE": {
+      "notificationPermissions": [
+        {
+          "privileges":  [ "post-notification" ],
+          "topicNames":  [ "ATLAS_HOOK" ]
+        }
       ]
     },
 
@@ -84,7 +99,8 @@
 
   "userRoles": {
     "admin": [ "ROLE_ADMIN" ],
-    "rangertagsync": [ "DATA_SCIENTIST" ]
+    "rangertagsync": [ "DATA_SCIENTIST" ],
+    "hivehook": [ "HIVE_HOOK_SERVICE" ]
   },
 
   "groupRoles": {

--- a/authorization/src/test/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthorizerTest.java
+++ b/authorization/src/test/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthorizerTest.java
@@ -21,6 +21,7 @@ import org.apache.atlas.authorize.AtlasAuthorizationException;
 import org.apache.atlas.authorize.AtlasAuthorizer;
 import org.apache.atlas.authorize.AtlasAuthorizerFactory;
 import org.apache.atlas.authorize.AtlasEntityAccessRequest;
+import org.apache.atlas.authorize.AtlasNotificationRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.model.instance.AtlasClassification;
 import org.apache.atlas.model.instance.AtlasEntityHeader;
@@ -50,6 +51,10 @@ public class AtlasSimpleAuthorizerTest {
     private static final String USER_FINANCE_PII      = "financePII";
     private static final String USER_IN_ADMIN_GROUP   = "admin-group-user";
     private static final String USER_IN_UNKNOWN_GROUP = "unknown-group-user";
+    private static final String USER_HIVE_HOOK        = "hivehook";
+
+    private static final String TOPIC_ATLAS_HOOK      = "ATLAS_HOOK";
+    private static final String TOPIC_ATLAS_ENTITIES  = "ATLAS_ENTITIES";
 
     private static final Map<String, Set<String>> USER_GROUPS       = new HashMap<>();
     private static final List<AtlasPrivilege>     ENTITY_PRIVILEGES = new ArrayList<>();
@@ -310,6 +315,42 @@ public class AtlasSimpleAuthorizerTest {
     }
 
     @Test
+    public void testPostNotificationAllowedForAdminUser() throws AtlasAuthorizationException {
+        AtlasNotificationRequest request = new AtlasNotificationRequest(AtlasPrivilege.POST_NOTIFICATION, TOPIC_ATLAS_HOOK);
+
+        setUser(request, USER_ADMIN);
+
+        AssertJUnit.assertTrue("admin should be allowed to post notification", authorizer.isAccessAllowed(request));
+    }
+
+    @Test
+    public void testPostNotificationDeniedForDataScientistUser() throws AtlasAuthorizationException {
+        AtlasNotificationRequest request = new AtlasNotificationRequest(AtlasPrivilege.POST_NOTIFICATION, TOPIC_ATLAS_HOOK);
+
+        setUser(request, USER_DATA_SCIENTIST);
+
+        AssertJUnit.assertFalse("data scientist should be denied to post notification", authorizer.isAccessAllowed(request));
+    }
+
+    @Test
+    public void testPostNotificationAllowedForTopicSpecificRole() throws AtlasAuthorizationException {
+        AtlasNotificationRequest request = new AtlasNotificationRequest(AtlasPrivilege.POST_NOTIFICATION, TOPIC_ATLAS_HOOK);
+
+        setUser(request, USER_HIVE_HOOK);
+
+        AssertJUnit.assertTrue("hivehook should be allowed to post to ATLAS_HOOK", authorizer.isAccessAllowed(request));
+    }
+
+    @Test
+    public void testPostNotificationDeniedForTopicSpecificRoleOnOtherTopic() throws AtlasAuthorizationException {
+        AtlasNotificationRequest request = new AtlasNotificationRequest(AtlasPrivilege.POST_NOTIFICATION, TOPIC_ATLAS_ENTITIES);
+
+        setUser(request, USER_HIVE_HOOK);
+
+        AssertJUnit.assertFalse("hivehook should be denied to post to ATLAS_ENTITIES", authorizer.isAccessAllowed(request));
+    }
+
+    @Test
     public void testBusinessMetadata() {
         try {
             for (String userName : Arrays.asList(USER_DATA_SCIENTIST, USER_DATA_STEWARD)) {
@@ -351,6 +392,7 @@ public class AtlasSimpleAuthorizerTest {
         USER_GROUPS.put(USER_FINANCE_PII, Collections.singleton("FINANCE_PII"));
         USER_GROUPS.put(USER_IN_ADMIN_GROUP, Collections.singleton("ROLE_ADMIN"));
         USER_GROUPS.put(USER_IN_UNKNOWN_GROUP, Collections.singleton("UNKNOWN_GROUP"));
+        USER_GROUPS.put(USER_HIVE_HOOK, Collections.emptySet());
 
         ENTITY_PRIVILEGES.add(AtlasPrivilege.ENTITY_CREATE);
         ENTITY_PRIVILEGES.add(AtlasPrivilege.ENTITY_UPDATE);

--- a/authorization/src/test/resources/atlas-simple-authz-policy.json
+++ b/authorization/src/test/resources/atlas-simple-authz-policy.json
@@ -35,6 +35,21 @@
           "endTwoEntityId":             [ ".*" ],
           "endTwoEntityClassification": [ ".*" ]
         }
+      ],
+      "notificationPermissions": [
+        {
+          "privileges":  [ ".*" ],
+          "topicNames":  [ ".*" ]
+        }
+      ]
+    },
+
+    "HIVE_HOOK_SERVICE": {
+      "notificationPermissions": [
+        {
+          "privileges":  [ "post-notification" ],
+          "topicNames":  [ "ATLAS_HOOK" ]
+        }
       ]
     },
 
@@ -133,6 +148,7 @@
   "userRoles": {
     "admin":          [ "ROLE_ADMIN" ],
     "rangertagsync":  [ "DATA_SCIENTIST" ],
+    "hivehook":       [ "HIVE_HOOK_SERVICE" ],
     "dataScientist1": [ "DATA_SCIENTIST"],
     "dataSteward1":   [ "DATA_STEWARD"]
   },

--- a/distro/src/conf/atlas-simple-authz-policy.json
+++ b/distro/src/conf/atlas-simple-authz-policy.json
@@ -36,6 +36,21 @@
           "end2EntityId":             [ ".*" ],
           "end2EntityClassification": [ ".*" ]
         }
+      ],
+      "notificationPermissions": [
+        {
+          "privileges":  [ ".*" ],
+          "topicNames":  [ ".*" ]
+        }
+      ]
+    },
+
+    "HIVE_HOOK_SERVICE": {
+      "notificationPermissions": [
+        {
+          "privileges":  [ "post-notification" ],
+          "topicNames":  [ "ATLAS_HOOK" ]
+        }
       ]
     },
 
@@ -83,7 +98,8 @@
 
   "userRoles": {
     "admin": [ "ROLE_ADMIN" ],
-    "rangertagsync": [ "DATA_SCIENTIST" ]
+    "rangertagsync": [ "DATA_SCIENTIST" ],
+    "hivehook": [ "HIVE_HOOK_SERVICE" ]
   },
 
   "groupRoles": {

--- a/rest-notification-webapp/src/main/java/org/apache/atlas/notification/rest/web/rest/NotificationREST.java
+++ b/rest-notification-webapp/src/main/java/org/apache/atlas/notification/rest/web/rest/NotificationREST.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.atlas.AtlasConfiguration;
 import org.apache.atlas.AtlasErrorCode;
-import org.apache.atlas.authorize.AtlasAdminAccessRequest;
 import org.apache.atlas.authorize.AtlasAuthorizationUtils;
+import org.apache.atlas.authorize.AtlasNotificationRequest;
 import org.apache.atlas.authorize.AtlasPrivilege;
 import org.apache.atlas.exception.AtlasBaseException;
 import org.apache.atlas.hook.AtlasHook;
@@ -91,7 +91,7 @@ public class NotificationREST {
     public void handleNotifications(@PathParam("topicName") String topicName, @Context HttpServletRequest request) throws AtlasBaseException, IOException {
         LOG.debug("Handling notifications for topic {}", topicName);
 
-        AtlasAuthorizationUtils.verifyAccess(new AtlasAdminAccessRequest(AtlasPrivilege.SERVICE_NOTIFICATION_POST), "post on rest notification service");
+        AtlasAuthorizationUtils.verifyAccess(new AtlasNotificationRequest(AtlasPrivilege.POST_NOTIFICATION, topicName), "post on notification topic ", topicName);
 
         if (!TOPICS.contains(topicName)) {
             throw new AtlasBaseException(AtlasErrorCode.INVALID_TOPIC_NAME, topicName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Problem

The `rest-notification-webapp` module (port **41000**) exposes  
`POST /rest/api/atlas/v2/notification/topic/{topicName}` as the REST ingress for hook messages to Kafka.

Authorization on this endpoint uses an **admin-shaped** check that **ignores the URL topic**:

```java
verifyAccess(
    new AtlasAdminAccessRequest(AtlasPrivilege.SERVICE_NOTIFICATION_POST),
    "post on rest notification service");
```

| Area | Before (broken) |
|------|-----------------|
| Request type | `AtlasAdminAccessRequest` |
| Privilege | `SERVICE_NOTIFICATION_POST` (`service-notification-post`) |
| Topic used in auth? | **No** — `topicName` ignored |
| Impact | Any user with notification permission could POST to **any** topic (`ATLAS_HOOK`.) |
| Hook scoping | Hook accounts could not be limited to one topic (e.g. hive-bridge → `ATLAS_HOOK` only) |
| Ranger | No `notification-topic` resource in Atlas service-def (follow-up: **RANGER-5759**) |

**Affected endpoint:**

```
POST http://<host>:41000/rest/api/atlas/v2/notification/topic/{topicName}
```

**topicName examples:** `ATLAS_HOOK`, 


---

### Solution

This PR introduces **topic-scoped authorization** so the `topicName` path parameter participates in the allow/deny decision.

#### 1. New request type and privilege (authorization module)

**New file:** `authorization/src/main/java/org/apache/atlas/authorize/AtlasNotificationRequest.java`

Carries `topicName` into the authorization layer (parallel to `AtlasEntityAccessRequest`, `AtlasTypeAccessRequest`).

**New file:** `authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizeConstants.java`

Defines `NOTIFICATION_TOPIC_RESOURCE_TYPE = "notification-topic"` for Ranger alignment (RANGER-5759).

**File:** `authorization/src/main/java/org/apache/atlas/authorize/AtlasPrivilege.java`

Renamed privilege:

```java
// Before
SERVICE_NOTIFICATION_POST("service-notification-post");

// After
POST_NOTIFICATION("post-notification");
```

**File:** `authorization/src/main/java/org/apache/atlas/authorize/AtlasAuthorizer.java`

Added authorizer contract (default deny):

```java
default boolean isAccessAllowed(AtlasNotificationRequest request)
    throws AtlasAuthorizationException {
    return false;
}
```

**Files:** `AtlasAuthorizationUtils.java`, `AtlasNoneAuthorizer.java`

Added `verifyAccess` / `isAccessAllowed` for `AtlasNotificationRequest`.

---

#### 2. Simple authorizer — topic-scoped policy model

**File:** `authorization/src/main/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthzPolicy.java`

Added `AtlasNotificationPermission` with:

| Field | Purpose |
|-------|---------|
| `privileges` | e.g. `["post-notification"]` or `[".*"]` |
| `topicNames` | e.g. `["ATLAS_HOOK"]` or `[".*"]` |

**File:** `authorization/src/main/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthorizer.java`

Matches **both** privilege and topic (wildcard/regex supported):

```java
if (isMatch(action, permission.getPrivileges())
    && isMatch(topicName, permission.getTopicNames())) {
    ret = true;
}
```

**Policy files updated:**

| File | Change |
|------|--------|
| `authorization/src/main/resources/atlas-simple-authz-policy.json` | `ROLE_ADMIN` wildcard + `HIVE_HOOK_SERVICE` example role |
| `authorization/src/test/resources/atlas-simple-authz-policy.json` | Test policy with `hivehook` user |
| `distro/src/conf/atlas-simple-authz-policy.json` | Shipped default policy |

**Example — topic-scoped hook user:**

```json
"HIVE_HOOK_SERVICE": {
  "notificationPermissions": [
    {
      "privileges":  [ "post-notification" ],
      "topicNames":  [ "ATLAS_HOOK" ]
    }
  ]
}
```

---

#### 3. REST ingress — topic-aware authorization

**File:** `rest-notification-webapp/src/main/java/org/apache/atlas/notification/rest/web/rest/NotificationREST.java`

Replaced admin-level check with topic-scoped request:

```java
// Before
AtlasAuthorizationUtils.verifyAccess(
    new AtlasAdminAccessRequest(AtlasPrivilege.SERVICE_NOTIFICATION_POST),
    "post on rest notification service");

// After
AtlasAuthorizationUtils.verifyAccess(
    new AtlasNotificationRequest(AtlasPrivilege.POST_NOTIFICATION, topicName),
    "post on notification topic ", topicName);
```

**Effect:** Authorization evaluates the **specific topic** from the URL. A user scoped to `ATLAS_HOOK` receives **403** when posting to `ATLAS_ENTITIES`.

---

#### 4. Unit tests

**File:** `authorization/src/test/java/org/apache/atlas/authorize/simple/AtlasSimpleAuthorizerTest.java`

Added 4 tests for admin allow, data-scientist deny, hivehook topic allow, and hivehook cross-topic deny.

---

### Build
mvn clean install -DskipITs=true
**Result:** BUILD SUCCESS. All modules.

### Unit tests

**Result:** `Tests run: Failures: 0, Errors: 0, Skipped: 0` — **BUILD SUCCESS**

| Test | User | Topic | Expected | Result |
|------|------|-------|----------|--------|
| `testPostNotificationAllowedForAdminUser` | admin | ATLAS_HOOK | ALLOW | Pass |
| `testPostNotificationDeniedForDataScientistUser` | dataScientist | ATLAS_HOOK | DENY | Pass |
| `testPostNotificationAllowedForTopicSpecificRole` | hivehook | ATLAS_HOOK | ALLOW | Pass |
| `testPostNotificationDeniedForTopicSpecificRoleOnOtherTopic` | hivehook | ATLAS_ENTITIES | DENY | Pass |

---

### Manual / integration tests (local)
**Test users:**

| User | Password | Role |
|------|----------|------|
| admin | admin | ROLE_ADMIN (wildcard notification access) |
| hivehook | hivehook | HIVE_HOOK_SERVICE (`ATLAS_HOOK` only) |
| rangertagsync | rangertagsync | DATA_SCIENTIST (no notification permissions) |

**Endpoint tested:**

```
http://localhost:41000/rest/api/atlas/v2/notification/topic/{topicName}
```

---

#### Baseline test results (port 41000)

| Test | Description | Expected | **Actual** | Pass? |
|------|-------------|----------|------------|-------|
| **T10.1** | admin → POST `/topic/ATLAS_HOOK` | **204** | **204** | Pass |
| **T10.2** | admin (wrong password) → POST | **401** | **401** | Pass |
| **T10.3** | admin → POST invalid topic | **400** | **400** | Pass |
| **T10.4** | unauthenticated → POST | **401** | **401** | Pass |

---

#### Core ATLAS-5388 test results (topic-scoped authorization)

| Test | Description | Expected | **Actual** | Pass? |
|------|-------------|----------|------------|-------|
| **T11.1** | rangertagsync → POST `/topic/ATLAS_HOOK` | **403** | **403** | Pass |
| **T11.2** | hivehook → POST `/topic/ATLAS_HOOK` | **204** | **204** | Pass |
| **T11.3** | hivehook → POST `/topic/ATLAS_ENTITIES` | **403** | **403** | Pass |
| **T11.4** | admin → POST `/topic/ATLAS_ENTITIES` | **204** | **204** | Pass |

**JIRA minimum acceptance criteria met:**

- **T11.2 = 204** — hivehook allowed on configured topic `ATLAS_HOOK`
- **T11.3 = 403** — hivehook denied on non-configured topic `ATLAS_ENTITIES`

---

No UI changes in this PR.

---

## Related

- **JIRA:** ATLAS-5388
- **Follow-up:** RANGER-5759 
- **Prerequisite (separate PR):** ATLAS-5377 — remove duplicate notification endpoint from main webapp (port 21000)
- **Security context:** REST notification POST must authorize by Kafka topic, not admin privilege alone
